### PR TITLE
refacto(getFeatureInfo): récuperation du layer title sans utilisation de la configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.0-210",
+  "version": "1.0.0-beta.0-211",
   "date": "18/10/2024",
   "module": "src/index.js",
   "directories": {},

--- a/src/packages/Controls/GetFeatureInfo/GetFeatureInfo.js
+++ b/src/packages/Controls/GetFeatureInfo/GetFeatureInfo.js
@@ -17,7 +17,6 @@ import AsyncData from "../Utils/AsyncData";
 
 // DOM
 import GetFeatureInfoDOM from "./GetFeatureInfoDOM";
-import Config from "../../Utils/Config";
 
 var logger = Logger.getLogger("getFeatureInfo");
 
@@ -417,6 +416,24 @@ var GetFeatureInfo = class GetFeatureInfo extends Control {
     }
 
     /**
+     * Get layer title
+     *
+     * @param {Object} gfiLayer - the layer object used by the gfi widget
+     * @returns {String} layerTitle - layer title
+     */
+    getLayerTitle (gfiLayer) {
+        if (gfiLayer.layer.getProperties !== undefined && gfiLayer.layer.getSource !== undefined) {
+            var layerProperties = gfiLayer.layer.getProperties();
+            var src = layerProperties.source;
+            var layerTitle = "";
+            if (src) {
+                layerTitle = src._title || src.name || src.url_;
+            }
+        }
+        return layerTitle;
+    }
+
+    /**
      * Main render function
      * @private
      */ 
@@ -424,18 +441,11 @@ var GetFeatureInfo = class GetFeatureInfo extends Control {
         var gfiLayers = this.layers.map((l) => {
             return this.getGetFeatureInfoLayer(l);
         });
+
         // Structuration de l'objet pour afficher les GFI par layer
         var gfiContent = gfiLayers.map((gfiLayer) => {
-            if (!Config.isConfigLoaded()) {
-                throw "ERROR : contract key configuration has to be loaded to load Geoportal layers.";
-            }
+            var layername = this.getLayerTitle(gfiLayer);
 
-            var layername = gfiLayer.layer.getSource().name ? gfiLayer.layer.getSource().name : gfiLayer.layer.getSource().url_;
-
-            var layerconf = Config.configuration.getLayerParams(layername, gfiLayer.format);
-            if (layerconf && Object.keys(layerconf).length !== 0) {
-                layername = layerconf.title;
-            }
             var content = null;
             var accordeon = this._createGetFeatureInfoLayerAccordion(layername);
             var pending = true;


### PR DESCRIPTION
Retrait de l'import Config.

Utilisation d'une fonction getLayerTitle qui récupère par ordre de priorité : 
- le titre de la couche
- le name/id de la couche
- l'url de la couche
- un string vide