### PR TITLE
fix(zoom): Afficher les boutons zoom de manière identique sur FF et Chrome

### DIFF
--- a/src/packages/CSS/Controls/Zoom/GPFzoom.css
+++ b/src/packages/CSS/Controls/Zoom/GPFzoom.css
@@ -1,6 +1,7 @@
 [id^=GPzoom-] {
     top: 0.5em;
     left: 0.5em;
+    flex-direction: column;
 }
 
 #GPzoomIn,

--- a/src/packages/CSS/DSFRgeneralWidget.css
+++ b/src/packages/CSS/DSFRgeneralWidget.css
@@ -8,12 +8,12 @@
 .gpf-widget {
   position: absolute;
   pointer-events: auto;
-  /* display: flex;*/
+  display: flex;
   padding: 2px;
 }
 
 .gpf-widget-button {
-  width: 40px;
+  width: 44px;
 }
 
 .gpf-panel {


### PR DESCRIPTION
toujours un petit décalage avec autres boutons 
A gérer dans une autre PR