### PR TITLE
fix(layerSwitcher): Ajout de l’événement de modification de position d'une couche

### DIFF
--- a/samples-src/pages/tests/LayerSwitcher/pages-ol-layerswitcher-modules-addlayers.html
+++ b/samples-src/pages/tests/LayerSwitcher/pages-ol-layerswitcher-modules-addlayers.html
@@ -106,7 +106,9 @@
                     layerSwitcher.on("layerswitcher:change:visibility", function (e) {
                         console.warn("layer", e, e.layer, e.visibility);
                     });
-
+                    layerSwitcher.on("layerswitcher:change:position", function (e) {
+                        console.warn("layer", e, e.layer, e.position);
+                    });
                     // // Appel du LayerSwitcher
                     // var layerSwitcher1 = new ol.control.LayerSwitcher({
                     //     options : {

--- a/src/packages/Controls/LayerSwitcher/LayerSwitcher.js
+++ b/src/packages/Controls/LayerSwitcher/LayerSwitcher.js
@@ -1165,6 +1165,7 @@ var LayerSwitcher = class LayerSwitcher extends Control {
          * @property {Object} type - event
          * @property {Object} position - position
          * @property {Object} layer - layer
+         * @property {Object} layers - layers sorted
          * @property {Object} target - instance LayerSwitcher
          * @example
          * LayerSwitcher.on("layerswitcher:change:position", function (e) {
@@ -1174,7 +1175,8 @@ var LayerSwitcher = class LayerSwitcher extends Control {
         this.dispatchEvent({
             type : "layerswitcher:change:position",
             position : e.newIndex,
-            layer : this._layersOrder[e.newIndex]
+            layer : this._layersOrder[e.newIndex],
+            layers : this._layersOrder
         });
     }
 

--- a/src/packages/Controls/LayerSwitcher/LayerSwitcher.js
+++ b/src/packages/Controls/LayerSwitcher/LayerSwitcher.js
@@ -46,8 +46,7 @@ var logger = Logger.getLogger("layerswitcher");
  * @fires layerswitcher:extent
  * @fires layerswitcher:change:opacity
  * @fires layerswitcher:change:visibility
- * @fires layerswitcher:start:dragndrop (todo)
- * @fires layerswitcher:end:dragndrop (todo)
+ * @fires layerswitcher:change:position
  * @example
  * map.addControl(new ol.control.LayerSwitcher(
  *  [
@@ -78,6 +77,9 @@ var logger = Logger.getLogger("layerswitcher");
  * });
  * LayerSwitcher.on("layerswitcher:change:visibility", function (e) {
  *    console.warn("layer", e.layer, e.visibility);
+ * });
+ * LayerSwitcher.on("layerswitcher:change:position", function (e) {
+ *    console.warn("layer", e.layer, e.position);
  * });
  */
 var LayerSwitcher = class LayerSwitcher extends Control {
@@ -1115,9 +1117,11 @@ var LayerSwitcher = class LayerSwitcher extends Control {
     /**
      * change layers order (on map) on drag and drop (on control container)
      *
+     * @param {Event} e - CustomEvent
      * @private
      */
-    _onEndDragAndDropLayerClick () {
+    _onEndDragAndDropLayerClick (e) {
+        logger.trace(e);
         // INFO : e.oldIndex et e.newIndex marchent en mode AMD mais pas Bundle.
         var map = this.getMap();
 
@@ -1153,6 +1157,25 @@ var LayerSwitcher = class LayerSwitcher extends Control {
 
         // mise à jour de la visu
         map.updateSize();
+
+        /**
+         * event triggered when an position layer is changed
+         *
+         * @event layerswitcher:change:visibility
+         * @property {Object} type - event
+         * @property {Object} position - position
+         * @property {Object} layer - layer
+         * @property {Object} target - instance LayerSwitcher
+         * @example
+         * LayerSwitcher.on("layerswitcher:change:position", function (e) {
+         *   console.log(e.position);
+         * })
+         */
+        this.dispatchEvent({
+            type : "layerswitcher:change:position",
+            position : e.newIndex,
+            layer : this._layersOrder[e.newIndex]
+        });
     }
 
     /**


### PR DESCRIPTION
#171 

Je m'abonne 
```js
layerSwitcher.on("layerswitcher:change:position", function (e) {
  console.warn("layer", e, e.layer, e.position);
});
```
La nouvelle position de la couche est 0 (soit au dessus de la pile de couches)
![image](https://github.com/user-attachments/assets/ff9c6630-f165-4dc0-9547-74e8d7d1cd18)
