### PR TITLE
fix(Search) : correction recherche avancée parcelle Cadastrale

### DIFF
--- a/src/packages/Controls/SearchEngine/SearchEngine.js
+++ b/src/packages/Controls/SearchEngine/SearchEngine.js
@@ -2023,6 +2023,9 @@ var SearchEngine = class SearchEngine extends Control {
         for (var i = 0; i < data.length; i++) {
             var filter = data[i];
             if (filter.value) {
+                if (filter.key === "section") {
+                    filter.value = filter.value.toUpperCase();
+                }
                 _filterOptions[filter.key] = filter.value;
             }
         }

--- a/src/packages/Utils/SearchEngineUtils.js
+++ b/src/packages/Utils/SearchEngineUtils.js
@@ -69,10 +69,6 @@ var SearchEngineUtils = {
                 title : "Code commune (INSEE)",
                 description : "Code INSEE de la commune : 3 chiffres (ex: 067)"
             }, {
-                name : "city",
-                title : "Nom commune",
-                description : "Nom de la commune"
-            }, {
                 name : "oldmunicipalitycode",
                 title : "Commune absorbée",
                 description : "Commune absorbée : 3 chiffres (ex: 000, 001)"


### PR DESCRIPTION
# Quel est le comportement actuel (avant PR) :

La recherche par parcelle cadastrale sur le champ section était case Sensitive.
La recherche par parcelle cadastrale proposait le champ "nom de ville", or le nouveau service de geocodage ne permet pas de chercher sur ce champ avec la resource cadastralParcel

# Quel est le nouveau comportement :

La recherche par parcelle cadastrale sur le champ section n'est plus case Sensitive.
La recherche par parcelle cadastrale ne propose plus le champ nom de ville