### PR TITLE
fix(search:css): meilleur centrage des éléments de la barre de recherche en DSFR

### DIFF
--- a/src/packages/CSS/Controls/SearchEngine/DSFRsearchEngineStyle.css
+++ b/src/packages/CSS/Controls/SearchEngine/DSFRsearchEngineStyle.css
@@ -47,6 +47,7 @@ button[id^=GPsearchInputReset] {
 
 [id^="GPsearchEngine-"].gpf-widget-padding {
   align-items: center;
+  padding-right: 15px;
 }
 
 div.GPbuttonsContainer > button {
@@ -63,6 +64,7 @@ div.GPbuttonsContainer > button {
 
 .GPbuttonsContainer {
   height: 56px;
+  padding-left: 10px;
 }
 
 .GPsearchRadioContainer {
@@ -84,7 +86,6 @@ div.GPbuttonsContainer > button {
 .GPsearchRadioElements {
   display: flex;
   flex-direction: row;
-  margin: 0.5rem;
 }
 
 .GPsearchSplitChoice {

--- a/src/packages/CSS/Controls/SearchEngine/GPFsearchEngine.css
+++ b/src/packages/CSS/Controls/SearchEngine/GPFsearchEngine.css
@@ -141,16 +141,6 @@ input[id^=GPadvancedSearchSubmit] {
   align-items: center;
 }
 
-
-/* Advanced search picto */
-
-.GPbuttonsContainer {
-  padding-left: 5px;
-  padding-right: 5px;
-}
-
-
-
 /* Autocomplete list / geocode results */
 
 .GPlabelTitle {

--- a/src/packages/CSS/Controls/SearchEngine/GPFsearchEngineStyle.css
+++ b/src/packages/CSS/Controls/SearchEngine/GPFsearchEngineStyle.css
@@ -29,6 +29,11 @@
   border: 2px solid rgba(255, 255, 255, 0.4);
 }
 
+.GPbuttonsContainer {
+  padding-right: 5px;
+  padding-left: 5px;
+}
+
 .GPsearchRadioContainer:hover {
   background-color: rgba(0,60,136,0.7);
 }

--- a/src/packages/Controls/SearchEngine/SearchEngineDOM.js
+++ b/src/packages/Controls/SearchEngine/SearchEngineDOM.js
@@ -413,7 +413,7 @@ var SearchEngineDOM = {
 
         var span = document.createElement("span");
         span.id = this._addUID("GPshowAdvancedSearch");
-        span.className = "GPshowOpen  GPshowAdvancedSearch fr-m-1w";
+        span.className = "GPshowOpen  GPshowAdvancedSearch";
         span.innerText = "Recherche avancée";
         span.setAttribute("tabindex", "0");
         span.setAttribute("aria-pressed", false);


### PR DESCRIPTION
Avant :

![image](https://github.com/user-attachments/assets/c36844f4-8308-46a9-bdab-391170bad42e)

Les éléments du haut et du bas sont un peu décalés.

Après : 

![image](https://github.com/user-attachments/assets/3d948b07-73d9-4825-ae7d-54d66f9a2b1e)

Les éléments du haut et du bas sont un mieux alignés et centrés, avec une réduction des marges et de la largeur globale du wiget.