### PR TITLE
feat(Layers): Ajout du format WFS

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -21,12 +21,13 @@ En attente de la 1ère release :
 ## 💥 Breaking changes
 
 Un nouvelle version du GFI avec un fonctionnement et des options differentes de l'ancien widget.
+Pour le WFS, on utilise la version 3.4.4 des services.
 
 ## 📖 Changelog
 
 * ✨ [Added]
 
-  * WFS : Exemple de moissonnage WFS avec export des données
+  * WFS : Affichage des couches WFS Géoplateform (#...)
   * SearchEngine : Ajout de l'option `markerUrl` pour afficher un marker de position personnalisé (#197)
   * Catalog : Nouveau widget Catalog (#155)
   * Territories : Nouveau widget Selecteur de territoires (#115)
@@ -55,9 +56,10 @@ Un nouvelle version du GFI avec un fonctionnement et des options differentes de 
 
 * 🐛 [Fixed]
 
-  * layerswitcher : zoomToExtent sur les données importées (vecteurs et services) (#232)￼
-     - Ajout du zoom to extent pour le vecteur
-     - Ajout du zoom to extent pour le WMS et WMTS
+  * layerswitcher : zoomToExtent sur les données importées (vecteurs et services) (#232)
+    - Ajout du zoom to extent pour le vecteur
+    - Ajout du zoom to extent pour le WMS et WMTS
+
   * LayerImport : Fix (#231)
   * Zoom : changer style classique des boutons zoom + et - (#227)
   * Measures : Fix (#109)

--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -27,7 +27,7 @@ Pour le WFS, on utilise la version 3.4.4 des services.
 
 * ✨ [Added]
 
-  * WFS : Affichage des couches WFS Géoplateform (#...)
+  * WFS : Affichage des couches WFS Géoplateforme (#265)
   * SearchEngine : Ajout de l'option `markerUrl` pour afficher un marker de position personnalisé (#197)
   * Catalog : Nouveau widget Catalog (#155)
   * Territories : Nouveau widget Selecteur de territoires (#115)

--- a/build/webpack/layers.webpack.config.js
+++ b/build/webpack/layers.webpack.config.js
@@ -19,8 +19,10 @@ module.exports = (env, argv) => {
             "GpfExtOl-Layers" : [
                 path.join(rootdir, "src", "packages", "Sources", "WMTS.js"),
                 path.join(rootdir, "src", "packages", "Layers", "LayerWMS.js"),
+                path.join(rootdir, "src", "packages", "Layers", "LayerWFS.js"),
                 path.join(rootdir, "src", "packages", "Layers", "LayerWMTS.js"),
                 path.join(rootdir, "src", "packages", "Layers", "SourceWMS.js"),
+                path.join(rootdir, "src", "packages", "Layers", "SourceWFS.js"),
                 path.join(rootdir, "src", "packages", "Layers", "SourceWMTS.js"),
                 path.join(rootdir, "src", "packages", "Layers", "LayerMapBox.js"),
             ]

--- a/build/webpack/modules.webpack.config.js
+++ b/build/webpack/modules.webpack.config.js
@@ -65,8 +65,10 @@ module.exports = (env, argv) => {
             "GpfExtOlLayers" : [
                 path.join(rootdir, "src", "packages", "Sources", "WMTS.js"),
                 path.join(rootdir, "src", "packages", "Layers", "LayerWMS.js"),
+                path.join(rootdir, "src", "packages", "Layers", "LayerWFS.js"),
                 path.join(rootdir, "src", "packages", "Layers", "LayerWMTS.js"),
                 path.join(rootdir, "src", "packages", "Layers", "SourceWMS.js"),
+                path.join(rootdir, "src", "packages", "Layers", "SourceWFS.js"),
                 path.join(rootdir, "src", "packages", "Layers", "SourceWMTS.js"),
                 path.join(rootdir, "src", "packages", "Layers", "LayerMapBox.js"),
             ],

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@gouvfr/dsfr": "^1.11.0",
     "@mapbox/mapbox-gl-style-spec": "14.7.1",
     "eventbusjs": "0.2.0",
-    "geoportal-access-lib": "3.4.3",
+    "geoportal-access-lib": "3.4.4",
     "loglevel": "^1.9.1",
     "ol": "8.2.0",
     "ol-mapbox-style": "12.3.5",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.0-266",
-  "date": "15/11/2024",
+  "version": "1.0.0-beta.0-265",
+  "date": "17/11/2024",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/samples-src/config.json
+++ b/samples-src/config.json
@@ -2,6 +2,6 @@
     "baseurl" : "../../..",
     "resources" : "../../resources",
     "apikey" : "essentiels,cartes,adresse,lambert93",
-    "configurl" : "https://raw.githubusercontent.com/IGNF/geoportal-configuration/new-url/dist/fullConfig.json",
+    "configurl" : "https://data.geopf.fr/annexes/cartes.gouv.fr-config/public/layers.json",
     "proxy" : "https://localhost/proxy/proxy.php"
 }

--- a/samples-src/pages/tests/Layers/pages-ol-layerwfs-modules-default.html
+++ b/samples-src/pages/tests/Layers/pages-ol-layerwfs-modules-default.html
@@ -54,7 +54,9 @@
 
                     const vector = new ol.layer.GeoportalWFS({
                         layer: "BDTOPO_V3:batiment",
+                        maxFeatures: 500,
                         olParams: {
+                            sourceParams : {},
                             minZoom: 15,
                             maxZoom: 21,
                             style: new ol.style.Style({

--- a/samples-src/pages/tests/Layers/pages-ol-layerwfs-modules-native.html
+++ b/samples-src/pages/tests/Layers/pages-ol-layerwfs-modules-native.html
@@ -1,0 +1,204 @@
+{{#extend "ol-sample-modules-layout"}}
+
+{{#content "vendor"}}
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlLayers.js"></script>
+        <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlExport.css" />
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlExport.js"></script>
+{{/content}}
+
+{{#content "head"}}
+        <title>Sample openlayers</title>
+{{/content}}
+
+{{#content "style"}}
+        <style>
+            div#map {
+                width: 100%;
+                height: 500px;
+                position: relative;
+            }
+            @keyframes spinner {
+                to {
+                    transform: rotate(360deg);
+                }
+            }
+            .spinner:after {
+                content: "";
+                box-sizing: border-box;
+                position: absolute;
+                top: 50%;
+                left: 50%;
+                width: 40px;
+                height: 40px;
+                margin-top: -20px;
+                margin-left: -20px;
+                border-radius: 50%;
+                border: 5px solid rgba(180, 180, 180, 0.6);
+                border-top-color: rgba(0, 0, 0, 0.6);
+                animation: spinner 0.6s linear infinite;
+            }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+            <h2>Ajout d'une couche WFS (avec pagination des résultats)</h2>
+            <ul>
+                <li>implementation native : https://openlayers.org/en/latest/examples/vector-wfs-getfeature.html</li>
+                <li>tests à partir de https://openlayers.org/en/latest/apidoc/module-ol_source_Vector-VectorSource.html</li>
+                <li>spinner : https://openlayers.org/en/latest/examples/load-events.html</li>
+            </ul>
+            <p>
+                Stratégie en place pour recupérer les features :
+                <ul>
+                    <li>le moissonnage est activé 
+                        sur une resolution min/max défini (15/21)
+                        sur l'étendu de la carte
+                    </li>
+                    <li>le nombre d'élements à moissonner est defini (valeur par le service)</li>
+                    <li>le deplacement sur la carte ajoute les données moissonnées</li>
+                    <li>le style des données est defini par l'utilisateur</li>
+                    <li>le format d'export des données est en GeoJSON</li>
+                </ul>
+            </p>
+            <pre>
+                Ex. requête :
+                GET https://data.geopf.fr/wfs/ows?
+                    SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&
+                    typename=BDTOPO_V3:batiment&
+                    outputFormat=application/json&srsname=EPSG:4326&
+                    bbox=${extent},EPSG:4326&
+                    maxFeatures=500&count=500&startIndex=0
+                Ex. de reponse :
+                {
+                    "bbox": [...],
+                    "links": {...},
+                    "type": "FeatureCollection",
+                    "features": [...],
+                    "totalFeatures": 0,
+                    "numberMatched": 0,
+                    "numberReturned": 0,
+                    "timeStamp": "2024-11-15T23:52:20.996Z",
+                    "crs": {...}
+                }
+            </pre>
+            <!-- map -->
+            <div id="btnExport"></div>
+            <div id="map"></div>
+{{/content}}
+
+{{#content "js"}}
+            <script type="text/javascript">
+                var map;
+                var createMap = function() {
+
+                    const vectorSource = new ol.source.Vector({
+                        format: new ol.format.GeoJSON(),
+                        // url: function (extent) {
+                        //     return (
+                        //         'https://data.geopf.fr/wfs/ows?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&' +
+                        //         'typename=BDTOPO_V3:batiment&' +
+                        //         'outputFormat=application/json&srsname=EPSG:4326&' +
+                        //         'bbox=' + extent.join(',') + ',EPSG:4326'
+                        //         + '&maxFeatures=500&count=500&startIndex=0'
+                        //     );
+                        // },
+                        loader: function(extent, resolution, projection, success, failure) {
+                            const maxFeatures = 5000;
+                            const layerName = "BDTOPO_V3:batiment";
+                            const proj = projection.getCode();
+                            const url = 'https://data.geopf.fr/wfs/ows?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&' +
+                                'typename=' + layerName + '&' +
+                                'outputFormat=application/json&srsname=' + proj + '&' +
+                                'bbox=' + extent.join(',') + ',' + proj
+                                + '&maxFeatures=' + maxFeatures + '&count=' + maxFeatures + '&startIndex=0';
+                            const xhr = new XMLHttpRequest();
+                            xhr.open('GET', url);
+                            const onError = function() {
+                                vectorSource.removeLoadedExtent(extent);
+                                failure();
+                            }
+                            xhr.onerror = onError;
+                            xhr.onload = function() {
+                                if (xhr.status == 200) {
+                                    const features = vectorSource.getFormat().readFeatures(xhr.responseText);
+                                    vectorSource.addFeatures(features);
+                                    success(features);
+                                } else {
+                                    onError();
+                                }
+                            }
+                            xhr.send();
+                        },
+                        strategy: ol.loadingstrategy.tile(ol.tilegrid.createXYZ({minZoom: 15, maxZoom: 21, tileSize: 512})),
+                    });
+
+                    const vector = new ol.layer.Vector({
+                        minZoom: 15,
+                        maxZoom: 21,
+                        source: vectorSource,
+                        style: new ol.style.Style({
+                            stroke: new ol.style.Stroke({
+                                color: 'rgba(0, 0, 255, 1.0)',
+                                width: 2,
+                            }),
+                            fill: new ol.style.Fill({
+                                color: 'rgba(0, 0, 255, 0.5)'
+                            }),
+                        }),
+                    });
+
+                    vectorSource.on('featuresloadstart', function () {
+                        console.log("featuresloadstart")
+                    });
+                    vectorSource.on(['featuresloadend', 'featuresloaderror'], function (e) {
+                        console.log("featuresloadend", e.features)
+                    });
+
+                    map = new ol.Map({
+                        target : "map",
+                        view : new ol.View({
+                            center : [288074.8449901076, 6247982.515792289],
+                            zoom : 6
+                        }),
+                        layers : [
+                            new ol.layer.Tile({
+                                source: new ol.source.OSM(),
+                                opacity: 0.5
+                            }),
+                            // new ol.layer.GeoportalWMTS({
+                            //     layer : "ORTHOIMAGERY.ORTHOPHOTOS"
+                            // }),
+                            vector,
+                        ]
+                    });
+                    map.on('loadstart', function () {
+                        map.getTargetElement().classList.add('spinner');
+                    });
+                    map.on('loadend', function () {
+                        map.getTargetElement().classList.remove('spinner');
+                    });
+
+                    var exportBtn = new ol.control.Export({});
+                    exportBtn.setLayer(vector);
+                    exportBtn.setFormat("geojson");
+                    exportBtn.setName("export");
+                    exportBtn.setTitle("Exporter");
+                    exportBtn.on("export:compute", (e) => {
+                        console.log("Export", e);
+                    });
+                    document.getElementById("btnExport").appendChild(exportBtn.getContainer());
+                };
+                Gp.Services.getConfig({
+                    customConfigFile : "{{ configurl }}",
+                    callbackSuffix : "",
+                    // apiKey: "{{ apikey }}",
+                    timeOut : 20000,
+                    onSuccess : createMap,
+                    onFailure : (e) => {
+                        console.error(e);
+                    }
+                });
+           </script>
+{{/content}}
+
+{{/extend}}

--- a/samples-src/pages/tests/Layers/pages-ol-layerwfs-modules-native.html
+++ b/samples-src/pages/tests/Layers/pages-ol-layerwfs-modules-native.html
@@ -54,7 +54,8 @@
                         sur une resolution min/max défini (15/21)
                         sur l'étendu de la carte
                     </li>
-                    <li>le nombre d'élements à moissonner est defini (valeur par le service)</li>
+                    <li>le nombre d'élements à moissonner est defini (valeur max fourni par le service)</li>
+                    <li>(on moissone tous les elements de l'étendu par paquet de maxFeatures)</li>
                     <li>le deplacement sur la carte ajoute les données moissonnées</li>
                     <li>le style des données est defini par l'utilisateur</li>
                     <li>le format d'export des données est en GeoJSON</li>

--- a/samples-src/pages/tests/Layers/pages-ol-sourcewfs-modules-default.html
+++ b/samples-src/pages/tests/Layers/pages-ol-sourcewfs-modules-default.html
@@ -2,8 +2,6 @@
 
 {{#content "vendor"}}
         <script src="{{ baseurl }}/dist/modules/GpfExtOlLayers.js"></script>
-        <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlExport.css" />
-        <script src="{{ baseurl }}/dist/modules/GpfExtOlExport.js"></script>
 {{/content}}
 
 {{#content "head"}}
@@ -15,7 +13,6 @@
             div#map {
                 width: 100%;
                 height: 500px;
-                position: relative;
             }
             @keyframes spinner {
                 to {
@@ -41,34 +38,17 @@
 {{/content}}
 
 {{#content "body"}}
-            <h2>Ajout d'une couche WFS (avec pagination des résultats)</h2>
+            <h2>Ajout d'une couche WFS</h2>
             <!-- map -->
-            <div id="btnExport"></div>
-            <div id="map"></div>
+            <div id="map">
+            </div>
 {{/content}}
 
 {{#content "js"}}
             <script type="text/javascript">
                 var map;
                 var createMap = function() {
-
-                    const vector = new ol.layer.GeoportalWFS({
-                        layer: "BDTOPO_V3:batiment",
-                        olParams: {
-                            minZoom: 15,
-                            maxZoom: 21,
-                            style: new ol.style.Style({
-                                stroke: new ol.style.Stroke({
-                                    color: 'rgba(0, 0, 255, 1.0)',
-                                    width: 2,
-                                }),
-                                fill: new ol.style.Fill({
-                                    color: 'rgba(0, 0, 255, 0.5)'
-                                }),
-                            }),
-                        }
-                    });
-
+        
                     map = new ol.Map({
                         target : "map",
                         view : new ol.View({
@@ -80,10 +60,30 @@
                                 source: new ol.source.OSM(),
                                 opacity: 0.5
                             }),
-                            // new ol.layer.GeoportalWMTS({
-                            //     layer : "ORTHOIMAGERY.ORTHOPHOTOS"
-                            // }),
-                            vector,
+                            new ol.layer.Vector({
+                                source : new ol.source.GeoportalWFS({
+                                    layer : "BDTOPO_V3:batiment",
+                                    maxFeatures: 500,
+                                    olParams: {}
+                                }),
+                                opacity : 1,
+                                minZoom: 15,
+                                maxZoom: 21,
+                                style: new ol.style.Style({
+                                    stroke: new ol.style.Stroke({
+                                        color: 'rgba(0, 0, 255, 1.0)',
+                                        width: 2,
+                                    }),
+                                    fill: new ol.style.Fill({
+                                        color: 'rgba(0, 0, 255, 0.5)'
+                                    }),
+                                }),
+                            }),
+                            // new ol.layer.Tile({
+                            //     source : new ol.source.GeoportalWMTS({
+                            //         layer : "GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2"
+                            //     })
+                            // })
                         ]
                     });
                     map.on('loadstart', function () {
@@ -92,16 +92,6 @@
                     map.on('loadend', function () {
                         map.getTargetElement().classList.remove('spinner');
                     });
-
-                    var exportBtn = new ol.control.Export({});
-                    exportBtn.setLayer(vector);
-                    exportBtn.setFormat("geojson");
-                    exportBtn.setName("export");
-                    exportBtn.setTitle("Exporter");
-                    exportBtn.on("export:compute", (e) => {
-                        console.log("Export", e);
-                    });
-                    document.getElementById("btnExport").appendChild(exportBtn.getContainer());
                 };
                 Gp.Services.getConfig({
                     customConfigFile : "{{ configurl }}",

--- a/samples-src/resources/data/configuration/sample.json
+++ b/samples-src/resources/data/configuration/sample.json
@@ -4,7 +4,8 @@
         "cartes": [
           "GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2$GEOPORTAIL:OGC:WMTS",
           "GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2$GEOPORTAIL:OGC:WMS",
-          "PLAN.IGN$GEOPORTAIL:GPP:TMS"
+          "PLAN.IGN$GEOPORTAIL:GPP:TMS",
+          "BDTOPO_V3:batiment$GEOPORTAIL:OGC:WFS"
         ]
       }
     },
@@ -319,7 +320,34 @@
         },
         "layerId": "PLAN.IGN$GEOPORTAIL:GPP:TMS",
         "defaultProjection": "EPSG:3857"
-      }
+      },
+      "BDTOPO_V3:batiment$GEOPORTAIL:OGC:WFS": {
+      "name": "BDTOPO_V3:batiment",
+      "title": "BDTOPO : Bâtiments",
+      "description": "Bâtiments - BDTOPO",
+      "globalConstraint": {
+        "minScaleDenominator": 0.0,
+        "maxScaleDenominator": 62236752975597,
+        "bbox": {
+          "left": -63.28125,
+          "right": 55.8984375,
+          "top": 51.9734375,
+          "bottom": -21.77265625
+        }
+      },
+      "serviceParams": {
+        "id": "OGC:WFS",
+        "version": "2.0.0",
+        "serverUrl": {
+          "full": "https://data.geopf.fr/wfs/ows"
+        }
+      },
+      "defaultProjection": "EPSG:4326",
+      "queryable": false,
+      "metadata": [],
+      "styles": [],
+      "legends": [],
+      "formats": []
     },
     "tileMatrixSets": {
       "PM_0_19": {

--- a/src/index.js
+++ b/src/index.js
@@ -14,8 +14,10 @@ export { default as GeoJSON } from "./packages/Formats/GeoJSON";
 export { default as WMTS } from "./packages/Sources/WMTS";
 export { default as SourceWMTS } from "./packages/Layers/SourceWMTS";
 export { default as SourceWMS } from "./packages/Layers/SourceWMS";
+export { default as SourceWFS } from "./packages/Layers/SourceWFS";
 export { default as LayerWMTS } from "./packages/Layers/LayerWMTS";
 export { default as LayerWMS } from "./packages/Layers/LayerWMS";
+export { default as LayerWFS } from "./packages/Layers/LayerWFS";
 export { default as LayerMapBox } from "./packages/Layers/LayerMapBox";
 
 // controles

--- a/src/packages/Layers/LayerWFS.js
+++ b/src/packages/Layers/LayerWFS.js
@@ -1,0 +1,205 @@
+import VectorLayer from "ol/layer/Vector";
+import {
+    Fill,
+    Stroke,
+    Style
+} from "ol/style";
+// import local
+import Utils from "../Utils/Helper";
+import Config from "../Utils/Config";
+// import local with ol dependencies
+import SourceWFS from "./SourceWFS";
+
+const MINZOOMDEFAULT = 15;
+const MAXZOOMDEFAULT = 21;
+const STYLEBYDEFAULT = new Style({
+    stroke : new Stroke({
+        color : "rgba(0, 0, 255, 1.0)",
+        width : 2,
+    }),
+    fill : new Fill({
+        color : "rgba(0, 0, 255, 0.5)"
+    }),
+});
+
+/**
+ * @classdesc
+ * Geoportal LayerWMS source creation (inherit from ol.layer.Tile)
+ *
+ * @constructor
+ * @extends {ol.layer.Vector}
+ * @alias ol.layer.GeoportalWFS
+ * @type {ol.layer.GeoportalWFS}
+ * @param {Object} options            - options for function call.
+ * @param {String} options.layer      - Layer name (e.g. "")
+ * @param {Object} [options.configuration] - configuration (cf. example) 
+ * @param {Boolean} [options.ssl]     - if set true, enforce protocol https (only for nodejs)
+ * @param {String} [options.apiKey]   - Access key to Geoportal platform
+ * @param {Object} [options.olParams] - other options for ol.layer.Vector function (see {@link http://openlayers.org/en/latest/apidoc/ol.layer.Vector.html ol.layer.Vector})
+ * @param {Object} [options.olParams.sourceParams] - other options for ol.source.Vector function (see {@link http://openlayers.org/en/latest/apidoc/ol.source.Vector.html ol.source.Vector})
+ * @example
+ * var layerWFS = new ol.layer.GeoportalWFS({
+ *      layer  : "ORTHOIMAGERY.ORTHOPHOTOS"
+ * });
+ * 
+ * layerWFS.getLegends();
+ * layerWFS.getMetadata();
+ * layerWFS.getTitle();
+ * layerWFS.getDescription();
+ * layerWFS.getQuicklookUrl();
+ * layerWFS.getOriginators();
+ */
+var LayerWFS = class LayerWFS extends VectorLayer {
+
+    /**
+     * See {@link ol.layer.GeoportalWFS}
+     * @module LayerWFS
+     * @alias module:~layers/GeoportalWFS
+     * @param {*} options - options
+     * @example
+     * import LayerWFS from "gpf-ext-ol/layers/LayerWFS"
+     * ou 
+     * import { LayerWFS } from "gpf-ext-ol"
+     */
+    constructor (options) {
+        if (!options.layer) {
+            throw new Error("ERROR PARAM_MISSING : layer");
+        }
+
+        if (typeof options.layer !== "string") {
+            throw new Error("ERROR WRONG TYPE : layer");
+        }
+
+        // par defaut
+        if (typeof options.ssl === "undefined") {
+            options.ssl = true;
+        }
+
+        // configuration de la ressource
+        var layerCfg = options.configuration;
+
+        if (!layerCfg) {
+            // Check if configuration is loaded
+            if (!Config.isConfigLoaded()) {
+                throw new Error("ERROR : contract key configuration has to be loaded to load Geoportal layers.");
+            }
+            // récupération des autres paramètres nécessaires à la création de la layer
+            var layerId = Config.configuration.getLayerId(options.layer, "WFS");
+            layerCfg = Config.configuration.getLayerConf(layerId);
+            if (!layerCfg) {
+                throw new Error("ERROR : Layer ID not found into the catalogue !?");
+            }
+        }
+
+        // création de la source WFS
+        var olSourceParams;
+        if (options.olParams && options.olParams.sourceParams) {
+            olSourceParams = options.olParams.sourceParams;
+        }
+
+        var wfsSource = new SourceWFS({
+            layer : options.layer,
+            configuration : options.configuration,
+            ssl : options.ssl,
+            apiKey : options.apiKey,
+            olParams : olSourceParams || {
+                minZoom : MINZOOMDEFAULT,
+                maxZoom : MAXZOOMDEFAULT
+            }
+        });
+
+        var layerVectorOptions = {
+            source : wfsSource
+        };
+
+        // récupération des autres paramètres passés par l'utilisateur
+        // avec application des contraintes
+        if (!options.olParams) {
+            options.olParams = {
+                minZoom : MINZOOMDEFAULT,
+                maxZoom : MAXZOOMDEFAULT,
+                style : STYLEBYDEFAULT
+            };
+        } else {
+            Utils.mergeParams({
+                minZoom : MINZOOMDEFAULT,
+                maxZoom : MAXZOOMDEFAULT,
+                style : STYLEBYDEFAULT
+            }, options.olParams);
+        }
+        Utils.mergeParams(layerVectorOptions, options.olParams);
+
+        // création d'une ol.layer.Vector avec les options récupérées ci-dessus.
+        super(layerVectorOptions);
+
+        this.name = options.layer;
+        this.service = "WFS";
+        this.config = layerCfg;
+
+        return this;
+    }
+
+    /**
+     * Get configuration
+     * @returns {Object} - configuration
+     */
+    getConfiguration () {
+        return this.config;
+    }
+    
+    /**
+     * Get legends
+     * @returns  {Array} - legends
+     */
+    getLegends () {
+        return this.getSource()._legends;
+    }
+
+    /**
+     * Get metadata
+     * @returns  {Array} - metadata
+     */
+    getMetadata () {
+        return this.getSource()._metadata;
+    }
+
+    /**
+     * Get description
+     * @returns {String} - description
+     */
+    getDescription () {
+        return this.getSource()._description;
+    }
+
+    /**
+     * Get title
+     * @returns {String} - title
+     */
+    getTitle () {
+        return this.getSource()._title;
+    }
+
+    /**
+     * Get quicklook url
+     * @returns {String} - quicklook
+     */
+    getQuicklookUrl () {
+        return this.getSource()._quicklookUrl;
+    }
+
+    /**
+     * Get originators
+     * @returns {Array} - originators
+     */
+    getOriginators () {
+        return this.getSource()._originators;
+    }
+
+};
+
+export default LayerWFS;
+
+// Expose LayerWFS as ol.layerGeoportalWFS. (for a build bundle)
+if (window.ol && window.ol.layer) {
+    window.ol.layer.GeoportalWFS = LayerWFS;
+}

--- a/src/packages/Layers/LayerWFS.js
+++ b/src/packages/Layers/LayerWFS.js
@@ -10,6 +10,7 @@ import Config from "../Utils/Config";
 // import local with ol dependencies
 import SourceWFS from "./SourceWFS";
 
+const MAXFEATURES = 500;
 const MINZOOMDEFAULT = 15;
 const MAXZOOMDEFAULT = 21;
 const STYLEBYDEFAULT = new Style({
@@ -32,6 +33,7 @@ const STYLEBYDEFAULT = new Style({
  * @type {ol.layer.GeoportalWFS}
  * @param {Object} options            - options for function call.
  * @param {String} options.layer      - Layer name (e.g. "")
+ * @param {Number} [options.maxFeatures] - maximum features (max: 5000) 
  * @param {Object} [options.configuration] - configuration (cf. example) 
  * @param {Boolean} [options.ssl]     - if set true, enforce protocol https (only for nodejs)
  * @param {String} [options.apiKey]   - Access key to Geoportal platform
@@ -39,7 +41,14 @@ const STYLEBYDEFAULT = new Style({
  * @param {Object} [options.olParams.sourceParams] - other options for ol.source.Vector function (see {@link http://openlayers.org/en/latest/apidoc/ol.source.Vector.html ol.source.Vector})
  * @example
  * var layerWFS = new ol.layer.GeoportalWFS({
- *      layer  : "ORTHOIMAGERY.ORTHOPHOTOS"
+ *      layer  : "BDTOPO_V3:batiment",
+ *      maxFeatures: 500,
+ *      olParams : {
+ *          minZoom: 15,
+ *          maxZoom: 21,
+ *          style: new ol.style.Style(...),
+ *          sourceParams: {}
+ *      }
  * });
  * 
  * layerWFS.getLegends();
@@ -100,6 +109,7 @@ var LayerWFS = class LayerWFS extends VectorLayer {
         var wfsSource = new SourceWFS({
             layer : options.layer,
             configuration : options.configuration,
+            maxFeatures : options.maxFeatures || MAXFEATURES,
             ssl : options.ssl,
             apiKey : options.apiKey,
             olParams : olSourceParams || {

--- a/src/packages/Layers/SourceWFS.js
+++ b/src/packages/Layers/SourceWFS.js
@@ -1,0 +1,172 @@
+import VectorSource from "ol/source/Vector";
+import GeoJSON from "ol/format/GeoJSON";
+import { tile as olLoadingstrategyTile } from "ol/loadingstrategy";
+import * as olTilegrid from "ol/tilegrid";
+// import local
+import Utils from "../Utils/Helper";
+import Logger from "../Utils/LoggerByDefault";
+import Config from "../Utils/Config";
+// package.json (extract version)
+import Pkg from "../../../package.json";
+
+var logger = Logger.getLogger("sourcewfs");
+
+/**
+ * @classdesc
+ * Geoportal tile WMS source creation (inherit from ol.source.TileWMS)
+ *
+ * @constructor
+ * @alias ol.source.GeoportalWFS
+ * @type {ol.source.GeoportalWFS}
+ * @extends {ol.source.Vector}
+ * @param {Object} options            - options for function call.
+ * @param {String} options.layer      - Layer name (e.g. "")
+ * @param {Object} [options.maxFeatures] - maximum features (max: 5000) 
+ * @param {Object} [options.configuration] - configuration (cf. example) 
+ * @param {Boolean} [options.ssl]     - if set true, enforce protocol https (only for nodejs)
+ * @param {String} [options.apiKey]   - Access key to Geoportal platform
+ * @param {Array} [options.legends]   - Legends objects associated to the layer
+ * @param {Array} [options.metadata]   - Metadata objects associated to the layer
+ * @param {String} [options.title]   - title of the layer
+ * @param {String} [options.description]   - description of the layer
+ * @param {String} [options.quicklookUrl]   - quicklookUrl of the layer
+ * @param {Object} [options.olParams] - other options for ol.source.Vector function (see {@link http://openlayers.org/en/latest/apidoc/ol.source.Vector.html ol.source.Vector})
+ * @example
+ * var sourceWFS = new ol.source.GeoportalWFS({
+ *      layer  : ""
+ * });
+ */
+var SourceWFS = class SourceWFS extends VectorSource {
+
+    constructor (options) {
+        // check layer params
+        if (!options.layer) {
+            throw new Error("ERROR PARAM_MISSING : layer");
+        }
+        if (typeof options.layer !== "string") {
+            throw new Error("ERROR WRONG TYPE : layer");
+        }
+
+        // par defaut
+        if (typeof options.ssl === "undefined") {
+            options.ssl = true;
+        }
+
+        // configuration de la ressource
+        var layerCfg = options.configuration;
+        var wfsParams = (layerCfg) ? layerCfg.params : null;
+        var apiKey = options.apiKey;
+
+        // 2 solutions pour la récupération des ressources utiles 
+        // * soit depuis la configuration en option
+        // * soit via la variable globale Gp.Config
+        if (!layerCfg) {
+            // Check if configuration is loaded
+            if (!Config.isConfigLoaded()) {
+                throw new Error("ERROR : contract key configuration has to be loaded to load Geoportal layers.");
+            }
+
+            var layerId = Config.configuration.getLayerId(options.layer, "WFS");
+            if (!layerId) {
+                throw new Error(`ERROR : WFS Layer ID ${options.layer} cannot be found in Geoportal Configuration. Make sure that this resource is included in your contract key.`);
+            }
+
+            layerCfg = Config.configuration.getLayerConf(layerId);
+            if (!layerCfg) {
+                throw new Error("ERROR : WFS Layer configuration cannot be found in Geoportal.");
+            }
+
+            apiKey = Config.configuration.getLayerKey(layerId)[0];
+            wfsParams = Config.configuration.getLayerParams(options.layer, "WFS");
+        }
+
+        // si ssl = false on fait du http
+        // par défaut, ssl = true, on fait du https
+        var protocol = options.ssl === false ? "http://" : "https://";
+
+        var urlParams = {
+            "gp-ol-ext" : Pkg.olExtVersion || Pkg.version
+        };
+        if (wfsParams.url.includes("/private/")) {
+            // si l'url est privée
+            // Ajout de la clef d'API fournie par l'utilisateur en prioritée
+            // ou récupérée depuis la configuration
+            var key = options.apiKey || apiKey;
+            if (!key) {
+                throw new Error("ERROR : WFS Layer apiKey cannot be found in Geoportal Configuration.");
+            }
+            urlParams["apikey"] = key;
+        }
+
+        var wfsSourceOptions = {
+            format : new GeoJSON(),
+            loader : function (extent, resolution, projection, success, failure) {
+                var self = this;
+                const maxFeatures = options.maxFeatures || 5000;
+                const layerName = options.layer;
+                const proj = projection.getCode();
+                const url = "https://data.geopf.fr/wfs/ows?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&" +
+                    "typename=" + layerName + "&" +
+                    "outputFormat=application/json&srsname=" + proj + "&" +
+                    "bbox=" + extent.join(",") + "," + proj
+                    + "&maxFeatures=" + maxFeatures + "&count=" + maxFeatures + "&startIndex=0";
+                const xhr = new XMLHttpRequest();
+                xhr.open("GET", url);
+                const onError = function () {
+                    self.removeLoadedExtent(extent);
+                    failure();
+                };
+                xhr.onerror = onError;
+                xhr.onload = function () {
+                    if (xhr.status == 200) {
+                        const features = self.getFormat().readFeatures(xhr.responseText);
+                        self.addFeatures(features);
+                        success(features);
+                    } else {
+                        onError();
+                    }
+                };
+                xhr.send();
+            },
+            strategy : olLoadingstrategyTile(olTilegrid.createXYZ({
+                minZoom : options.olParams.minZoom || 15, 
+                maxZoom : options.olParams.maxZoom || 21, 
+                tileSize : 512
+            })),
+        };
+
+        // récupération des autres paramètres passés par l'utilisateur
+        Utils.mergeParams(wfsSourceOptions, options.olParams);
+
+        // on surcharge les originators (non récupérés depuis configuration de la couche)
+        if (options.olParams && !wfsParams.originators) {
+            wfsParams.originators = options.olParams.attributions;
+        }
+
+        // returns a WMS object, that inherits from ol.source.TileWMS.
+        super(wfsSourceOptions);
+
+        // save originators (to be updated by Originators control)
+        this._originators = wfsParams.originators;
+
+        // save legends and metadata (to be added to LayerSwitcher control)
+        this._legends = options.legends || wfsParams.legends;
+        this._metadata = options.metadata || wfsParams.metadata;
+        this._title = options.title || wfsParams.title;
+        this._description = options.description || wfsParams.description;
+        this._quicklookUrl = options.quicklookUrl || wfsParams.quicklookUrl;
+
+        this.name = options.layer;
+        this.service = "WFS";
+
+        return this;
+    }
+    
+};
+
+export default SourceWFS;
+
+// Expose SourceWFS as ol.source.GeoportalWFTS. (for a build bundle)
+if (window.ol && window.ol.source) {
+    window.ol.source.GeoportalWFS = SourceWFS;
+}

--- a/src/packages/bundle.js
+++ b/src/packages/bundle.js
@@ -70,8 +70,10 @@ import GeoJSON from "./Formats/GeoJSON";
 import WMTS from "./Sources/WMTS";
 import SourceWMTS from "./Layers/SourceWMTS";
 import SourceWMS from "./Layers/SourceWMS";
+import SourceWFS from "./Layers/SourceWFS";
 import LayerWMTS from "./Layers/LayerWMTS";
 import LayerWMS from "./Layers/LayerWMS";
+import LayerWFS from "./Layers/LayerWFS";
 import LayerMapBox from "./Layers/LayerMapBox";
 
 import LayerSwitcher from "./Controls/LayerSwitcher/LayerSwitcher";
@@ -236,10 +238,12 @@ Ol.source = Ol.source || {};
 Ol.source.WMTSExtended = WMTS;
 Ol.source.GeoportalWMTS = SourceWMTS;
 Ol.source.GeoportalWMS = SourceWMS;
+Ol.source.GeoportalWFS = SourceWFS;
 
 Ol.layer = Ol.layer || {};
 Ol.layer.GeoportalWMTS = LayerWMTS;
 Ol.layer.GeoportalWMS = LayerWMS;
+Ol.layer.GeoportalWFS = LayerWFS;
 Ol.layer.GeoportalMapBox = LayerMapBox;
 
 Ol.control = Ol.control || {};
@@ -292,9 +296,11 @@ export {
      * @see ol.control.Legends
      * @see ol.layer.GeoportalWMTS
      * @see ol.layer.GeoportalWMS
+     * @see ol.layer.GeoportalWFS
      * @see ol.layer.GeoportalMapBox
      * @see ol.source.GeoportalWMTS
      * @see ol.source.GeoportalWMS
+     * @see ol.source.GeoportalWFS
      * @see ol.format.KMLExtended
      * @see ol.format.GPXExtended
      * @see ol.format.GeoJSONExtended


### PR DESCRIPTION
# Ajout du format WFS pour les données issues du catalogue

Exemples 
```js
const vectorLayer = new ol.layer.GeoportalWFS({
   layer: "BDTOPO_V3:batiment"
});
```
ou 
```js
const vectorLayer = new ol.layer.Vector({
    source : new ol.source.GeoportalWFS({ layer : "BDTOPO_V3:batiment" })
});
```

Stratégie en place pour recupérer les features :
```text
Le moissonnage est actif
- sur un zoom min/max défini (par défaut, 15 à 21)
- sur l'étendu de la carte

Le nombre d’éléments à moissonner est défini par une valeur max : _maxFeatures_
On moissone tous les éléments de l'étendu par paquet de _maxFeatures_
Le déplacement sur la carte moissonne les données
Le style des données est défini par l'utilisateur (style par défaut d'openlayers) 
Le format d'export des données est en _GeoJSON_
```

:warning: Les performances !