### PR TITLE
fix(DOM/CSS): change les boutons non icon en priorité secondaire

### DIFF
--- a/samples-src/pages/tests/Default/pages-ol-modules-default.html
+++ b/samples-src/pages/tests/Default/pages-ol-modules-default.html
@@ -42,7 +42,7 @@
         <style>
             div#map {
                 width: 100%;
-                height: 500px;
+                height: 800px;
             }
         </style>
 {{/content}}

--- a/samples-src/pages/tests/Default/pages-ol-modules-dsrf-default.html
+++ b/samples-src/pages/tests/Default/pages-ol-modules-dsrf-default.html
@@ -43,7 +43,7 @@
         <style>
             div#map {
                 width: 100%;
-                height: 500px;
+                height: 800px;
             }
         </style>
 {{/content}}

--- a/samples-src/pages/tests/Default/pages-ol-packages-default.html
+++ b/samples-src/pages/tests/Default/pages-ol-packages-default.html
@@ -13,7 +13,7 @@
         <style>
             div#map {
                 width: 100%;
-                height: 500px;
+                height: 800px;
             }
         </style>
 {{/content}}

--- a/samples-src/pages/tests/Default/pages-ol-packages-dsfr-default.html
+++ b/samples-src/pages/tests/Default/pages-ol-packages-dsfr-default.html
@@ -13,7 +13,7 @@
         <style>
             div#map {
                 width: 100%;
-                height: 500px;
+                height: 800px;
             }
         </style>
 {{/content}}

--- a/src/packages/CSS/Controls/ElevationPath/DSFRelevationPathStyle.css
+++ b/src/packages/CSS/Controls/ElevationPath/DSFRelevationPathStyle.css
@@ -1,0 +1,3 @@
+#profileElevationByDefaultSvg {
+    height: 80%;
+}

--- a/src/packages/CSS/Controls/ElevationPath/GPFelevationPath.css
+++ b/src/packages/CSS/Controls/ElevationPath/GPFelevationPath.css
@@ -1,6 +1,7 @@
 div[id^=GPelevationPath-] {
   bottom: 48px;
   left: 10px;
+  height: 36px;
 }
 
 /* Showing/hiding elevationPath panel */

--- a/src/packages/CSS/DSFRgeneralWidget.css
+++ b/src/packages/CSS/DSFRgeneralWidget.css
@@ -182,7 +182,7 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  align-items: center;
+  /* align-items: center; */
   min-width: var(--size-per-row);
   min-height: var(--size-per-row);
   padding: 5px;

