### PR TITLE
feat(dsfr): dialog des widgets toujous en haut (a gauche ou a droite en fonction du positionnement du bouton)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.0-196",
-  "date": "14/10/2024",
+  "version": "1.0.0-beta.0-201",
+  "date": "15/10/2024",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/src/packages/CSS/DSFRgeneralWidget.css
+++ b/src/packages/CSS/DSFRgeneralWidget.css
@@ -310,13 +310,14 @@
   position: absolute;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   /* crée un décalage sur le searchEngine */
   /* align-items: center; */
   /* + 5px pour l'indicateur "bouton actif" */
   width: calc(var(--size-per-row) + 4px);
   min-height: var(--size-per-row);
   /* padding: 5px; */
+  height: calc(100% - 8px);
 }
 
 .position-container-top-left,
@@ -337,6 +338,7 @@
 .position-container-bottom-left,
 .position-container-bottom-right {
   bottom: 4px;
+  justify-content: flex-end;
 }
 
 .position-container-bottom-right {
@@ -494,29 +496,12 @@
       width: 100vw !important;
   }
 
-  .position-container-bottom-right:has(.gpf-mobile-fullscreen > button[aria-pressed="true"]),
-  .position-container-bottom-left:has(.gpf-mobile-fullscreen > button[aria-pressed="true"]) {
-      top: 4px;
-      bottom: unset;
-  }
-
-  .position-container-top-left:has(.gpf-mobile-fullscreen > button[aria-pressed="true"]) .gpf-mobile-fullscreen,
-  .position-container-top-right:has(.gpf-mobile-fullscreen > button[aria-pressed="true"]) .gpf-mobile-fullscreen,
-  .position-container-bottom-right:has(.gpf-mobile-fullscreen > button[aria-pressed="true"]) .gpf-mobile-fullscreen,
-  .position-container-bottom-left:has(.gpf-mobile-fullscreen > button[aria-pressed="true"]) .gpf-mobile-fullscreen {
-      position: absolute !important;
-      top: 0px !important;
-  }
-
   .position-container-top-right .gpf-mobile-fullscreen > button[aria-pressed="true"] + dialog,
-  .position-container-bottom-right .gpf-mobile-fullscreen > button[aria-pressed="true"] + dialog {
-      inset: unset !important;
-      transform: translate(calc(-100% + 56px), -46px);
-  }
-
+  .position-container-bottom-right .gpf-mobile-fullscreen > button[aria-pressed="true"] + dialog,
   .position-container-top-left .gpf-mobile-fullscreen > button[aria-pressed="true"] + dialog,
   .position-container-bottom-left .gpf-mobile-fullscreen > button[aria-pressed="true"] + dialog {
-      inset: unset !important;
-      transform: translate(-10px, -46px);
+      top: -4px !important;
+      left: -8px !important;
+      right: unset !important;
   }
 }

--- a/src/packages/Controls/Control.js
+++ b/src/packages/Controls/Control.js
@@ -1,4 +1,5 @@
 import Control from "ol/control/Control";
+import checkDsfr from "./Utils/CheckDsfr";
 
 var ControlExtended = class ControlExtended extends Control {
 
@@ -162,19 +163,35 @@ class PositionFactory {
             // ex. bouton : bottom-left, menu : bottom:0px; left:50px
             switch (pos.toLowerCase()) {
                 case "top-left":
-                    panel.style.top = position(pos) ? sizeH(pos) + "px" : "0px";
+                    if (checkDsfr()) {
+                        panel.style.top = "0px";
+                    } else {
+                        panel.style.top = position(pos) ? sizeH(pos) + "px" : "0px";
+                    }
                     panel.style.left = sizeW(pos) + offset + "px";
                     break;
                 case "bottom-left":
-                    panel.style.bottom = position(pos) ? sizeH(pos) + "px" : "0px";
+                    if (checkDsfr()) {
+                        panel.style.top = "0px";
+                    } else {
+                        panel.style.bottom = position(pos) ? sizeH(pos) + "px" : "0px";
+                    }
                     panel.style.left = sizeW(pos) + offset + "px";
                     break;
                 case "top-right":
-                    panel.style.top = position(pos) ? sizeH(pos) + "px" : "0px";
+                    if (checkDsfr()) {
+                        panel.style.top = "0px";
+                    } else {
+                        panel.style.top = position(pos) ? sizeH(pos) + "px" : "0px";
+                    }
                     panel.style.right = sizeW(pos) + offset + "px";
                     break;
                 case "bottom-right":
-                    panel.style.bottom = position(pos) ? sizeH(pos) + "px" : "0px";
+                    if (checkDsfr()) {
+                        panel.style.top = "0px";
+                    } else {
+                        panel.style.bottom = position(pos) ? sizeH(pos) + "px" : "0px";
+                    }
                     panel.style.right = sizeW(pos) + offset + "px";
                     break;
                 default:


### PR DESCRIPTION
closes https://github.com/IGNF/geopf-extensions-openlayers/issues/200

Il reste quelques petites surcharges à faire côté entrée carto car la marge en haut pour les boutons n'est pas la même 