### PR TITLE
fix(route)(isochrone): container initialized multiple times if add + remove + add control

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.0-139",
+  "version": "1.0.0-beta.0-142",
   "date": "01/08/2024",
   "module": "src/index.js",
   "directories": {},

--- a/src/packages/Controls/Isocurve/Isocurve.js
+++ b/src/packages/Controls/Isocurve/Isocurve.js
@@ -813,6 +813,9 @@ var Isocurve = class Isocurve extends Control {
     _initContainer (map) {
         // get main container
         var container = this._container;
+        if (container.childElementCount > 0) {
+            return container;
+        }
 
         var picto = this._pictoIsoButton = this._createShowIsoPictoElement();
         container.appendChild(picto);

--- a/src/packages/Controls/Route/Route.js
+++ b/src/packages/Controls/Route/Route.js
@@ -679,6 +679,9 @@ var Route = class Route extends Control {
     _initContainer (map) {
         // get main container
         var container = this._container;
+        if (container.childElementCount > 0) {
+            return container;
+        }
 
         var picto = this._showRouteButton = this._createShowRoutePictoElement();
         container.appendChild(picto);


### PR DESCRIPTION
Dû au fait que this._initContainer(map) est appelé à chaque setMap().

Correctif : ne rien faire dans ce _initContainer si le container est déjà initialisé (plus que 0 nœuds enfants)


Pour tester, dans samples-src/pages/tests/Isocurve/pages-ol-isocurve-modules-dsfr-default.html et samples-src/pages/tests/Route/pages-ol-route-modules-default.html, ajouter après le map.addControl(route ou iso) :
> map.removeControl(route ou iso);
> map.addControl(route ou iso);
> map.removeControl(route ou iso);
> map.addControl(route ou iso);
> map.removeControl(route ou iso);
> map.addControl(route ou iso);

Avant / après la PR