### PR TITLE
fix(search-dsfr): results height in chrome

### DIFF
--- a/src/packages/CSS/Controls/SearchEngine/DSFRsearchEngineStyle.css
+++ b/src/packages/CSS/Controls/SearchEngine/DSFRsearchEngineStyle.css
@@ -17,6 +17,7 @@
 
 .gpf-panel__items.GPautoCompleteProposal {
   height: 45px;
+  box-sizing: border-box;
 }
 
 .GPlabelTitle {


### PR DESCRIPTION
fixes #83