### PR TITLE
feat(dsfr): afficher un bouton ol-disabled quand même avec le style de fr-btn disabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geoportal-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.102",
+  "version": "1.0.0-beta.104",
   "date": "08/07/2024",
   "module": "src/index.js",
   "directories": {},

--- a/src/packages/CSS/DSFRgeneralWidget.css
+++ b/src/packages/CSS/DSFRgeneralWidget.css
@@ -441,3 +441,14 @@
   padding-bottom: 10px;
   border-bottom: 1px dotted #666;
 }
+
+.ol-disabled {
+  --idle: transparent;
+  --hover: var(--background-disabled-grey-hover);
+  --active: var(--background-disabled-grey-active);
+  background-color: var(--background-disabled-grey);
+  color: var(--text-disabled-grey);
+  cursor: not-allowed;
+  /* instead of display: none */
+  display: block;
+}


### PR DESCRIPTION
Plutôt que pas affiché du tout 

![image](https://github.com/IGNF/geoportal-extensions-openlayers/assets/18074428/9c851bae-f3e3-4165-96b5-33e219f0156f)
