### PR TITLE
fix(alti-profile): #247 saisie ppossible sous la fenêtre de résultats

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.0-251",
-  "date": "05/11/2024",
+  "version": "1.0.0-beta.0-256",
+  "date": "14/11/2024",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/src/packages/CSS/Controls/ElevationPath/DSFRelevationPathStyle.css
+++ b/src/packages/CSS/Controls/ElevationPath/DSFRelevationPathStyle.css
@@ -10,6 +10,11 @@
   left: 0;
 }
 
+/* surcharge de fr-panel pour permettre la saisie sous la fenêtre de résultat */
+[id^=GPelevationPathPanel] {
+  height: unset;
+}
+
 [id^=GPelevationPathPanelInfo]::after {
   -webkit-mask: url("../../img/GPinfo_secondary.svg") center no-repeat;
   mask: url("../../img/GPinfo_secondary.svg") center no-repeat;


### PR DESCRIPTION
Fix #247 

Avant : 
la saisie d'un profil altimétrique dans la zone de la carte située sous la fenêtre de résultats du profil alti est ipossible


Après : 
la saisie dans la zone située sous la fenêtre de résultat d'un précédent calcul est possible

![image](https://github.com/user-attachments/assets/e82f9d40-550a-48b9-b87c-014d7489407b)
