### PR TITLE
fix(advanced-search)(dsfr): add disabled state on button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geoportal-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.103",
+  "version": "1.0.0-beta.110",
   "date": "14/07/2024",
   "module": "src/index.js",
   "directories": {},

--- a/src/packages/CSS/Controls/SearchEngine/DSFRsearchEngineStyle.css
+++ b/src/packages/CSS/Controls/SearchEngine/DSFRsearchEngineStyle.css
@@ -103,10 +103,6 @@ button[id^="GPshowSearchEnginePicto-"] {
   border-radius: 0 0.25rem 0 0;
 }
 
-/* hack pour forcer la couleur d'un element desactivé */
-.gpf-btn-icon-search:disabled {
-    background-color: #000091;
-}
 .gpf-btn-icon-search-advanced::after {
   -webkit-mask: url("img/dsfr/recherche-avancee.svg") center no-repeat;
   mask: url("img/dsfr/recherche-avancee.svg") center no-repeat;

--- a/src/packages/CSS/Controls/SearchEngine/GPFsearchEngine.css
+++ b/src/packages/CSS/Controls/SearchEngine/GPFsearchEngine.css
@@ -74,7 +74,6 @@ button[id^=GPsearchInputReset] {
   top: 0px;
   right: 0px;
   border: unset;
-  cursor: pointer;
 }
 
 /* General panels */

--- a/src/packages/CSS/DSFRgeneralWidget.css
+++ b/src/packages/CSS/DSFRgeneralWidget.css
@@ -161,6 +161,11 @@
   mask: linear-gradient(#0000, #0000);
 }
 
+.gpf-btn--tertiary:disabled:after,
+.gpf-btn--secondary:disabled::after {
+  background-color: var(--text-disabled-grey);
+}
+
 
 .gpf-btn--hidden {}
 
@@ -182,7 +187,7 @@
   width: inherit;
 }
 