--- a/src/packages/Controls/Drawing/DrawingDOM.js
+++ b/src/packages/Controls/Drawing/DrawingDOM.js
@@ -118,7 +118,7 @@ var DrawingDOM = {
 
         var divClose = document.createElement("button");
         divClose.id = this._addUID("GPdrawingPanelClose");
-        divClose.className = "GPpanelClose GPdrawingPanelClose gpf-btn gpf-btn-icon-close fr-btn--close fr-btn";
+        divClose.className = "GPpanelClose GPdrawingPanelClose gpf-btn gpf-btn-icon-close fr-btn--close fr-btn fr-btn--secondary";
         divClose.title = "Fermer le panneau";
 
         // Link panel close / visibility checkbox

--- a/src/packages/Controls/ElevationPath/ElevationPathDOM.js
+++ b/src/packages/Controls/ElevationPath/ElevationPathDOM.js
@@ -107,7 +107,7 @@ var ElevationPathDOM = {
 
         var divInfo = document.createElement("button");
         divInfo.id = this._addUID("GPelevationPathPanelInfo");
-        divInfo.className = "GPpanelInfo gpf-btn gpf-btn-icon-info fr-btn";
+        divInfo.className = "GPpanelInfo gpf-btn gpf-btn-icon-info fr-btn fr-btn--secondary";
         divInfo.title = "Informations";
         // add event on click
         if (divInfo.addEventListener) {
@@ -135,7 +135,7 @@ var ElevationPathDOM = {
 
         var buttonReduce = document.createElement("button");
         buttonReduce.id = this._addUID("GPelevationPathPanelReduce");
-        buttonReduce.className = "GPpanelReduce gpf-btn gpf-btn-icon-reduce fr-btn";
+        buttonReduce.className = "GPpanelReduce gpf-btn gpf-btn-icon-reduce fr-btn fr-btn--secondary";
         buttonReduce.title = "Masquer le panneau";
 
         if (buttonReduce.addEventListener) {
@@ -155,7 +155,7 @@ var ElevationPathDOM = {
 
         var buttonClose = document.createElement("button");
         buttonClose.id = this._addUID("GPelevationPathPanelClose");
-        buttonClose.className = "GPpanelClose gpf-btn gpf-btn-icon-close fr-btn--close fr-btn";
+        buttonClose.className = "GPpanelClose gpf-btn gpf-btn-icon-close fr-btn--close fr-btn fr-btn--secondary";
         buttonClose.title = "Fermer le panneau";
 
         // Link panel close / visibility checkbox

--- a/src/packages/Controls/Isocurve/IsocurveDOM.js
+++ b/src/packages/Controls/Isocurve/IsocurveDOM.js
@@ -135,7 +135,7 @@ var IsoDOM = {
 
         var divClose = document.createElement("button");
         divClose.id = this._addUID("GPisochronPanelClose");
-        divClose.className = "GPpanelClose GPisochronPanelClose gpf-btn gpf-btn-icon-close fr-btn--close fr-btn";
+        divClose.className = "GPpanelClose GPisochronPanelClose gpf-btn gpf-btn-icon-close fr-btn--close fr-btn fr-btn--secondary";
         divClose.title = "Fermer le panneau";
 
         // Link panel close / visibility checkbox
@@ -677,7 +677,7 @@ var IsoDOM = {
 
         var button = document.createElement("button");
         button.id = this._addUID("GPshowIsoExclusionsPicto");
-        button.className = "GPshowAdvancedToolPicto GPshowMoreOptionsImage GPshowMoreOptions GPshowIsoExclusionsPicto gpf-btn fr-btn--sm fr-icon-arrow-down-fill";
+        button.className = "GPshowAdvancedToolPicto GPshowMoreOptionsImage GPshowMoreOptions GPshowIsoExclusionsPicto gpf-btn fr-btn--sm fr-btn--secondary fr-icon-arrow-down-fill";
         button.title = "Exclusions";
         // button.style.top = "240px";
         button.setAttribute("tabindex", "0");
@@ -842,7 +842,7 @@ var IsoDOM = {
     _createIsoSubmitFormElement : function () {
         var input = document.createElement("input");
         input.id = this._addUID("GPisochronSubmit");
-        input.className = "GPsubmit gpf-btn fr-btn";
+        input.className = "GPsubmit gpf-btn fr-btn fr-btn--secondary";
         input.type = "submit";
         input.value = "Calculer";
 
@@ -863,7 +863,7 @@ var IsoDOM = {
 
         var buttonReset = document.createElement("button");
         buttonReset.id = this._addUID("GPisochronReset");
-        buttonReset.className = "GPresetPicto GPisochronReset gpf-btn gpf-btn-icon-reset fr-btn";
+        buttonReset.className = "GPresetPicto GPisochronReset gpf-btn gpf-btn-icon-reset fr-btn fr-btn--secondary";
         buttonReset.title = "Réinitialiser les paramètres";
         buttonReset.setAttribute("tabindex", "0");
         buttonReset.setAttribute("aria-pressed", false);

--- a/src/packages/Controls/LayerImport/LayerImportDOM.js
+++ b/src/packages/Controls/LayerImport/LayerImportDOM.js
@@ -133,7 +133,7 @@ var LayerImportDOM = {
 
         var divClose = document.createElement("button");
         divClose.id = this._addUID("GPimportPanelClose");
-        divClose.className = "GPpanelClose GPimportPanelClose gpf-btn gpf-btn-icon-close fr-btn--close fr-btn";
+        divClose.className = "GPpanelClose GPimportPanelClose gpf-btn gpf-btn-icon-close fr-btn--close fr-btn fr-btn--secondary";
         divClose.title = "Fermer le panneau";
 
         // Link panel close / visibility checkbox
@@ -577,7 +577,7 @@ var LayerImportDOM = {
     _createImportSubmitFormElement : function () {
         var input = document.createElement("input");
         input.id = this._addUID("GPimportSubmit");
-        input.className = "GPsubmit gpf-btn fr-btn";
+        input.className = "GPsubmit gpf-btn fr-btn fr-btn--secondary";
         input.type = "submit";
         input.value = "Importer";
 
@@ -621,7 +621,7 @@ var LayerImportDOM = {
 
         // close picto
         var closeDiv = document.createElement("button");
-        closeDiv.className = "GPpanelClose GPimportGetCapPanelClose gpf-btn gpf-btn-icon-close fr-btn--close fr-btn";
+        closeDiv.className = "GPpanelClose GPimportGetCapPanelClose gpf-btn gpf-btn-icon-close fr-btn--close fr-btn fr-btn--secondary";
         closeDiv.title = "Fermer le panneau";
         closeDiv.id = this._addUID("GPimportGetCapPanelClose");
         if (closeDiv.addEventListener) {
@@ -677,7 +677,7 @@ var LayerImportDOM = {
 
         // label for
         var label = document.createElement("label");
-        label.className = "GPimportGetCapRubriqueTitle gpf-label fr-btn";
+        label.className = "GPimportGetCapRubriqueTitle gpf-label fr-btn fr-btn--secondary";
         label.htmlFor = input.id;
         label.innerHTML = title;
         label.title = title;
@@ -749,7 +749,7 @@ var LayerImportDOM = {
         var returnDiv = document.createElement("button");
         returnDiv.id = this._addUID("GPimportMapBoxPanelReturnPicto");
         returnDiv.title = "Masquer le panneau";
-        returnDiv.className = "GPreturnPicto GPimportMapBoxPanelReturnPicto gpf-btn gpf-btn-icon-return fr-btn";
+        returnDiv.className = "GPreturnPicto GPimportMapBoxPanelReturnPicto gpf-btn gpf-btn-icon-return fr-btn fr-btn--secondary";
         if (returnDiv.addEventListener) {
             returnDiv.addEventListener("click", function (e) {
                 document.getElementById(context._addUID("GPshowImportPicto")).click();
@@ -772,7 +772,7 @@ var LayerImportDOM = {
 
         // close picto
         var closeDiv = document.createElement("button");
-        closeDiv.className = "GPpanelClose GPimportMapBoxPanelClose gpf-btn gpf-btn-icon-close fr-btn--close fr-btn";
+        closeDiv.className = "GPpanelClose GPimportMapBoxPanelClose gpf-btn gpf-btn-icon-close fr-btn--close fr-btn fr-btn--secondary";
         closeDiv.title = "Fermer le panneau";
         closeDiv.id = this._addUID("GPimportMapBoxPanelClose");
         if (closeDiv.addEventListener) {

--- a/src/packages/Controls/LocationSelector/LocationSelectorDOM.js
+++ b/src/packages/Controls/LocationSelector/LocationSelectorDOM.js
@@ -59,7 +59,7 @@ var LocationSelectorDOM = {
         var buttonOrigin = document.createElement("button");
         buttonOrigin.id = this._addUID("GPlocationOriginLabel_" + id);
         buttonOrigin.innerHTML = text;
-        buttonOrigin.className = "GPlocationOriginLabel gpf-btn gpf-btn-icon-label fr-btn";
+        buttonOrigin.className = "GPlocationOriginLabel gpf-btn gpf-btn-icon-label fr-btn fr-btn--secondary";
         buttonOrigin.addEventListener("click", function (e) {
             var i = ID.index(this.id);
             var points = document.getElementsByClassName(self._addUID("GPlocationPoint"));
@@ -75,10 +75,10 @@ var LocationSelectorDOM = {
             document.getElementById(self._addUID("GPlocationOrigin_" + i)).className = "GPelementShow gpf-show  gpf-input fr-input";
             document.getElementById(self._addUID("GPlocationOriginCoords_" + i)).className = "GPelementHidden gpf-hidden";
             if (document.getElementById(self._addUID("GPlocationStageRemove_" + i))) {
-                document.getElementById(self._addUID("GPlocationStageRemove_" + i)).className = "GPlocationStageRemove gpf-btn gpf-btn-icon-remove fr-btn--sm";
+                document.getElementById(self._addUID("GPlocationStageRemove_" + i)).className = "GPlocationStageRemove gpf-btn gpf-btn-icon-remove fr-btn--sm fr-btn--secondary";
             }
             if (document.getElementById(self._addUID("GPlocationStageAdd"))) {
-                document.getElementById(self._addUID("GPlocationStageAdd")).className = "GPlocationStageAdd gpf-btn gpf-btn-icon-add fr-btn--sm";
+                document.getElementById(self._addUID("GPlocationStageAdd")).className = "GPlocationStageAdd gpf-btn gpf-btn-icon-add fr-btn--sm fr-btn--secondary";
             }
             // document.getElementById(self._addUID("GPlocationOriginCoords_" + i)).disabled = true;
             self.onLocationClearPointClick(e);
@@ -243,7 +243,7 @@ var LocationSelectorDOM = {
         var buttonOriginPointer = document.createElement("button");
         buttonOriginPointer.id = this._addUID("GPlocationOriginPointerImg_" + id);
         buttonOriginPointer.htmlFor = this._addUID("GPlocationOriginPointer_" + id);
-        buttonOriginPointer.className = "GPlocationOriginPointerImg gpf-btn gpf-btn-icon-pointer fr-btn";
+        buttonOriginPointer.className = "GPlocationOriginPointerImg gpf-btn gpf-btn-icon-pointer fr-btn fr-btn--secondary";
         buttonOriginPointer.title = "Pointer un lieu sur la carte";
         buttonOriginPointer.addEventListener("click", function (e) {
             e.preventDefault();
@@ -273,10 +273,10 @@ var LocationSelectorDOM = {
                     document.getElementById(self._addUID("GPlocationPoint_" + id)).style.cssText = "";
                 }
                 if (document.getElementById(self._addUID("GPlocationStageRemove_" + i))) {
-                    document.getElementById(self._addUID("GPlocationStageRemove_" + i)).className = "GPlocationStageRemove  gpf-btn gpf-btn-icon-remove fr-btn--sm";
+                    document.getElementById(self._addUID("GPlocationStageRemove_" + i)).className = "GPlocationStageRemove  gpf-btn gpf-btn-icon-remove fr-btn--sm fr-btn--secondary";
                 }
                 if (document.getElementById(self._addUID("GPlocationStageAdd"))) {
-                    document.getElementById(self._addUID("GPlocationStageAdd")).className = "GPlocationStageAdd gpf-btn gpf-btn-icon-add fr-btn--sm";
+                    document.getElementById(self._addUID("GPlocationStageAdd")).className = "GPlocationStageAdd gpf-btn gpf-btn-icon-add fr-btn--sm fr-btn--secondary";
                 }
                 document.getElementById(self._addUID("GPlocationOriginPointer_" + i)).checked = false;
                 document.getElementById(self._addUID("GPlocationOrigin_" + i)).className = "GPelementShow gpf-show  gpf-input fr-input";
@@ -324,7 +324,7 @@ var LocationSelectorDOM = {
 
         var buttonRm = document.createElement("button");
         buttonRm.id = this._addUID("GPlocationStageRemove_" + id);
-        buttonRm.className = "GPlocationOpen GPlocationStageRemove gpf-btn gpf-btn-icon-remove fr-btn--sm";
+        buttonRm.className = "GPlocationOpen GPlocationStageRemove gpf-btn gpf-btn-icon-remove fr-btn--sm fr-btn--secondary";
         buttonRm.title = "Supprimer l'étape";
         buttonRm.setAttribute("tabindex", "0");
         buttonRm.setAttribute("aria-pressed", false);
@@ -372,7 +372,7 @@ var LocationSelectorDOM = {
 
         var buttonAdd = document.createElement("button");
         buttonAdd.id = this._addUID("GPlocationStageAdd");
-        buttonAdd.className = "GPlocationOpen GPlocationStageAdd gpf-btn gpf-btn-icon-add fr-btn--sm";
+        buttonAdd.className = "GPlocationOpen GPlocationStageAdd gpf-btn gpf-btn-icon-add fr-btn--sm fr-btn--secondary";
         buttonAdd.title = "Ajouter une étape";
         buttonAdd.setAttribute("tabindex", "0");
         buttonAdd.setAttribute("aria-pressed", false);
@@ -495,7 +495,7 @@ var LocationSelectorDOM = {
                     var id2 = ID.index(tag);
                     document.getElementById(this._addUID("GPlocationPoint_" + id2)).style.cssText = "";
                     if (document.getElementById(this._addUID("GPlocationStageRemove_" + id2))) {
-                        document.getElementById(this._addUID("GPlocationStageRemove_" + id2)).className = "GPlocationStageRemove gpf-btn gpf-btn-icon-remove fr-btn--sm";
+                        document.getElementById(this._addUID("GPlocationStageRemove_" + id2)).className = "GPlocationStageRemove gpf-btn gpf-btn-icon-remove fr-btn--sm fr-btn--secondary";
                     }
                 }
                 document.getElementById(this._addUID("GPlocationOriginPointer_" + id1)).checked = false;

--- a/src/packages/Controls/MousePosition/MousePositionDOM.js
+++ b/src/packages/Controls/MousePosition/MousePositionDOM.js
@@ -136,7 +136,7 @@ var MousePositionDOM = {
 
         var divClose = document.createElement("button");
         divClose.id = this._addUID("GPmousePositionPanelClose");
-        divClose.className = "GPpanelClose gpf-btn gpf-btn-close fr-btn--close fr-btn";
+        divClose.className = "GPpanelClose gpf-btn gpf-btn-close fr-btn--close fr-btn fr-btn--secondary";
         divClose.title = "Fermer le panneau";
 
         // Link panel close / visibility checkbox
@@ -500,7 +500,7 @@ var MousePositionDOM = {
         var button = document.createElement("button");
         button.id = this._addUID("GPshowMousePositionSettings");
 
-        button.className = "GPshowAdvancedToolPicto GPshowMoreOptionsImage GPshowMoreOptions GPshowMousePositionSettingsPicto gpf-btn fr-btn--sm fr-icon-arrow-down-fill";
+        button.className = "GPshowAdvancedToolPicto GPshowMoreOptionsImage GPshowMoreOptions GPshowMousePositionSettingsPicto gpf-btn fr-btn--sm fr-btn--secondary fr-icon-arrow-down-fill";
         button.title = "Réglages";
         button.setAttribute("tabindex", "0");
         button.setAttribute("aria-pressed", false);

--- a/src/packages/Controls/ReverseGeocode/ReverseGeocodeDOM.js
+++ b/src/packages/Controls/ReverseGeocode/ReverseGeocodeDOM.js
@@ -208,7 +208,7 @@ var ReverseGeocodeDOM = {
         var buttonNew = document.createElement("button");
         buttonNew.id = this._addUID("GPreverseGeocodingReturnPicto");
         buttonNew.title = "Nouvelle recherche";
-        buttonNew.className = "GPreturnPicto GPreverseGeocodingReturnPicto gpf-btn gpf-btn-icon-return fr-btn";
+        buttonNew.className = "GPreturnPicto GPreverseGeocodingReturnPicto gpf-btn gpf-btn-icon-return fr-btn fr-btn--secondary";
         buttonNew.classList.add("GPelementHidden");
         buttonNew.classList.add("gpf-hidden");
         if (buttonNew.addEventListener) {
@@ -257,7 +257,7 @@ var ReverseGeocodeDOM = {
 
         var divClose = document.createElement("button");
         divClose.id = this._addUID("GPreverseGeocodingPanelClose");
-        divClose.className = "GPpanelClose GPreverseGeocodingPanelClose gpf-btn gpf-btn-icon-close fr-btn--close fr-btn";
+        divClose.className = "GPpanelClose GPreverseGeocodingPanelClose gpf-btn gpf-btn-icon-close fr-btn--close fr-btn fr-btn--secondary";
         divClose.title = "Fermer le panneau";
 
         // Link panel close / visibility checkbox
@@ -473,7 +473,7 @@ var ReverseGeocodeDOM = {
     _createReverseGeocodingSubmitFormElement : function () {
         var input = document.createElement("input");
         input.id = this._addUID("GPreverseGeocodingSubmit");
-        input.className = "GPsubmit gpf-btn fr-btn";
+        input.className = "GPsubmit gpf-btn fr-btn fr-btn--secondary";
         input.type = "submit";
         input.value = "Rechercher";
 

--- a/src/packages/Controls/Route/RouteDOM.js
+++ b/src/packages/Controls/Route/RouteDOM.js
@@ -121,7 +121,7 @@ var RouteDOM = {
 
         var divClose = document.createElement("button");
         divClose.id = this._addUID("GProutePanelClose");
-        divClose.className = "GPpanelClose GProutePanelClose gpf-btn gpf-btn-icon-close fr-btn--close fr-btn";
+        divClose.className = "GPpanelClose GProutePanelClose gpf-btn gpf-btn-icon-close fr-btn--close fr-btn fr-btn--secondary";
         divClose.title = "Masquer le panneau";
 
         // Link panel close / visibility checkbox
@@ -1031,7 +1031,7 @@ var RouteDOM = {
 
         var button = document.createElement("button");
         button.id = this._addUID("GPshowRouteExclusionsPicto");
-        button.className = "GPshowAdvancedToolPicto GPshowMoreOptionsImage GPshowMoreOptions GPshowRouteExclusionsPicto gpf-btn fr-btn--sm fr-icon-arrow-down-fill";
+        button.className = "GPshowAdvancedToolPicto GPshowMoreOptionsImage GPshowMoreOptions GPshowRouteExclusionsPicto gpf-btn fr-btn--sm fr-btn--secondary fr-icon-arrow-down-fill";
         button.title = "Exclusions";
         // button.style.top = "185px";
         button.setAttribute("tabindex", "0");
@@ -1194,7 +1194,7 @@ var RouteDOM = {
     _createRouteSubmitFormElement : function () {
         var input = document.createElement("input");
         input.id = this._addUID("GProuteSubmit");
-        input.className = "GPsubmit gpf-btn gpf-btn-submit fr-btn";
+        input.className = "GPsubmit gpf-btn gpf-btn-submit fr-btn fr-btn--secondary";
         input.type = "submit";
         input.value = "Calculer";
 
@@ -1216,7 +1216,7 @@ var RouteDOM = {
         var buttonReset = document.createElement("button");
         buttonReset.id = this._addUID("GProuteReset");
         buttonReset.title = "Réinitialiser les paramètres";
-        buttonReset.className = "GPresetPicto gpf-btn gpf-icon-return fr-btn";
+        buttonReset.className = "GPresetPicto gpf-btn gpf-icon-return fr-btn fr-btn--secondary";
         buttonReset.title = "Réinitialiser les paramètres";
         buttonReset.setAttribute("tabindex", "0");
         buttonReset.setAttribute("aria-pressed", false);

--- a/src/packages/Controls/SearchEngine/SearchEngineDOM.js
+++ b/src/packages/Controls/SearchEngine/SearchEngineDOM.js
@@ -219,7 +219,7 @@ var SearchEngineDOM = {
 
         var buttonReset = document.createElement("button");
         buttonReset.id = this._addUID("GPsearchInputReset");
-        buttonReset.className = "GPshowOpen gpf-btn gpf-btn-icon-close fr-btn"; /* not use : fr-btn--close */
+        buttonReset.className = "GPshowOpen gpf-btn gpf-btn-icon-close fr-btn fr-btn--secondary"; /* not use : fr-btn--close */
         // Reset input
         buttonReset.addEventListener("click", function (e) {
             // FIXME event déclenché sur la frappe "return" dans la zone de saisie !?
@@ -246,7 +246,7 @@ var SearchEngineDOM = {
 
         var button = document.createElement("button");
         button.id = this._addUID("GPshowAdvancedSearch");
-        button.className = "GPshowOpen GPshowAdvancedToolPicto gpf-btn fr-btn";
+        button.className = "GPshowOpen GPshowAdvancedToolPicto gpf-btn fr-btn fr-btn--secondary";
         button.title = "Ouvrir la recherche avancée";
         button.setAttribute("tabindex", "0");
         button.setAttribute("aria-pressed", false);
@@ -431,7 +431,7 @@ var SearchEngineDOM = {
 
         var divClose = document.createElement("button");
         divClose.id = this._addUID("GPadvancedSearchClose");
-        divClose.className = "GPpanelClose gpf-btn gpf-icon-close fr-btn--close fr-btn";
+        divClose.className = "GPpanelClose gpf-btn gpf-icon-close fr-btn--close fr-btn fr-btn--secondary";
         divClose.title = "Fermer la recherche avancée";
 
         if (divClose.addEventListener) {
@@ -578,7 +578,7 @@ var SearchEngineDOM = {
         var input = document.createElement("input");
         input.type = "submit";
         input.id = this._addUID("GPadvancedSearchSubmit");
-        input.className = "GPsubmit gpf-btn gpf-btn-submit fr-btn";
+        input.className = "GPsubmit gpf-btn gpf-btn-submit fr-btn fr-btn--secondary";
         input.value = "Chercher";
 
         return input;
@@ -705,7 +705,7 @@ var SearchEngineDOM = {
 
         var divClose = document.createElement("button");
         divClose.id = this._addUID("GPgeocodeResultsClose");
-        divClose.className = "GPpanelClose gpf-btn gpf-icon-close fr-btn--close fr-btn";
+        divClose.className = "GPpanelClose gpf-btn gpf-icon-close fr-btn--close fr-btn fr-btn--secondary";
         divClose.title = "Fermer la fenêtre de résultats";
 
         if (divClose.addEventListener) {


### PR DESCRIPTION
Seuls les boutons permettant d'activer/désactiver le widget doivent être "primaires" (fond bleu DSFR)

Les autres boutons doivent être secondaires : pour cela on leur rajoute la classe fr-btn--secondary (fond blanc)