### PR TITLE
fix(layerswitcher)(dsfr): positionnement et rendu de la fenetre infos

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.0-154",
-  "date": "23/08/2024",
+  "version": "1.0.0-beta.0-158",
+  "date": "30/08/2024",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/src/packages/CSS/Controls/LayerSwitcher/DSFRlayerSwitcherStyle.css
+++ b/src/packages/CSS/Controls/LayerSwitcher/DSFRlayerSwitcherStyle.css
@@ -217,3 +217,8 @@ div[id^=GPadvancedTools_ID_] {
 .GPlayerOpacity.fr-range--sm[data-fr-js-range]::before {
   top: 25%;
 }
+
+div[id^=GPlayerInfoContent] {
+    width: 350px;
+}
+

--- a/src/packages/CSS/Controls/LayerSwitcher/GPFlayerSwitcher.css
+++ b/src/packages/CSS/Controls/LayerSwitcher/GPFlayerSwitcher.css
@@ -119,7 +119,6 @@ button[id^=GPshowAdvancedTools_ID_][aria-pressed="true"] + .GPlayerAdvancedTools
 
 div[id^=GPlayerInfoContent] {
   position: relative;
-  width: 280px;
   max-height: 200px;
   overflow-y: auto;
   padding-left: 10px;

--- a/src/packages/CSS/Controls/LayerSwitcher/GPFlayerSwitcherStyle.css
+++ b/src/packages/CSS/Controls/LayerSwitcher/GPFlayerSwitcherStyle.css
@@ -412,3 +412,7 @@ div[id^=GPlayerInfoMetadata] {
 .outOfRange .GPlayerName {
   color: #AAA;
 }
+
+div[id^=GPlayerInfoContent] {
+  width: 280px;
+}

--- a/src/packages/Controls/Control.js
+++ b/src/packages/Controls/Control.js
@@ -78,7 +78,7 @@ class PositionFactory {
      */
     #createContainer (name) {
         this.container = this.caller.getMap().getOverlayContainerStopEvent();
-        
+
         if (this.#existContainer(name)) {
             return;
         }
@@ -88,7 +88,7 @@ class PositionFactory {
         var div = document.createElement("div");
         div.id = "position-container-" + name;
         div.className = "position position-container-" + name ;
-        
+
         this.container.appendChild(div);
     }
 
@@ -125,7 +125,7 @@ class PositionFactory {
                     }
                     height -= element.children[index].offsetHeight;
                 }
-            } 
+            }
             return height;
         };
         const clear = (element) => {
@@ -135,7 +135,7 @@ class PositionFactory {
             element.style.right = "unset";
         };
 
-        // on supprime le style de positionnement (top, left...) 
+        // on supprime le style de positionnement (top, left...)
         // car on souhaite une nouvelle position
         clear(this.caller.element);
         this.caller.element.style.position = "unset"; // div.GPwidget
@@ -147,6 +147,7 @@ class PositionFactory {
         if (panels.length === 0) {
             return;
         }
+        var offset = 0;
         panels.forEach((panel) => {
             // INFO
             // on va eviter de modifier les panneaux de resultats
@@ -156,29 +157,30 @@ class PositionFactory {
                 return;
             }
             clear(panel);
-            // on modifie le positionnement du menu (dialog ou div : panel) 
+            // on modifie le positionnement du menu (dialog ou div : panel)
             // en fonction du bouton
             // ex. bouton : bottom-left, menu : bottom:0px; left:50px
             switch (pos.toLowerCase()) {
                 case "top-left":
                     panel.style.top = position(pos) ? sizeH(pos) + "px" : "0px";
-                    panel.style.left = sizeW(pos) + "px";
+                    panel.style.left = sizeW(pos) + offset + "px";
                     break;
                 case "bottom-left":
                     panel.style.bottom = position(pos) ? sizeH(pos) + "px" : "0px";
-                    panel.style.left = sizeW(pos) + "px";
+                    panel.style.left = sizeW(pos) + offset + "px";
                     break;
                 case "top-right":
                     panel.style.top = position(pos) ? sizeH(pos) + "px" : "0px";
-                    panel.style.right = sizeW(pos) + "px";
+                    panel.style.right = sizeW(pos) + offset + "px";
                     break;
                 case "bottom-right":
                     panel.style.bottom = position(pos) ? sizeH(pos) + "px" : "0px";
-                    panel.style.right = sizeW(pos) + "px";
+                    panel.style.right = sizeW(pos) + offset + "px";
                     break;
                 default:
                     break;
             }
+            offset += panel.offsetWidth;
         });
     }
 
@@ -204,13 +206,13 @@ class PositionFactory {
     /**
      * ...
      * @param {*} pos - ...
-     * @public 
+     * @public
      */
     update (pos) {
         if (!ANCHORS.includes(pos.toLowerCase())) {
             return;
         }
-        // positionnement de l'element 
+        // positionnement de l'element
         // mais, il faut prendre en compte la position !
         this.#setAnchor(pos, true);
     }

--- a/src/packages/Controls/LayerSwitcher/LayerSwitcherDOM.js
+++ b/src/packages/Controls/LayerSwitcher/LayerSwitcherDOM.js
@@ -808,6 +808,7 @@ var LayerSwitcherDOM = {
                         maxScale = legends[scale].maxScaleDenominator || maxScale;
 
                         var reflgd = document.createElement("a");
+                        reflgd.className = "fr-link";
                         reflgd.href = urllgd;
                         reflgd.innerHTML = "Du 1/" + scale + " au 1/" + maxScale;
                         lgdlink.appendChild(reflgd);


### PR DESCRIPTION
https://github.com/IGNF/cartes.gouv.fr-entree-carto/issues/87

Checker le bon fonctionnement des widgets avec plusieurs modales (search, layerimport, layerswitcher).

A priori pas de nouveau bug : layerimport ne marche pas sur la main pour l'ouverture de la fenêtre mapbox ou wmts cf https://github.com/IGNF/geopf-extensions-openlayers/issues/34