### PR TITLE
fix(scalebar): surcharge ol pour passer l'echelle sous les tooltips

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.0-251",
-  "date": "05/11/2024",
+  "version": "1.0.0-beta.0-257",
+  "date": "14/11/2024",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/samples-src/pages/tests/Default/pages-ol-modules-dsrf-default.html
+++ b/samples-src/pages/tests/Default/pages-ol-modules-dsrf-default.html
@@ -69,7 +69,13 @@
 
 {{#content "js"}}
             <script type="text/javascript">
-
+              const scaleControl = new ol.control.ScaleLine({
+                  units: 'metric',
+                  bar: true,
+                  steps: 4,
+                  text: true,
+                  minWidth: 140,
+              });
               var createMap = function () {
                 // on cache l'image de chargement du Géoportail.
                 document.getElementById("map").style.backgroundImage = "none";
@@ -87,6 +93,9 @@
                     zoom : 8
                   })
                 });
+
+
+                map.addControl(scaleControl);
 
                 var catalog = new ol.control.Catalog({
                   draggable: true,

--- a/src/packages/CSS/DSFRgeneralWidget.css
+++ b/src/packages/CSS/DSFRgeneralWidget.css
@@ -508,6 +508,7 @@
   border-bottom: 1px dotted #666;
 }
 
+/* surcharge css OpenLayers */
 .ol-disabled {
   --idle: transparent;
   --hover: var(--background-disabled-grey-hover);
@@ -517,6 +518,10 @@
   cursor: not-allowed;
   /* instead of display: none */
   display: block;
+}
+
+.ol-scale-bar, .ol-scale-line {
+  z-index: -1;
 }
 
 /* surcharge DSFR pour coller aux règles et au rendu de https://www.systeme-de-design.gouv.fr/composants-et-modeles/composants/accordeon/ */


### PR DESCRIPTION
fix #248 

Avant : 

le tooltip se place sous la barre d'echelle 

![Capture d’écran du 2024-11-14 18-42-30](https://github.com/user-attachments/assets/b18d228f-5f6d-46f8-853c-ebdbeb6a060e)
![Capture d’écran du 2024-11-14 18-42-54](https://github.com/user-attachments/assets/0d11cfab-cac8-46bf-8c86-efb64311250a)


Après : 

![Capture d’écran du 2024-11-14 18-38-36](https://github.com/user-attachments/assets/ec7c50e0-29db-422d-93a2-81ad93de23b0)
![Capture d’écran du 2024-11-14 18-40-03](https://github.com/user-attachments/assets/6583de3f-8516-4675-aa52-580a93a96557)

le tooltip se place au dessus de la bar d'echelle