### PR TITLE
fix(search:dom): vérifie l'existence du bouton de reset de la recherche 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geoportal-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.110",
-  "date": "14/07/2024",
+  "version": "1.0.0-beta.111",
+  "date": "22/07/2024",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/src/packages/Controls/SearchEngine/SearchEngineDOM.js
+++ b/src/packages/Controls/SearchEngine/SearchEngineDOM.js
@@ -428,7 +428,10 @@ var SearchEngineDOM = {
                 document.getElementById(self._addUID("GPadvancedSearchPanel")).classList.replace("GPelementVisible", "GPelementHidden");
                 document.getElementById(self._addUID("GPadvancedSearchPanel")).classList.replace("gpf-visible", "gpf-hidden");
                 document.querySelector(id + " input").disabled = false;
-                document.querySelector(id + " .GPsearchInputReset").disabled = false;
+                // only if displayButtonClose option is set to true
+                if (document.querySelector(id + " .GPsearchInputReset")) {
+                    document.querySelector(id + " .GPsearchInputReset").disabled = false;
+                }
                 if (checkDsfr()) {
                     document.querySelector("#GPshowSearchEnginePicto-" + self._uid).disabled = false;
                 }
@@ -436,7 +439,10 @@ var SearchEngineDOM = {
                 document.getElementById(self._addUID("GPadvancedSearchPanel")).classList.replace("GPelementHidden", "GPelementVisible");
                 document.getElementById(self._addUID("GPadvancedSearchPanel")).classList.replace("gpf-hidden", "gpf-visible");
                 document.querySelector(id + " input").disabled = true;
-                document.querySelector(id + " .GPsearchInputReset").disabled = true;
+                // only if displayButtonClose option is set to true
+                if (document.querySelector(id + " .GPsearchInputReset")) {
+                    document.querySelector(id + " .GPsearchInputReset").disabled = true;
+                }
                 if (checkDsfr()) {
                     document.querySelector("#GPshowSearchEnginePicto-" + self._uid).disabled = true;
                 }
@@ -810,7 +816,10 @@ var SearchEngineDOM = {
             divClose.addEventListener("click", function () {
                 var id = "#GPsearchInput-" + self._uid;
                 document.querySelector(id + " input").disabled = false;
-                document.querySelector(id + " .GPsearchInputReset").disabled = false;
+                // only if displayButtonClose option is set to true
+                if (document.querySelector(id + " .GPsearchInputReset")) {
+                    document.querySelector(id + " .GPsearchInputReset").disabled = false;
+                }
                 if (checkDsfr()) {
                     document.querySelector("#GPshowSearchEnginePicto-" + self._uid).disabled = false;
                 }
@@ -825,7 +834,10 @@ var SearchEngineDOM = {
             divClose.attachEvent("onclick", function () {
                 var id = "#GPsearchInput-" + self._uid;
                 document.querySelector(id + " input").disabled = false;
-                document.querySelector(id + " .GPsearchInputReset").disabled = false;
+                // only if displayButtonClose option is set to true
+                if (document.querySelector(id + " .GPsearchInputReset")) {
+                    document.querySelector(id + " .GPsearchInputReset").disabled = false;
+                }
                 if (checkDsfr()) {
                     document.querySelector("#GPshowSearchEnginePicto-" + self._uid).disabled = false;
                 }
@@ -1202,7 +1214,10 @@ var SearchEngineDOM = {
             divClose.addEventListener("click", function () {
                 var id = "#GPsearchInput-" + self._uid;
                 document.querySelector(id + " input").disabled = false;
-                document.querySelector(id + " .GPsearchInputReset").disabled = false;
+                // only if displayButtonClose option is set to true
+                if (document.querySelector(id + " .GPsearchInputReset")) {
+                    document.querySelector(id + " .GPsearchInputReset").disabled = false;
+                }
                 if (checkDsfr()) {
                     document.querySelector("#GPshowSearchEnginePicto-" + self._uid).disabled = false;
                 }
@@ -1215,7 +1230,10 @@ var SearchEngineDOM = {
             divClose.attachEvent("onclick", function () {
                 var id = "#GPsearchInput-" + self._uid;
                 document.querySelector(id + " input").disabled = false;
-                document.querySelector(id + " .GPsearchInputReset").disabled = false;
+                // only if displayButtonClose option is set to true
+                if (document.querySelector(id + " .GPsearchInputReset")) {
+                    document.querySelector(id + " .GPsearchInputReset").disabled = false;
+                }
                 if (checkDsfr()) {
                     document.querySelector("#GPshowSearchEnginePicto-" + self._uid).disabled = false;
                 }


### PR DESCRIPTION
Corrige la fermeture du panel de recherche avancée dans le cas où le bouton de reset n'existe pas, comme c'est le cas sur l'entrée carto, en vérifiant son existence dans les fonctions appelées par les listeners sur le clic du bouton "Fermer".

Bug introduit par #110. 