### PR TITLE
feat(draggable): refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.0-219",
-  "date": "21/10/2024",
+  "version": "1.0.0-beta.0-225",
+  "date": "23/10/2024",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/src/packages/Controls/Catalog/Catalog.js
+++ b/src/packages/Controls/Catalog/Catalog.js
@@ -31,7 +31,7 @@ var logger = Logger.getLogger("widget");
  * @type {ol.control.Catalog}
  * @extends {ol.control.Control}
  * @param {Object} options - options for function call.
- * 
+ *
  * @fires catalog:loaded
  * @fires catalog:layer:add
  * @fires catalog:layer:remove
@@ -46,7 +46,7 @@ var logger = Logger.getLogger("widget");
  *           layerLabel : "title",
  *           layerFilter : [],
  *           search : {
- *               display : true, 
+ *               display : true,
  *               criteria : [
  *                   "name",
  *                   "title",
@@ -85,7 +85,7 @@ var logger = Logger.getLogger("widget");
  * widget.on("catalog:layer:add", (e) => { console.log(e); });
  * widget.on("catalog:layer:remove", (e) => { console.log(e); });
  * map.addControl(widget);
- * 
+ *
  * @todo filtrage des couches
  * @todo type:service
  * @todo validation du schema
@@ -99,9 +99,9 @@ var Catalog = class Catalog extends Control {
      * @param {Object} [options] - options
      * @example
      * import Catalog from "gpf-ext-ol/controls/Catalog"
-     * ou 
+     * ou
      * import { Catalog } from "gpf-ext-ol"
-     * 
+     *
      * var widget = new Catalog({
      *           collapsed : true,
      *           draggable : false,
@@ -110,7 +110,7 @@ var Catalog = class Catalog extends Control {
      *           layerLabel : "title",
      *           layerFilter : [],
      *           search : {
-     *               display : true, 
+     *               display : true,
      *               criteria : [
      *                   "name",
      *                   "title",
@@ -152,7 +152,7 @@ var Catalog = class Catalog extends Control {
      */
     constructor (options) {
         options = options || {};
-        
+
         // call ol.control.Control constructor
         super({
             element : options.element,
@@ -173,7 +173,7 @@ var Catalog = class Catalog extends Control {
         // ajout du container
         (this.element) ? this.element.appendChild(this.container) : this.element = this.container;
 
-        // INFO 
+        // INFO
         // le DOM est mis en place sans la liste des couches du catalogue
         // car l'opération peut être async si un download est demandé.
         // une patience permet d'attendre que la liste soit récupérée.
@@ -224,7 +224,7 @@ var Catalog = class Catalog extends Control {
                 Draggable.dragElement(
                     this.panelCatalogContainer,
                     this.panelCatalogHeaderContainer,
-                    this.options.position ? null : map.getTargetElement()
+                    map.getTargetElement()
                 );
             }
             // mode "collapsed"
@@ -269,7 +269,7 @@ var Catalog = class Catalog extends Control {
     // ################################################################### //
     // #################### privates methods ############################# //
     // ################################################################### //
-    
+
     /**
      * Initialize Catalog control (called by Catalog constructor)
      *
@@ -289,7 +289,7 @@ var Catalog = class Catalog extends Control {
             layerLabel : "title",
             layerFilter : [], // TODO filtre
             search : {
-                display : true, 
+                display : true,
                 criteria : [
                     "name",
                     "title",
@@ -303,7 +303,7 @@ var Catalog = class Catalog extends Control {
                     id : "data",
                     default : true,
                     filter : null
-                    // INFO 
+                    // INFO
                     // > sous categories avec ou sans section
                     // items : [
                     //     {
@@ -330,27 +330,27 @@ var Catalog = class Catalog extends Control {
         // merge with user options
         Utils.assign(this.options, options);
 
-        /** 
-         * specify if control is collapsed (true) or not (false) 
-         * @type {Boolean} 
+        /**
+         * specify if control is collapsed (true) or not (false)
+         * @type {Boolean}
          */
         this.collapsed = this.options.collapsed;
 
-        /** 
-         * specify if control is draggable (true) or not (false) 
-         * @type {Boolean} 
+        /**
+         * specify if control is draggable (true) or not (false)
+         * @type {Boolean}
          */
         this.draggable = this.options.draggable;
 
-        /** 
-         * specify if control add some stuff auto 
-         * @type {Boolean} 
+        /**
+         * specify if control add some stuff auto
+         * @type {Boolean}
          */
         this.auto = this.options.auto;
 
         /**
-         * specify some events listeners 
-         * @type {Array} 
+         * specify some events listeners
+         * @type {Array}
          */
         this.eventsListeners = [];
 
@@ -362,7 +362,7 @@ var Catalog = class Catalog extends Control {
         this.contentCatalogContainer = null;
         this.waitingContainer = null;
 
-        /** 
+        /**
          * specify all list of layers (configuration service)
          * @type {Object}
          * @see [schema](https://raw.githubusercontent.com/IGNF/geoportal-configuration/new-url/doc/schema.json)
@@ -377,7 +377,7 @@ var Catalog = class Catalog extends Control {
         this.categories = this.options.categories.map((cat) => {
             // INFO
             // on reecrit correctement les categories
-            // ex. properties mal renseignées tels que id ou default 
+            // ex. properties mal renseignées tels que id ou default
             var items = cat.items;
             if (cat.items) {
                 items = cat.items.map((i) => {
@@ -399,13 +399,13 @@ var Catalog = class Catalog extends Control {
             };
         });
 
-        /** 
-         * specify the current category selected 
-         * @type {String} 
+        /**
+         * specify the current category selected
+         * @type {String}
          */
         this.categoryId = (() => {
             // INFO
-            // par défaut, la categorie affichée sera la 1ere 
+            // par défaut, la categorie affichée sera la 1ere
             // sauf si on a specifié une categorie avec l'attribut 'default:true'
             var index = this.categories.findIndex((category) => category.default);
             if (index === -1) {
@@ -415,9 +415,9 @@ var Catalog = class Catalog extends Control {
             return this.categories[index].id;
         })();
 
-        /** 
-         * list of layers added on map by key pair : name/service 
-         * @type {Object} 
+        /**
+         * list of layers added on map by key pair : name/service
+         * @type {Object}
          * @example
          * {
          *    "GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2:WMTS" : ol/layer/Tile,
@@ -469,7 +469,7 @@ var Catalog = class Catalog extends Control {
 
         widgetContentDiv.appendChild(widgetContentElementDiv);
         widgetPanelDiv.appendChild(widgetContentDiv);
-        
+
         container.appendChild(widgetPanel);
         logger.log(container);
 
@@ -478,7 +478,7 @@ var Catalog = class Catalog extends Control {
 
     /**
      * Configuration loading
-     * 
+     *
      * @returns {Promise} - promise
      * @private
      */
@@ -491,7 +491,7 @@ var Catalog = class Catalog extends Control {
 
             var widgetContentEntryTabs = self._createCatalogContentCategoriesTabs(this.categories);
             container.appendChild(widgetContentEntryTabs);
-            
+
             var categories = []; // remise à plat des catégories / sous-categories
             self.categories.forEach((category) => {
                 if (category.items) {
@@ -504,7 +504,7 @@ var Catalog = class Catalog extends Control {
                 }
             });
             // INFO
-            // les containers de contenu sont definis à partir 
+            // les containers de contenu sont definis à partir
             // de l'ordre des catégories / sous-categories
             // il y'a autant de catégories / sous-categories que de containers
             var contents = container.querySelectorAll(".tabcontent");
@@ -514,13 +514,13 @@ var Catalog = class Catalog extends Control {
                 content.appendChild(self._createCatalogContentCategoryTabContent(categories[i], layersCategorised));
             }
         };
-        
-        // traitement du contenu (liste de couches) d'une categorie 
+
+        // traitement du contenu (liste de couches) d'une categorie
         // en fonction d'un filtre
         const getLayersByCategory = (category, layers) => {
             // INFO
             // comment gerer les listes de layers filtrées pour chaque categorie ?
-            // on doit les stocker si l'on souhaite faire des requêtes 
+            // on doit les stocker si l'on souhaite faire des requêtes
             // avec l'outil de recherche par la suite
             var layersCategorised = layers;
             var filter = category.filter;
@@ -540,7 +540,7 @@ var Catalog = class Catalog extends Control {
                     }
                 }
             }
-            
+
             return layersCategorised;
         };
 
@@ -548,9 +548,9 @@ var Catalog = class Catalog extends Control {
         const getLayersByFilter = (filter, layers) => {
             // INFO
             // definir les filtres possibles :
-            // - sur un champ spécifique : ex field:"service" 
+            // - sur un champ spécifique : ex field:"service"
             // - sur des valeurs : ex. value:"[WMS,TMS,WMTS]" ou "*"
-            // - ... 
+            // - ...
             return layers;
         };
 
@@ -564,10 +564,10 @@ var Catalog = class Catalog extends Control {
             }
 
             // INFO
-            // on en profite pour ajouter des properties : 
+            // on en profite pour ajouter des properties :
             // - service : utile pour identifier la couche
             // de manière unique : name + service
-            // - categories : utile pour definir l'appartenance d'une couche 
+            // - categories : utile pour definir l'appartenance d'une couche
             // à une ou plusieurs categories
             for (const key in data.layers) {
                 if (Object.prototype.hasOwnProperty.call(data.layers, key)) {
@@ -630,16 +630,16 @@ var Catalog = class Catalog extends Control {
                 }
 
                 // TODO gestion du type service
-            
+
                 if (Config.isConfigLoaded()) {
                     Utils.mergeParams(data, Config.configuration);
                 }
 
                 // INFO
-                // on en profite pour ajouter des properties : 
+                // on en profite pour ajouter des properties :
                 // - service : utile pour identifier la couche
                 // de manière unique : name + service
-                // - categories : utile pour definir l'appartenance d'une couche 
+                // - categories : utile pour definir l'appartenance d'une couche
                 // à une ou plusieurs categories
                 for (const key in data.layers) {
                     if (Object.prototype.hasOwnProperty.call(data.layers, key)) {
@@ -674,7 +674,7 @@ var Catalog = class Catalog extends Control {
 
     /**
      * Add events listeners on map (called by setMap)
-     * 
+     *
      * @param {*} map - map
      * @private
      */
@@ -694,7 +694,7 @@ var Catalog = class Catalog extends Control {
                 });
             }
         };
-        // the event custom:action is associate with an openlayers event 
+        // the event custom:action is associate with an openlayers event
         map.getLayers().on("add", this.eventsListeners["map:add"]);
 
         this.eventsListeners["map:remove"] = function (e) {
@@ -711,7 +711,7 @@ var Catalog = class Catalog extends Control {
                 });
             }
         };
-        // the event custom:action is associate with an openlayers event 
+        // the event custom:action is associate with an openlayers event
         map.getLayers().on("remove", this.eventsListeners["map:remove"]);
     }
 
@@ -729,7 +729,7 @@ var Catalog = class Catalog extends Control {
 
     /**
      * Add layer on map
-     * 
+     *
      * @param {*} name - layer name
      * @param {*} service - layer service
      * @private
@@ -765,7 +765,7 @@ var Catalog = class Catalog extends Control {
 
     /**
      * Remove Layer on map
-     * 
+     *
      * @param {*} name - layer name
      * @param {*} service - layer service
      * @private
@@ -796,7 +796,7 @@ var Catalog = class Catalog extends Control {
     // ################################################################### //
     // ######################## methods search ########################### //
     // ################################################################### //
-    
+
     /**
      * Reset filtered layers
      * @private
@@ -804,7 +804,7 @@ var Catalog = class Catalog extends Control {
     resetFilteredLayersList () {
         // INFO
         // l'outil de recherche filtre les couches via un critère de recherche.
-        // l'affichage des couches filtrées est realisé en cachant 
+        // l'affichage des couches filtrées est realisé en cachant
         // les couches non conforme au critère.
         // le parametre pour masquer les couches : hidden
         for (const key in this.layersList) {
@@ -818,7 +818,7 @@ var Catalog = class Catalog extends Control {
 
     /**
      * Set filtered layers
-     * 
+     *
      * @param {*} value - value
      * @private
      */
@@ -842,7 +842,7 @@ var Catalog = class Catalog extends Control {
 
     /**
      * Update DOM layer visibility
-     * 
+     *
      * @param {*} id - ...
      * @param {*} service  - ...
      * @param {*} hidden  - ...
@@ -879,7 +879,7 @@ var Catalog = class Catalog extends Control {
     // ################################################################### //
     // ######################## event dom ################################ //
     // ################################################################### //
-    
+
     /**
      * ...
      * @param {*} e - ...
@@ -980,14 +980,14 @@ var Catalog = class Catalog extends Control {
     }
 
     /**
-     * 
+     *
      * @private
      */
     onSearchCatalogButtonClick () {
         // INFO
-        // la saisie du critère de recherche doit filtrer la liste des couches affichée 
+        // la saisie du critère de recherche doit filtrer la liste des couches affichée
         // dans l'onglet courant.
-        // on masque les entrées non conforme 
+        // on masque les entrées non conforme
         // - en ajoutant la classe 'gpf-hidden' dans le DOM
         // - en sauvegardant l'état avec la property 'hidden:true'
         var value = document.getElementById("search-input").value;
@@ -995,7 +995,7 @@ var Catalog = class Catalog extends Control {
     }
 
     /**
-     * 
+     *
      * @private
      */
     onSearchCatalogInputChange () {

--- a/src/packages/Controls/Drawing/Drawing.js
+++ b/src/packages/Controls/Drawing/Drawing.js
@@ -173,7 +173,7 @@ var Drawing = class Drawing extends Control {
      * @param {*} options - options
      * @example
      * import Drawing from "gpf-ext-ol/controls/Drawing"
-     * ou 
+     * ou
      * import { Drawing } from "gpf-ext-ol"
      */
     constructor (options) {
@@ -312,13 +312,13 @@ var Drawing = class Drawing extends Control {
         if (this.options.position) {
             this.setPosition(this.options.position);
         }
-        
+
         // mode "draggable"
         if (this.draggable) {
             Draggable.dragElement(
                 this._drawingPanel,
                 this._drawingPanelHeader,
-                this.options.position ? null : map.getTargetElement()
+                map.getTargetElement()
             );
         }
 

--- a/src/packages/Controls/GetFeatureInfo/GetFeatureInfo.js
+++ b/src/packages/Controls/GetFeatureInfo/GetFeatureInfo.js
@@ -30,7 +30,7 @@ var logger = Logger.getLogger("getFeatureInfo");
  * @type {ol.control.GetFeatureInfo}
  * @extends {ol.control.Control}
  * @param {Object} options - options for function call.
- * 
+ *
  * @fires custom:action
  * @example
  * var getFeatureInfo = new ol.control.GetFeatureInfo();
@@ -45,7 +45,7 @@ var GetFeatureInfo = class GetFeatureInfo extends Control {
      * @param {Object} [options] - options
      * @example
      * import GetFeatureInfo from "gpf-ext-ol/controls/GetFeatureInfo"
-     * ou 
+     * ou
      * import { GetFeatureInfo } from "gpf-ext-ol"
      */
     constructor (options) {
@@ -89,7 +89,7 @@ var GetFeatureInfo = class GetFeatureInfo extends Control {
                 Draggable.dragElement(
                     this.panelGetFeatureInfoContainer,
                     this.panelGetFeatureInfoHeaderContainer,
-                    this.options.position ? null : map.getTargetElement()
+                    map.getTargetElement()
                 );
             }
             // mode "collapsed"
@@ -128,7 +128,7 @@ var GetFeatureInfo = class GetFeatureInfo extends Control {
     // ################################################################### //
     // #################### privates methods ############################# //
     // ################################################################### //
-    
+
     /**
      * Initialize GetFeatureInfo control (called by GetFeatureInfo constructor)
      *
@@ -205,7 +205,7 @@ var GetFeatureInfo = class GetFeatureInfo extends Control {
         // close picto
         var getFeatureInfoCloseBtn = this.buttonGetFeatureInfoClose = this._createGetFeatureInfoPanelCloseElement();
         getFeatureInfoPanelHeader.appendChild(getFeatureInfoCloseBtn);
-        
+
         getFeatureInfoPanelDiv.appendChild(getFeatureInfoPanelHeader);
 
         // container for the custom code
@@ -222,7 +222,7 @@ var GetFeatureInfo = class GetFeatureInfo extends Control {
 
     /**
      * Add events listeners on map (called by setMap)
-     * 
+     *
      * @param {*} map - map
      * @private
      */
@@ -232,7 +232,7 @@ var GetFeatureInfo = class GetFeatureInfo extends Control {
             logger.trace(e);
             self.onMapClick(e);
         };
-        // the event custom:action is associate with an openlayers event 
+        // the event custom:action is associate with an openlayers event
         map.on("singleclick", this.eventsListeners["singleclick"]);
     }
 
@@ -260,7 +260,7 @@ var GetFeatureInfo = class GetFeatureInfo extends Control {
      * event handler
      * @param {Event} e évènement de click
      * @private
-     */ 
+     */
     onMapClick (e) {
         if (this.getFeatureInfoIsActive() === "true") {
             this.getFeatureInfoAccordionGroup.remove();
@@ -292,8 +292,8 @@ var GetFeatureInfo = class GetFeatureInfo extends Control {
     /**
      * Main render function
      * @param { ol.Layer } layer layer openlayer
-     * @return { Object } gfiLayer 
-     * { 
+     * @return { Object } gfiLayer
+     * {
      *      format : "wmts",
      *      layer: layer,
      *      url :  url          pour wmts et wms
@@ -311,7 +311,7 @@ var GetFeatureInfo = class GetFeatureInfo extends Control {
             let url = layer.getSource().getFeatureInfoUrl(
                 this.coordinates,
                 this.res,
-                this.map.getView().getProjection(), 
+                this.map.getView().getProjection(),
                 {
                     INFOFORMAT : "text/html",
                     STYLES : ""
@@ -328,7 +328,7 @@ var GetFeatureInfo = class GetFeatureInfo extends Control {
             let url = layer.getSource().getFeatureInfoUrl(
                 this.coordinates,
                 this.res,
-                this.map.getView().getProjection(), 
+                this.map.getView().getProjection(),
                 {
                     INFO_FORMAT : "text/html",
                     STYLES : ""
@@ -347,7 +347,7 @@ var GetFeatureInfo = class GetFeatureInfo extends Control {
     /**
      * Main render function
      * @param { ol.Layer } layer layer openlayer
-     * @return { Array } Array of ol features 
+     * @return { Array } Array of ol features
      * @private
      */
     getFeaturesAtClick (layer) {
@@ -363,8 +363,8 @@ var GetFeatureInfo = class GetFeatureInfo extends Control {
     /**
      * Main render function
      * @param { Object } gfiLayer layer openlayer
-     * @return { Object } gfi result 
-     * { 
+     * @return { Object } gfi result
+     * {
      *      layername : "layername",
      *      content: "html"
      * }
@@ -436,7 +436,7 @@ var GetFeatureInfo = class GetFeatureInfo extends Control {
     /**
      * Main render function
      * @private
-     */ 
+     */
     displayGetFeatureInfo () {
         var gfiLayers = this.layers.map((l) => {
             return this.getGetFeatureInfoLayer(l);
@@ -450,7 +450,7 @@ var GetFeatureInfo = class GetFeatureInfo extends Control {
             var accordeon = this._createGetFeatureInfoLayerAccordion(layername);
             var pending = true;
             return new AsyncData({
-                ...gfiLayer, 
+                ...gfiLayer,
                 ...{
                     layername : layername,
                     content : content,
@@ -531,7 +531,7 @@ var GetFeatureInfo = class GetFeatureInfo extends Control {
         }
         return "unknown";
     }
-    
+
     /**
      * Gets HTML content from features array
      *
@@ -628,7 +628,7 @@ var GetFeatureInfo = class GetFeatureInfo extends Control {
     // ################################################################### //
     // ######################## event dom ################################ //
     // ################################################################### //
-    
+
     /**
      * ...
      * @param {*} e - ...

--- a/src/packages/Controls/Isocurve/Isocurve.js
+++ b/src/packages/Controls/Isocurve/Isocurve.js
@@ -163,7 +163,7 @@ var Isocurve = class Isocurve extends Control {
                 Draggable.dragElement(
                     this._IsoPanelContainer,
                     this._IsoPanelHeaderContainer,
-                    this.options.position ? null : map.getTargetElement()
+                    map.getTargetElement()
                 );
             }
 

--- a/src/packages/Controls/LayerImport/LayerImport.js
+++ b/src/packages/Controls/LayerImport/LayerImport.js
@@ -150,7 +150,7 @@ var LayerImport = class LayerImport extends Control {
      * @param {*} options - options
      * @example
      * import LayerImport from "gpf-ext-ol/controls/LayerImport"
-     * ou 
+     * ou
      * import { LayerImport } from "gpf-ext-ol"
      */
     constructor (options) {
@@ -252,7 +252,7 @@ var LayerImport = class LayerImport extends Control {
                 Draggable.dragElement(
                     this._importPanel,
                     this._importPanelHeader,
-                    this.options.position ? null : map.getTargetElement()
+                    map.getTargetElement()
                 );
 
                 // panneau draggable pour les resultats ?
@@ -679,15 +679,15 @@ var LayerImport = class LayerImport extends Control {
         // create Import picto
         var picto = this._showImportButton = this._createShowImportPictoElement();
         container.appendChild(picto);
-        
+
         // panel
         var importPanel = this._importPanel = this._createImportPanelElement();
         var importPanelPanelDiv = this._createImportPanelDivElement();
         importPanel.appendChild(importPanelPanelDiv);
-        
+
         // header
         var panelHeader = this._importPanelHeader = this._createImportPanelHeaderElement();
-        
+
         // panel title
         var panelTitle = this._createImportPanelTitleElement();
         panelHeader.appendChild(panelTitle);
@@ -714,11 +714,11 @@ var LayerImport = class LayerImport extends Control {
         mapBoxPanel.appendChild(mapBoxPanelHeader);
         var importMapBoxResultsList = this._mapBoxResultsListContainer = this._createImportMapBoxResultsContainer();
         mapBoxPanel.appendChild(importMapBoxResultsList);
-        
+
         // loading element mapbox
         var loading = this._loadingContainer = this._createLoadingElement();
         mapBoxPanel.appendChild(loading);
-        
+
         importPanelPanelDiv.appendChild(mapBoxPanel);
 
         // waiting
@@ -1244,7 +1244,7 @@ var LayerImport = class LayerImport extends Control {
                             vectorSource = new VectorTileSource({
                                 attributions : _glSource.attribution,
                                 format : vectorFormat,
-                                // INFO 
+                                // INFO
                                 // on supprime la grille pour forcer l'utilisation par defaut des tuiles en 512
                                 // sur du vecteur tuilé
                                 // tileGrid : olCreateXYZTileGrid({ // TODO scheme tms ?

--- a/src/packages/Controls/Legends/Legends.js
+++ b/src/packages/Controls/Legends/Legends.js
@@ -25,7 +25,7 @@ var logger = Logger.getLogger("legends");
  * @type {ol.control.Legends}
  * @extends {ol.control.Control}
  * @param {Object} options - options for function call.
- * 
+ *
  * @fires legends:add
  * @fires legends:remove
  * @fires legends:modify
@@ -42,12 +42,12 @@ var Legends = class Legends extends Control {
      * @param {Object} [options] - options
      * @example
      * import Legends from "gpf-ext-ol/controls/Legends"
-     * ou 
+     * ou
      * import { Legends } from "gpf-ext-ol"
      */
     constructor (options) {
         options = options || {};
-        
+
         // call ol.control.Control constructor
         super({
             element : options.element,
@@ -87,7 +87,7 @@ var Legends = class Legends extends Control {
                 Draggable.dragElement(
                     this.panelLegendsContainer,
                     this.panelLegendsHeaderContainer,
-                    this.options.position ? null : map.getTargetElement()
+                    map.getTargetElement()
                 );
             }
             // mode "collapsed"
@@ -139,12 +139,12 @@ var Legends = class Legends extends Control {
 
     /**
      * Get all meta informations of a IGN's layer
-     * 
+     *
      * @param {*} layer - layer
      * @returns {*} informations
      * @public
      * @example
-     * getLegends() : 
+     * getLegends() :
      * "legends" : [
      *         {
      *             "format" : "image/jpeg",
@@ -171,7 +171,7 @@ var Legends = class Legends extends Control {
     }
 
     /**
-     * Add legends from layers 
+     * Add legends from layers
      * @param {*} layers  - ...
      * @public
      */
@@ -256,7 +256,7 @@ var Legends = class Legends extends Control {
     // ################################################################### //
     // #################### privates methods ############################# //
     // ################################################################### //
-    
+
     /**
      * Initialize Legends control (called by Legends constructor)
      *
@@ -295,8 +295,8 @@ var Legends = class Legends extends Control {
         this.eventsListeners = [];
 
         // tableau des entrées des legendes
-        // ex. 
-        // { 
+        // ex.
+        // {
         //   obj: layer openlayers,
         //   dom: DOMElement
         // }
@@ -349,7 +349,7 @@ var Legends = class Legends extends Control {
 
     /**
      * Add events listeners on map (called by setMap)
-     * 
+     *
      * @param {*} map - map
      * @private
      * @todo listener on change:position
@@ -373,7 +373,7 @@ var Legends = class Legends extends Control {
         this.eventsListeners["layer:remove"] = function (e) {
             logger.trace(e);
             // INFO
-            // à la suppression de la couche, on supprime l'entrée 
+            // à la suppression de la couche, on supprime l'entrée
             // * du DOM
             // * de la liste des entrées
             if (!self.remove(e.element)) {
@@ -384,19 +384,19 @@ var Legends = class Legends extends Control {
         this.eventsListeners["layer:change:position"] = function (e) {
             logger.trace(e);
             // TODO
-            // à la modification de l'ordre de la couche, on modifie l'entrée 
+            // à la modification de l'ordre de la couche, on modifie l'entrée
             // * du DOM
             // * de la liste des entrées
         };
         this.eventsListeners["view:change:resolution"] = function (e) {
             logger.trace(e);
-            // à la modification de l'echelle de la carte, on modifie les entrées 
+            // à la modification de l'echelle de la carte, on modifie les entrées
             // * du DOM si necessaire
             // * de la liste des entrées si necessaire
             var map = self.getMap();
             for (let j = 0; j < self.legends.length; j++) {
                 const legend = self.legends[j];
-                
+
                 var infos = self.getMetaInformations(legend.obj);
                 if (!infos) {
                     continue;
@@ -404,17 +404,17 @@ var Legends = class Legends extends Control {
                 // conversion resolution vers échelle
                 var resolution = map.getView().getResolution() || map.getView().getResolutionForZoom(map.getZoom());
                 var scaleDenominator = resolution*3570;
-                
+
                 // recherche de la legende en fonction de l'échelle
                 var cloneInfoLegends = infos.legends.slice(); //clone
                 var bestInfoLegend = cloneInfoLegends[0];
                 for (let i = 0; i < cloneInfoLegends.length; ++i) {
                     const InfoLegend = cloneInfoLegends[i];
-                    
+
                     if (!InfoLegend.minScaleDenominator) {
                         InfoLegend.minScaleDenominator = 0;
                     }
-    
+
                     if ( ( scaleDenominator > bestInfoLegend.minScaleDenominator && InfoLegend.minScaleDenominator > bestInfoLegend.minScaleDenominator && InfoLegend.minScaleDenominator < scaleDenominator ) ||
                          ( scaleDenominator < bestInfoLegend.minScaleDenominator && InfoLegend.minScaleDenominator < bestInfoLegend.minScaleDenominator ) ) {
                         bestInfoLegend = InfoLegend;
@@ -426,7 +426,7 @@ var Legends = class Legends extends Control {
                 }
                 infos.legends = [];
                 infos.legends.push(bestInfoLegend);
-    
+
                 // mise à jour du DOM
                 var newEntry = self._createLegendEntry(infos);
                 var oldEntry = legend.dom;

--- a/src/packages/Controls/MousePosition/MousePosition.js
+++ b/src/packages/Controls/MousePosition/MousePosition.js
@@ -182,7 +182,7 @@ var MousePosition = class MousePosition extends Control {
                 Draggable.dragElement(
                     this._panelMousePositionContainer,
                     this._panelHeaderContainer,
-                    this.options.position ? null : map.getTargetElement()
+                    map.getTargetElement()
                 );
             }
 

--- a/src/packages/Controls/ReverseGeocode/ReverseGeocode.js
+++ b/src/packages/Controls/ReverseGeocode/ReverseGeocode.js
@@ -82,7 +82,7 @@ var ReverseGeocode = class ReverseGeocode extends Control {
      * @param {*} options - options
      * @example
      * import ReverseGeocode from "gpf-ext-ol/controls/ReverseGeocode"
-     * ou 
+     * ou
      * import { ReverseGeocode } from "gpf-ext-ol"
      */
     constructor (options) {
@@ -161,7 +161,7 @@ var ReverseGeocode = class ReverseGeocode extends Control {
                 Draggable.dragElement(
                     this._panelContainer,
                     this._panelHeaderContainer,
-                    this.options.position ? null : map.getTargetElement()
+                    map.getTargetElement()
                 );
             }
             // mode "collapsed"
@@ -1509,7 +1509,7 @@ var ReverseGeocode = class ReverseGeocode extends Control {
         if (this.options.position && !this.collapsed) {
             this.updatePosition(this.options.position);
         }
-        
+
         if (!this._waiting && !this._reverseGeocodingLocations.length) {
             // Cas 1 : input panel (ni en attente, ni sur le panel des résultats)
             if (this.collapsed) {

--- a/src/packages/Controls/Route/Route.js
+++ b/src/packages/Controls/Route/Route.js
@@ -172,7 +172,7 @@ var Route = class Route extends Control {
                 Draggable.dragElement(
                     this._panelRouteContainer,
                     this._panelHeaderRouteContainer,
-                    this.options.position ? null : map.getTargetElement()
+                    map.getTargetElement()
                 );
             }
 

--- a/src/packages/Controls/Territories/Territories.js
+++ b/src/packages/Controls/Territories/Territories.js
@@ -28,7 +28,7 @@ var logger = Logger.getLogger("territories");
  * @type {ol.control.Territories}
  * @extends {ol.control.Control}
  * @param {Object} options - options for function call.
- * 
+ *
  * @fires custom:action
  * @example
  * var territories = new ol.control.Territories({
@@ -37,9 +37,9 @@ var logger = Logger.getLogger("territories");
  *   auto: true
  * });
  * map.addControl(territories);
- * 
+ *
  * or/and
- * 
+ *
  * var territories = new ol.control.Territories({});
  * territories.setTerritory({id: "MTQ", title: "Martinique", description: "", bbox: [], thumbnail: "data:image/png;base64,..."});
  * territories.setTerritory({id: "GLP", title: "Guadeloupe", description: "", bbox: [], thumbnail: "http://..."});
@@ -54,12 +54,12 @@ var Territories = class Territories extends Control {
      * @param {Object} [options] - options
      * @example
      * import Territories from "gpf-ext-ol/controls/Territories"
-     * ou 
+     * ou
      * import { Territories } from "gpf-ext-ol"
      */
     constructor (options) {
         options = options || {};
-        
+
         // call ol.control.Control constructor
         super({
             element : options.element,
@@ -99,7 +99,7 @@ var Territories = class Territories extends Control {
                 Draggable.dragElement(
                     this.panelTerritoriesContainer,
                     this.panelTerritoriesHeaderContainer,
-                    this.options.position ? null : map.getTargetElement()
+                    map.getTargetElement()
                 );
             }
             // mode "collapsed"
@@ -130,19 +130,19 @@ var Territories = class Territories extends Control {
     // ################################################################### //
     // ################### getters / setters ############################# //
     // ################################################################### //
-    
+
     /**
      * Add a territory
-     * 
+     *
      * @param {Object} territory  - territory
      * @returns {Boolean} - true|false
      * @public
      * @example
-     * territories.setTerritory ({ 
-     *  id: "MTQ", 
-     *  title: "Martinique", 
-     *  description: "", 
-     *  bbox: [minx, miny, maxx, maxy], 
+     * territories.setTerritory ({
+     *  id: "MTQ",
+     *  title: "Martinique",
+     *  description: "",
+     *  bbox: [minx, miny, maxx, maxy],
      *  thumbnail: "data:image/png;base64,..."
      * });
      */
@@ -165,7 +165,7 @@ var Territories = class Territories extends Control {
 
     /**
      * Remove a territory
-     * 
+     *
      * @param {String} territory - territory id (FRA, MTQ, ...)
      * @returns {Boolean} - true|false
      * @public
@@ -190,7 +190,7 @@ var Territories = class Territories extends Control {
 
     /**
      * Set collapse
-     * 
+     *
      * @param {Boolean} collapsed - true|false
      * @todo ...
      * @public
@@ -213,7 +213,7 @@ var Territories = class Territories extends Control {
 
     /**
      * Mode reduit des tuiles (uniquement le nom du territoire)
-     * 
+     *
      * @param {*} reduce - true|false
      * @public
      */
@@ -233,11 +233,11 @@ var Territories = class Territories extends Control {
     getContainer () {
         return this.container;
     }
-    
+
     // ################################################################### //
     // #################### privates methods ############################# //
     // ################################################################### //
-    
+
     /**
      * Initialize Territories control (called by Territories constructor)
      *
@@ -271,12 +271,12 @@ var Territories = class Territories extends Control {
 
         /** {Boolean} specify if we load the list of territories by default */
         this.auto = this.options.auto;
-        /** 
-         * {Array} list of object territories 
+        /**
+         * {Array} list of object territories
          * @example
-         * { 
-         *   dom : { HTMLelment }, 
-         *   data : { 
+         * {
+         *   dom : { HTMLelment },
+         *   data : {
          *     id: "MTQ", title: "Martinique", description: "", bbox: [minx, miny, maxx, maxy], thumbnail: "data:image/png;base64,..."
          *   }
          * }
@@ -351,7 +351,7 @@ var Territories = class Territories extends Control {
     // ################################################################### //
     // ######################## event dom ################################ //
     // ################################################################### //
-    
+
     /**
      * ...
      * @param {*} e - ...


### PR DESCRIPTION
fixes https://github.com/IGNF/geopf-extensions-openlayers/issues/174

Refactor du draggable pour utiliser `transform: translate` à la place de top/bottom/left/right vu que ces 4 derniers sont utilisés pour le positionnement des dialog.

Ajout systématique de la map en tant que container en mode draggable pour les widgets.