### PR TITLE
Fix/recette mouseposition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.0-180",
+  "version": "1.0.0-beta.0-182",
   "date": "03/10/2024",
   "module": "src/index.js",
   "directories": {},

--- a/src/packages/CSS/Controls/MousePosition/DSFRmousePositionStyle.css
+++ b/src/packages/CSS/Controls/MousePosition/DSFRmousePositionStyle.css
@@ -14,3 +14,7 @@ div[id^=GPmousePositionCoordinate-] > div {
   display: flex;
   justify-content: space-between;
 }
+
+div[id^=GPmousePositionCoordinate-] input[readonly] {
+  font-size: 1rem
+}

--- a/src/packages/Controls/MousePosition/MousePosition.js
+++ b/src/packages/Controls/MousePosition/MousePosition.js
@@ -714,28 +714,28 @@ var MousePosition = class MousePosition extends Control {
         var projectionUnitsByDefault = {
             Geographical : [{
                 code : "DEC",
-                label : "degrés décimaux",
+                label : "Degrés décimaux",
                 format : MathUtils.coordinateToDecimal
             }, {
                 code : "DMS",
-                label : "degrés sexagésimaux",
+                label : "Degrés sexagésimaux",
                 format : MathUtils.coordinateToDMS
             }, {
                 code : "RAD",
-                label : "radians",
+                label : "Radians",
                 format : MathUtils.coordinateToRad
             }, {
                 code : "GON",
-                label : "grades",
+                label : "Grades",
                 format : MathUtils.coordinateToGon
             }],
             Metric : [{
                 code : "M",
-                label : "mètres",
+                label : "Mètres",
                 format : MathUtils.coordinateToMeter
             }, {
                 code : "KM",
-                label : "kilomètres",
+                label : "Kilomètres",
                 format : MathUtils.coordinateToKMeter
             }]
         };

--- a/src/packages/Controls/MousePosition/MousePositionDOM.js
+++ b/src/packages/Controls/MousePosition/MousePositionDOM.js
@@ -831,8 +831,8 @@ var MousePositionDOM = {
                 elLat.title = "Latitude";
                 elLon.title = "Longitude";
 
-                elLat.type = "number";
-                elLon.type = "number";
+                elLat.type = "text";
+                elLon.type = "text";
 
                 // les unites
                 var unit = (coordinate.unit === undefined) ? "" : coordinate.unit;


### PR DESCRIPTION
Corrections retours de recette du ticket 323 de l'entrée carto : 
    - la taille des caractères des coordonnées uniformisée avec le reste
    - input des coordonnées transformés en type "text" pour enlever les ascenseurs
    - le sélecteur d'unité ne présente avec liste ayant des majuscules
