### PR TITLE
fix(AdvancedSearch): poi category avec un élément select et une liste de choix finie

### DIFF
--- a/src/packages/Controls/SearchEngine/SearchEngineDOM.js
+++ b/src/packages/Controls/SearchEngine/SearchEngineDOM.js
@@ -879,7 +879,8 @@ var SearchEngineDOM = {
             var data = [];
             // liste des attributs de la ressource de geocodage
             var id = "#GPadvancedSearchFilters-" + self._uid;
-            var matchesFilters = document.querySelectorAll(id + " > div > div > input,select#category");            for (var i = 0; i < matchesFilters.length; i++) {
+            var matchesFilters = document.querySelectorAll(id + " > div > div > input,select#category");            
+            for (var i = 0; i < matchesFilters.length; i++) {
                 var element = matchesFilters[i];
                 data.push({
                     key : element.name,


### PR DESCRIPTION
Remplacement de la liste "Type" de recherche avancée par Lieux et Points d'intérêts : 
<select> à la place de <input>


Classique : 
![image](https://github.com/user-attachments/assets/267e89ef-d6df-4910-8228-9a5be4e81e50)
 DSFR : 
![image](https://github.com/user-attachments/assets/5abf70cb-67b5-40ec-bd9b-a6ae9b06ecd6)


Firefox et Android ne géraient pas bien l'input avec autocomplétion dans son affichage. (voir https://github.com/IGNF/cartes.gouv.fr-entree-carto/issues/230)