### PR TITLE
fix(LS): corrige layerInfo clickable (#84)

### DIFF
--- a/src/packages/CSS/Controls/LayerSwitcher/DSFRlayerSwitcherStyle.css
+++ b/src/packages/CSS/Controls/LayerSwitcher/DSFRlayerSwitcherStyle.css
@@ -65,6 +65,12 @@ button[id^=GPshowAdvancedTools_ID_][aria-pressed="true"] + .GPlayerAdvancedTools
     height: 56px;
     max-height: 56px;
 }
+
+/* Surchargé en inline avec "hidden" pour les couches n'ayant pas de description ou de titre */
+button[id^=GPshowAdvancedTools_ID_][aria-pressed="true"] + .GPlayerAdvancedTools > .GPlayerInfo {
+    visibility: visible;
+}
+
 button[id^=GPshowAdvancedTools_ID_][aria-pressed="false"] {
     background-image: url("img/dsfr/collapse.svg");
     background-repeat: no-repeat;
@@ -72,6 +78,11 @@ button[id^=GPshowAdvancedTools_ID_][aria-pressed="false"] {
     background-position: center center;
     box-shadow: none;
 }
+
+button[id^=GPshowAdvancedTools_ID_][aria-pressed="false "] + .GPlayerAdvancedTools > .GPlayerInfo {
+    visibility: hidden;
+}
+
 button[id^=GPshowAdvancedTools_ID_] {
     position: absolute;
     top: 0;

--- a/src/packages/Controls/LayerSwitcher/LayerSwitcherDOM.js
+++ b/src/packages/Controls/LayerSwitcher/LayerSwitcherDOM.js
@@ -505,10 +505,7 @@ var LayerSwitcherDOM = {
         btnInfo.id = this._addUID("GPinfo_ID_" + obj.id);
         btnInfo.className = "GPlayerInfo GPlayerInfoClosed gpf-btn gpf-btn-icon gpf-btn-icon-ls-info fr-btn fr-btn--tertiary";
         // hack pour garder un emplacement vide
-        if (obj.title && obj.description) {
-            btnInfo.style.opacity = "100";
-            btnInfo.style.visibility = "visible";
-        } else {
+        if (!obj.title || !obj.description) {
             btnInfo.style.opacity = "0";
             btnInfo.style.visibility = "hidden";
         }


### PR DESCRIPTION
Correction du #84 

Gestion de la visibilité en CSS + réduction du hack inline CSS au cas des couches dont l'icone layerInfo ne doit pas s'afficher.


