### PR TITLE
fix(zoom): ajout d'une marge et d'un aplat compatible multi navigateurs

### DIFF
--- a/src/packages/CSS/Controls/Zoom/DSFRzoomStyle.css
+++ b/src/packages/CSS/Controls/Zoom/DSFRzoomStyle.css
@@ -7,6 +7,7 @@
     height: inherit;
     width: inherit;
 }
+
 .gpf-btn-icon-zoom-out {
     background-image: url("img/dsfr/zoom-out.svg");
     background-repeat: no-repeat;
@@ -17,13 +18,13 @@
     width: inherit;
 }
 
-#GPzoomIn { 
+#GPzoomIn {
     margin-bottom: 4px;
     box-shadow: 0px 12px var(--background-action-high-blue-france);
 }
 
-@-moz-document url-prefix() { 
-    #GPzoomIn { 
+@supports(-moz-appearance:none) {
+    #GPzoomIn {
         box-shadow: 0px 4px var(--background-action-high-blue-france);
     }
 }


### PR DESCRIPTION
Permet de réaligner la grille des boutons, et de prendre en compte les spécificités Mozilla / Chrome.

PR intégrée sur branche fix/button-grid-position de l'Entrée carto. N'y résoud pas le problème de décalage de boutons (certainement plusieurs causes)

### MOZILLA 

**AVANT**
![image](https://github.com/IGNF/geoportal-extensions-openlayers/assets/6764800/fb910076-8933-47dc-9b56-46b4106ecb68)


**APRES**
![image](https://github.com/IGNF/geoportal-extensions-openlayers/assets/6764800/db52b46b-5ff3-4455-b86b-d5c278c51c81)


### CHROME

**AVANT**
![image](https://github.com/IGNF/geoportal-extensions-openlayers/assets/6764800/c7f0c043-e988-48fc-80ef-98423e2067d5)


**APRES**

![image](https://github.com/IGNF/geoportal-extensions-openlayers/assets/6764800/adf58e20-d1b0-4c98-a3fe-b647a93b9c27)
