### PR TITLE
fix(terr:css): retrait important pour surcharge hauteur cote entree carto

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.0-192",
+  "version": "1.0.0-beta.0-193",
   "date": "11/10/2024",
   "module": "src/index.js",
   "directories": {},

--- a/src/packages/CSS/Controls/Territories/DSFRterritoriesStyle.css
+++ b/src/packages/CSS/Controls/Territories/DSFRterritoriesStyle.css
@@ -21,7 +21,7 @@
 
 .gpf-panel__body_territories {
     overflow: auto;
-    max-height: 300px !important;
+    max-height: 300px;
 }
 
 .gpf-panel__title_territories {


### PR DESCRIPTION
Retrait d'une commande important dans la css territory qui empeche surcharge côté entrée carto