### PR TITLE
fix(panel:iso/route): ajout d'une hauteur max avec scrollbar en DSFR

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.0-142",
-  "date": "01/08/2024",
+  "version": "1.0.0-beta.0-143",
+  "date": "13/08/2024",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/samples-src/pages/tests/Isocurve/pages-ol-isocurve-modules-default.html
+++ b/samples-src/pages/tests/Isocurve/pages-ol-isocurve-modules-default.html
@@ -16,7 +16,7 @@
         <style>
             div#map {
                 width: 100%;
-                height: 500px;
+                height: 700px;
             }
         </style>
 {{/content}}

--- a/samples-src/pages/tests/Isocurve/pages-ol-isocurve-modules-dsfr-default.html
+++ b/samples-src/pages/tests/Isocurve/pages-ol-isocurve-modules-dsfr-default.html
@@ -50,7 +50,8 @@
                 });
 
                 iso = new ol.control.Isocurve({
-                  draggable: true
+                  draggable: true,
+                  position: "bottom-left"
                 });
                 map.addControl(iso);
              };

--- a/samples-src/pages/tests/Route/pages-ol-route-modules-default.html
+++ b/samples-src/pages/tests/Route/pages-ol-route-modules-default.html
@@ -16,7 +16,7 @@
         <style>
             div#map {
                 width: 100%;
-                height: 500px;
+                height: 700px;
             }
         </style>
 {{/content}}

--- a/samples-src/pages/tests/Route/pages-ol-route-modules-dsfr-default.html
+++ b/samples-src/pages/tests/Route/pages-ol-route-modules-dsfr-default.html
@@ -50,7 +50,9 @@
                   })
                 });
 
-                var route = new ol.control.Route({});
+                var route = new ol.control.Route({
+                  position: "bottom-left"
+                });
                 map.addControl(route);
 
                 var layerSwitcher = new ol.control.LayerSwitcher({});

--- a/src/packages/CSS/Controls/Isochron/DSFRisochronStyle.css
+++ b/src/packages/CSS/Controls/Isochron/DSFRisochronStyle.css
@@ -40,6 +40,12 @@ div[id^="GPisochronModeChoice"] {
   gap: 1rem;
 }
 
+/* FIXME A remplacer avec gestion des collisions */
+[id^=GPisochronForm-] {
+  max-height: 400px;
+  overflow: scroll;
+}
+
 [id^=GPisochronForm-] > .GPpanelFooter {
   position: unset;
 }

--- a/src/packages/CSS/Controls/Isochron/GPFisochron.css
+++ b/src/packages/CSS/Controls/Isochron/GPFisochron.css
@@ -35,7 +35,6 @@ form[id^=GPisochronForm] {
   padding: 15px;
 }
 
-
 input[id^="GPisochronOriginPointer"] + .GPisochronOriginPointerImg {
   background-position: -1px -1px;
 }

--- a/src/packages/CSS/Controls/Route/DSFRrouteStyle.css
+++ b/src/packages/CSS/Controls/Route/DSFRrouteStyle.css
@@ -13,6 +13,12 @@
   color: var(--grey-200-850);
 }
 
+/* FIXME A remplacer avec gestion des collisions */
+[id^=GProuteForm-] {
+  max-height: 400px;
+  overflow: scroll;
+}
+
 [id^="GProuteForm-"] .GPlocationOriginLabel {
   display: unset;
 }

--- a/src/packages/CSS/Controls/Route/GPFroute.css
+++ b/src/packages/CSS/Controls/Route/GPFroute.css
@@ -38,7 +38,6 @@ form[id^=GProuteForm] {
   padding: 15px;
 }
 
-
 form[id^=GProuteForm] > .GPlocationStageFlexInput {
   margin-top: 5px;
 }


### PR DESCRIPTION
Fixe une hauteur max pour les formulaires itinéraire et isochrone à 400px, avec ajout d'une scrollbar, afin que le panel ne dépasse pas de la fenêtre carto (si celle-ci n'est pas trop petite...)

Avant PR : 

Le formulaire dépasse et impossible de l'utiliser car pas de possibilité de défilement
![image](https://github.com/user-attachments/assets/104c2d4c-2e91-4e16-83f1-ea002ab47c14)


Après PR : 
Possibilité de défiler le formulaire avec une scrollbar

![image](https://github.com/user-attachments/assets/00fae5ab-33fa-4d81-b6c5-154392961887)