-.gpf-btn-icon-reset {
+.gpf-btn-icon-reset::after {
   -webkit-mask:
     linear-gradient(#fff 0 0) top /100% 1px,
     linear-gradient(#fff 0 0) bottom/100% 1px,

--- a/src/packages/Controls/SearchEngine/SearchEngineDOM.js
+++ b/src/packages/Controls/SearchEngine/SearchEngineDOM.js
@@ -118,6 +118,9 @@ var SearchEngineDOM = {
             }
             var id = "#GPsearchInput-" + self._uid;
             document.querySelector(id + " input").disabled = false; // FIXME form[id^=GPsearchInput] = #GPsearchInput ?
+            if (checkDsfr()) {
+                document.querySelector("#GPshowSearchEnginePicto-" + self._uid).disabled = false;
+            }
             self.onShowSearchEngineClick();
         });
 
@@ -425,10 +428,18 @@ var SearchEngineDOM = {
                 document.getElementById(self._addUID("GPadvancedSearchPanel")).classList.replace("GPelementVisible", "GPelementHidden");
                 document.getElementById(self._addUID("GPadvancedSearchPanel")).classList.replace("gpf-visible", "gpf-hidden");
                 document.querySelector(id + " input").disabled = false;
+                document.querySelector(id + " .GPsearchInputReset").disabled = false;
+                if (checkDsfr()) {
+                    document.querySelector("#GPshowSearchEnginePicto-" + self._uid).disabled = false;
+                }
             } else {
                 document.getElementById(self._addUID("GPadvancedSearchPanel")).classList.replace("GPelementHidden", "GPelementVisible");
                 document.getElementById(self._addUID("GPadvancedSearchPanel")).classList.replace("gpf-hidden", "gpf-visible");
                 document.querySelector(id + " input").disabled = true;
+                document.querySelector(id + " .GPsearchInputReset").disabled = true;
+                if (checkDsfr()) {
+                    document.querySelector("#GPshowSearchEnginePicto-" + self._uid).disabled = true;
+                }
             }
 
             document.getElementById(self._addUID("GPautoCompleteList")).classList.replace("GPelementVisible", "GPelementHidden");
@@ -499,10 +510,18 @@ var SearchEngineDOM = {
                 document.getElementById(self._addUID("GPcoordinateSearchPanel")).classList.replace("GPelementVisible", "GPelementHidden");
                 document.getElementById(self._addUID("GPcoordinateSearchPanel")).classList.replace("gpf-visible", "gpf-hidden");
                 document.querySelector(id + " input").disabled = false;
+                document.querySelector(id + " .GPsearchInputReset").disabled = false;
+                if (checkDsfr()) {
+                    document.querySelector("#GPshowSearchEnginePicto-" + self._uid).disabled = false;
+                }
             } else {
                 document.getElementById(self._addUID("GPcoordinateSearchPanel")).classList.replace("GPelementHidden", "GPelementVisible");
                 document.getElementById(self._addUID("GPcoordinateSearchPanel")).classList.replace("gpf-hidden", "gpf-visible");
                 document.querySelector(id + " input").disabled = true;
+                document.querySelector(id + " .GPsearchInputReset").disabled = true;
+                if (checkDsfr()) {
+                    document.querySelector("#GPshowSearchEnginePicto-" + self._uid).disabled = true;
+                }
             }
 
             document.getElementById(self._addUID("GPautoCompleteList")).classList.replace("GPelementVisible", "GPelementHidden");
@@ -791,6 +810,10 @@ var SearchEngineDOM = {
             divClose.addEventListener("click", function () {
                 var id = "#GPsearchInput-" + self._uid;
                 document.querySelector(id + " input").disabled = false;
+                document.querySelector(id + " .GPsearchInputReset").disabled = false;
+                if (checkDsfr()) {
+                    document.querySelector("#GPshowSearchEnginePicto-" + self._uid).disabled = false;
+                }
                 document.getElementById(self._addUID("GPgeocodeResultsList")).classList.replace("GPelementVisible", "GPelementHidden");
                 document.getElementById(self._addUID("GPgeocodeResultsList")).classList.replace("gpf-visible", "gpf-hidden");
                 // document.getElementById(self._addUID("GPshowAdvancedSearch")).style.display = "inline-block";
@@ -802,6 +825,10 @@ var SearchEngineDOM = {
             divClose.attachEvent("onclick", function () {
                 var id = "#GPsearchInput-" + self._uid;
                 document.querySelector(id + " input").disabled = false;
+                document.querySelector(id + " .GPsearchInputReset").disabled = false;
+                if (checkDsfr()) {
+                    document.querySelector("#GPshowSearchEnginePicto-" + self._uid).disabled = false;
+                }
                 document.getElementById(self._addUID("GPgeocodeResultsList")).classList.replace("GPelementVisible", "GPelementHidden");
                 document.getElementById(self._addUID("GPgeocodeResultsList")).classList.replace("gpf-visible", "gpf-hidden");
                 // document.getElementById(self._addUID("GPshowAdvancedSearch")).style.display = "inline-block";
@@ -1175,6 +1202,10 @@ var SearchEngineDOM = {
             divClose.addEventListener("click", function () {
                 var id = "#GPsearchInput-" + self._uid;
                 document.querySelector(id + " input").disabled = false;
+                document.querySelector(id + " .GPsearchInputReset").disabled = false;
+                if (checkDsfr()) {
+                    document.querySelector("#GPshowSearchEnginePicto-" + self._uid).disabled = false;
+                }
                 document.getElementById(self._addUID("GPshowSearchByCoordinate")).setAttribute("aria-pressed", false);
                 document.getElementById(self._addUID("GPcoordinateSearchPanel")).classList.replace("GPelementVisible", "GPelementHidden");
                 document.getElementById(self._addUID("GPcoordinateSearchPanel")).classList.replace("gpf-visible", "gpf-hidden");
@@ -1184,6 +1215,10 @@ var SearchEngineDOM = {
             divClose.attachEvent("onclick", function () {
                 var id = "#GPsearchInput-" + self._uid;
                 document.querySelector(id + " input").disabled = false;
+                document.querySelector(id + " .GPsearchInputReset").disabled = false;
+                if (checkDsfr()) {
+                    document.querySelector("#GPshowSearchEnginePicto-" + self._uid).disabled = false;
+                }
                 document.getElementById(self._addUID("GPshowSearchByCoordinate")).setAttribute("aria-pressed", false);
                 document.getElementById(self._addUID("GPcoordinateSearchPanel")).classList.replace("GPelementVisible", "GPelementHidden");
                 document.getElementById(self._addUID("GPcoordinateSearchPanel")).classList.replace("gpf-visible", "gpf-hidden");


### PR DESCRIPTION
fixes #99

Pour la recherche avancée, la chaine de caractère principale de la recherche est celle de la barre de recherche par défaut. Cette barre est bien désactivée, mais il faut aussi désactiver le bouton en mode DSFR car il lance la recherche.

Avant :
![image](https://github.com/user-attachments/assets/dacb1c2d-fc98-412a-a120-f32dda88120c)
Après :
![350896548-ab10dfdf-8521-44fe-a47f-de3c68a0900b](https://github.com/user-attachments/assets/02eb293b-9c73-40ab-93f1-3590af8f7fd4)


J'en ai profité pour corriger des anomalies des style sur les boutons dsfr, notamment en mode disabled.