### PR TITLE
fix(gfi): retrait d'une scrollbar horizontale inutile (#253)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.0-260",
+  "version": "1.0.0-beta.0-263",
   "date": "15/11/2024",
   "module": "src/index.js",
   "directories": {},

--- a/src/packages/CSS/Controls/GetFeatureInfo/GPFgetFeatureInfo.css
+++ b/src/packages/CSS/Controls/GetFeatureInfo/GPFgetFeatureInfo.css
@@ -24,6 +24,7 @@ dialog[id^="GPgetFeatureInfoPanel-"] {
     left: 47px;
     top: 2px;
     max-height: 52vh;
+    overflow-x: hidden;
 }
 
 .GPgetFeatureInfoAccordionGroup {

--- a/src/packages/Controls/GetFeatureInfo/GetFeatureInfoDOM.js
+++ b/src/packages/Controls/GetFeatureInfo/GetFeatureInfoDOM.js
@@ -222,7 +222,7 @@ var GetFeatureInfoDOM = {
                         <span id="gfiLayerName">${layername}</span>
                     </button>
                 </h3>
-                <div class="fr-collapse GPgetFeatureInfoAccordionContent GPelementHidden" id="accordion-${layername}">
+                <div class="fr-collapse GPgetFeatureInfoAccordionContent GPelementHidden" id="accordion-${layername}" style="margin:unset;">
                     ${this._createGetFeatureInfoWaitingDiv()}
                 </div>
             </section>


### PR DESCRIPTION
Fix #253 

l'élément accordion dsfr impose une marge qui provoque une scrollbar horizontale. On surcharge le dsfr en inline css dans le code HTML de la pop-up (évite un !important).


Avant : 


Scrollbar horizontale inutile : 
![image](https://github.com/user-attachments/assets/007c5ac8-8cf3-4729-922f-1e5591c6f4a0)


Après : 


Plus de scrollbar :
![image](https://github.com/user-attachments/assets/644c8e68-6ced-404e-9d55-6a7f8a23d2ec)
