### PR TITLE
fix(LayerImport): Afficher le bouton retour sur la fenêtre des résultats

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.0-241",
+  "version": "1.0.0-beta.0-250",
   "date": "05/11/2024",
   "module": "src/index.js",
   "directories": {},

--- a/src/packages/Controls/LayerImport/LayerImport.js
+++ b/src/packages/Controls/LayerImport/LayerImport.js
@@ -532,7 +532,7 @@ var LayerImport = class LayerImport extends Control {
 
         // ################################################################## //
         // ################ Interrogation du GetCapabilities ################ //
-
+        this._hasGetCapResults = false;
         this._getCapRequestUrl = null;
         this._getCapResponseWMS = null;
         this._getCapResponseWMSLayers = [];
@@ -844,9 +844,15 @@ var LayerImport = class LayerImport extends Control {
             this._mapBoxPanel.classList.replace("GPelementHidden", "GPelementVisible");
             this._mapBoxPanel.classList.replace("gpf-hidden", "gpf-visible");
             this._hideFormContainer();
+        } else if (this._hasGetCapResults) {
+            this._getCapPanel.classList.replace("GPelementHidden", "GPelementVisible");
+            this._getCapPanel.classList.replace("gpf-hidden", "gpf-visible");
+            this._hideFormContainer();
         } else {
             this._getCapPanel.classList.replace("GPelementVisible", "GPelementHidden");
             this._getCapPanel.classList.replace("gpf-visible", "gpf-hidden");
+            this._mapBoxPanel.classList.replace("GPelementVisible", "GPelementHidden");
+            this._mapBoxPanel.classList.replace("gpf-visible", "gpf-hidden");
             this._displayFormContainer();
         }
     }
@@ -2083,7 +2089,9 @@ var LayerImport = class LayerImport extends Control {
         this._getCapPanel.classList.replace("GPelementHidden", "GPelementVisible");
         this._getCapPanel.classList.replace("gpf-hidden", "gpf-visible");
         this._importPanelTitle.innerHTML = "Couches accessibles";
-
+        this._importPanelReturnPicto.classList.replace("GPelementHidden", "GPelementVisible");
+        this._importPanelReturnPicto.classList.replace("gpf-hidden", "gpf-visible");
+        this._hasGetCapResults = true;
         // Parse GetCapabilities Response
         if (this._currentImportType === "WMS") {
             parser = new WMSCapabilities();
@@ -3059,6 +3067,7 @@ var LayerImport = class LayerImport extends Control {
      * @private
      */
     cleanGetCapResultsList () {
+        this._hasGetCapResults = false;
         this._getCapRequestUrl = null;
         this._getCapResponseWMS = null;
         this._getCapResponseWMTS = null;

--- a/src/packages/Utils/PanelManager.js
+++ b/src/packages/Utils/PanelManager.js
@@ -4,12 +4,12 @@ function getSameSideOpenedPanel (position, openedPanelID) {
     // on ajoute aux exceptions le panel qui vient d'être ouvert
     var exceptionPanel = [...exceptions, openedPanelID];
     var controlPanels = [];
-    if (position.includes("left")) {
+    if (position && position.includes("left")) {
         var bottomLeft = document.getElementById("position-container-bottom-left");
         var topLeft = document.getElementById("position-container-top-left");
         controlPanels = [...bottomLeft.children, ...topLeft.children];
     }
-    if (position.includes("right")) {
+    if (position && position.includes("right")) {
         var bottomRight = document.getElementById("position-container-bottom-right");
         var topRight = document.getElementById("position-container-top-right");
         controlPanels = [...bottomRight.children, ...topRight.children];


### PR DESCRIPTION
Le bouton retour sur les panneaux de résultat est utile pour fermer le panneau sans supprimer les résultats. Ce qui est différent avec le bouton de fermeture, qui réinitialise le formulaire.

![image](https://github.com/user-attachments/assets/7736ee10-483b-4caf-9c1d-9f1a4b8802fc)
![image](https://github.com/user-attachments/assets/8776a492-dd33-4845-8537-02a2c4550fdb)
![image](https://github.com/user-attachments/assets/0abf9ce1-1df9-4013-adae-236226b8d99c)
