### PR TITLE
fix gfi close panels with panel manager

### DIFF
--- a/src/packages/Controls/GetFeatureInfo/GetFeatureInfo.js
+++ b/src/packages/Controls/GetFeatureInfo/GetFeatureInfo.js
@@ -638,7 +638,9 @@ var GetFeatureInfo = class GetFeatureInfo extends Control {
         if (e.target.ariaPressed === "true") {
             this.onPanelOpen();
         }
-        if (e === false){
+        // ouverture du panel pas systématique quand on clic sur le bouton d'activation
+        // donc on doit fermer explicitement le panel quand on désactive le GFI
+        if (e.target.ariaPressed === "false"){
             this.buttonGetFeatureInfoClose.setAttribute("aria-pressed", false);
         }
         logger.trace(e);


### PR DESCRIPTION
résolution du bug : 
fermeture du panel gfi qui ne se fait pas quand on ouvre un autre widget