### PR TITLE
fix(ls): mauvaise orthographe pour le mot zoomer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.0-188",
-  "date": "08/10/2024",
+  "version": "1.0.0-beta.0-189",
+  "date": "11/10/2024",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/src/packages/Controls/LayerSwitcher/LayerSwitcherDOM.js
+++ b/src/packages/Controls/LayerSwitcher/LayerSwitcherDOM.js
@@ -710,7 +710,7 @@ var LayerSwitcherDOM = {
         button.title = "Zoomer dans l'étendue";
         button.layerId = obj.id;
         if (contextual) {
-            button.innerText = "Zommer";
+            button.innerText = "Zoomer";
         }
         button.setAttribute("tabindex", "0");
         button.setAttribute("aria-pressed", true);


### PR DESCRIPTION
Tout est dans le titre : le mot zoomer est mal orthographié.