### PR TITLE
fix(panels): ajoute libellé "fermer" aux panels à entete

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.0-170",
+  "version": "1.0.0-beta.0-187",
   "date": "08/10/2024",
   "module": "src/index.js",
   "directories": {},

--- a/src/packages/Controls/LayerSwitcher/LayerSwitcherDOM.js
+++ b/src/packages/Controls/LayerSwitcher/LayerSwitcherDOM.js
@@ -210,6 +210,12 @@ var LayerSwitcherDOM = {
         btnClose.className = "GPpanelClose GPlayersPanelClose gpf-btn gpf-btn-icon-close fr-btn--close fr-btn fr-btn--tertiary-no-outline fr-m-1w";
         btnClose.title = "Fermer le panneau";
 
+        var span = document.createElement("span");
+        span.className = "GPelementHidden gpf-visible fr-mx-1w"; // afficher en dsfr
+        span.innerText = "Fermer";
+
+        btnClose.appendChild(span);
+
         // Link panel close / visibility checkbox
         if (btnClose.addEventListener) {
             btnClose.addEventListener("click", function () {

--- a/src/packages/Controls/Legends/LegendsDOM.js
+++ b/src/packages/Controls/Legends/LegendsDOM.js
@@ -111,8 +111,14 @@ var LegendsDOM = {
         var self = this;
 
         var btnClose = document.createElement("button");
-        btnClose.className = "gpf-btn gpf-btn-icon-close fr-btn--close fr-btn fr-btn--tertiary-no-outline fr-m-1w";
+        btnClose.className = "gpf-btn gpf-btn-icon-close fr-btn--close fr-btn fr-btn--tertiary-no-outline";
         btnClose.title = "Fermer le panneau";
+
+        var span = document.createElement("span");
+        span.className = "GPelementHidden gpf-visible"; // afficher en dsfr
+        span.innerText = "Fermer";
+
+        btnClose.appendChild(span);
 
         // Link panel close / visibility checkbox
         if (btnClose.addEventListener) {


### PR DESCRIPTION
Ajoute le libellé fermer aux panels du layerSwitcher et des Légendes

cf issue https://github.com/IGNF/cartes.gouv.fr-entree-carto/issues/334