### PR TITLE
fix(Search): Amélioration de la recherche

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.0-265",
-  "date": "17/11/2024",
+  "version": "1.0.0-beta.0-267",
+  "date": "21/11/2024",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/samples-src/pages/tests/SearchEngine/pages-ol-searchengine-modules-dsfr-default.html
+++ b/samples-src/pages/tests/SearchEngine/pages-ol-searchengine-modules-dsfr-default.html
@@ -45,7 +45,7 @@
                     Gp.Logger.enableAll();
                 }
                 var map;
-                window.onload = function() {
+                var createMap = function() {
                     // on cache l'image de chargement du Géoportail.
                     document.getElementById('map').style.backgroundImage = 'none';
 
@@ -76,7 +76,7 @@
                           search : true
                         },
                         searchOptions: {
-                            addToMap: false,
+                            addToMap: true,
                             filterServices : "WMTS,WMS,TMS,WFS",
                             filterLayersPriority : "PLAN.IGN,GEOGRAPHICALGRIDSYSTEMS.MAPS.BDUNI.J1,GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2,CADASTRALPARCELS.PARCELLAIRE_EXPRESS,ORTHOIMAGERY.ORTHOPHOTOS",
                             filterWMTSPriority : true,
@@ -107,6 +107,15 @@
                         console.warn("coordinate", e.coordinates);
                     });
                 };
+                Gp.Services.getConfig({
+                    customConfigFile : "{{ configurl }}",
+                     callbackSuffix : "",
+                     timeOut : 20000,
+                     onSuccess : createMap,
+                     onFailure : (e) => {
+                       console.error(e);
+                     }
+                 });
            </script>
 {{/content}}
 

--- a/samples-src/pages/tests/SearchEngine/pages-ol-searchengine-modules-dsfr-default.html
+++ b/samples-src/pages/tests/SearchEngine/pages-ol-searchengine-modules-dsfr-default.html
@@ -21,6 +21,18 @@
 
 {{#content "body"}}
             <h2>Ajout du moteur de recherche avec les options par défaut</h2>
+            <p>
+                Liste des couches prioritaires :
+                <pre> 
+                PLAN.IGN,
+                GEOGRAPHICALGRIDSYSTEMS.MAPS.BDUNI.J1,
+                GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2,
+                CADASTRALPARCELS.PARCELLAIRE_EXPRESS,
+                ORTHOIMAGERY.ORTHOPHOTOS
+                </pre>
+
+                Ex. si on saisie 'ortho', la couche "photographies aeriennes" devrait sortir en 1ere position.
+            </p>
             <!-- map -->
             <div id="map">
             </div>
@@ -28,6 +40,10 @@
 
 {{#content "js"}}
             <script type="text/javascript">
+                if (window.Gp) {
+                    // activation des loggers
+                    Gp.Logger.enableAll();
+                }
                 var map;
                 window.onload = function() {
                     // on cache l'image de chargement du Géoportail.
@@ -54,14 +70,18 @@
                         displayButtonAdvancedSearch : true,
                         displayButtonGeolocate : true,
                         displayButtonCoordinateSearch : true,
+                        displayButtonClose : false,
                         collapsible : false,
                         resources : {
                           search : true
                         },
                         searchOptions: {
                             addToMap: false,
-                            filterServices : "WMTS,WMS,TMS",
-                            serviceOptions: {}
+                            filterServices : "WMTS,WMS,TMS,WFS",
+                            filterLayersPriority : "PLAN.IGN,GEOGRAPHICALGRIDSYSTEMS.MAPS.BDUNI.J1,GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2,CADASTRALPARCELS.PARCELLAIRE_EXPRESS,ORTHOIMAGERY.ORTHOPHOTOS",
+                            serviceOptions: {
+                                maximumResponses : 20
+                            }
                         },
                         markerUrl : "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAzNiIgd2lkdGg9IjQ4IiBoZWlnaHQ9IjQ4Ij48cGF0aCBmaWxsPSIjMDAwMDkxIiBkPSJNMTguMzY0IDMuNjM2YTkgOSAwIDAgMSAwIDEyLjcyOEwxMiAyMi43MjhsLTYuMzY0LTYuMzY0QTkgOSAwIDAgMSAxOC4zNjQgMy42MzZaTTEyIDhhMiAyIDAgMSAwIDAgNCAyIDIgMCAwIDAgMC00WiIvPjwvc3ZnPg=="
                     });

--- a/samples-src/pages/tests/SearchEngine/pages-ol-searchengine-modules-dsfr-default.html
+++ b/samples-src/pages/tests/SearchEngine/pages-ol-searchengine-modules-dsfr-default.html
@@ -79,6 +79,7 @@
                             addToMap: false,
                             filterServices : "WMTS,WMS,TMS,WFS",
                             filterLayersPriority : "PLAN.IGN,GEOGRAPHICALGRIDSYSTEMS.MAPS.BDUNI.J1,GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2,CADASTRALPARCELS.PARCELLAIRE_EXPRESS,ORTHOIMAGERY.ORTHOPHOTOS",
+                            filterWMTSPriority : true,
                             serviceOptions: {
                                 maximumResponses : 20
                             }

--- a/samples-src/pages/tests/SearchEngine/pages-ol-searchengine-modules-options.html
+++ b/samples-src/pages/tests/SearchEngine/pages-ol-searchengine-modules-options.html
@@ -142,7 +142,7 @@
                         },
                         searchOptions : {
                           addToMap : bAddToMapAuto,
-                          filterServices : "WMTS,TMS",
+                          filterServices : "WMTS,TMS,WFS",
                           filterVectortiles : "PLAN.IGN,PCI",
                           updateVectortiles : true,
                           serviceOptions : {
@@ -172,6 +172,11 @@
                             break;
                           case "TMS":
                             layer = new ol.layer.GeoportalMapBox({
+                              layer : name
+                            });
+                            break;
+                          case "WFS":
+                            layer = new ol.layer.GeoportalWFS({
                               layer : name
                             });
                           default:

--- a/samples-src/pages/tests/Services/pages-ol-searchservice-modules-default.html
+++ b/samples-src/pages/tests/Services/pages-ol-searchservice-modules-default.html
@@ -112,6 +112,10 @@
                         class="input" 
                         type="number" 
                         value="10"/>
+                    <label for="conf-wmts">prioriser les couches de type WMTS</label>
+                    <input id="conf-wmts" 
+                        class="input" 
+                        type="checkbox"/>
                     <button id="load">Load</button>
                 </div>
                 <div class="run">
@@ -167,12 +171,13 @@
                     Search.setIndex(document.getElementById("conf-index").value);
                     Search.setUrl(document.getElementById("conf-url").value);
                     Search.setSize(document.getElementById("conf-size").value);
-                    Search.setFiltersByService(document.getElementById("conf-services").value);
-                    Search.setFiltersByLayerPriority(document.getElementById("conf-layers").value);
                     Search.setFields(document.getElementById("conf-fields").value);
                     Search.setMaximumResponses(document.getElementById("conf-max").value);
+                    Search.setFiltersByService(document.getElementById("conf-services").value);
+                    Search.setFiltersByLayerPriority(document.getElementById("conf-layers").value);
                     Search.setFiltersByTMS(document.getElementById("conf-vector").value);
                     Search.setFiltersByProjection(document.getElementById("conf-proj").value);
+                    Search.setFiltersWMTSPriority(document.getElementById("conf-wmts").checked);
                 });
 
                 document.getElementById("update").addEventListener("click", (e) => {

--- a/samples-src/pages/tests/Services/pages-ol-searchservice-modules-default.html
+++ b/samples-src/pages/tests/Services/pages-ol-searchservice-modules-default.html
@@ -80,6 +80,11 @@
                         class="input" 
                         type="text" 
                         value="WMTS,TMS"/>
+                    <label for="conf-services">filtres sur les couches prioritaires</label>
+                    <input id="conf-layers" 
+                        class="input" 
+                        type="text" 
+                        value=""/>
                     <label for="conf-vector">filtres sur les couches vecteurs tuilés</label>
                     <textarea id="conf-vector" 
                         rows="2"
@@ -124,7 +129,7 @@
                         <label for="results-names">Liste des couches :</label>
                         <select name="names" id="results-names"></select>
                     </p>
-                    <textarea id="results-textarea" name="textarea" rows="5" cols="30"></textarea>
+                    <textarea id="results-textarea" name="textarea" rows="100" cols="30"></textarea>
                 </div>
 
             </div>
@@ -163,6 +168,7 @@
                     Search.setUrl(document.getElementById("conf-url").value);
                     Search.setSize(document.getElementById("conf-size").value);
                     Search.setFiltersByService(document.getElementById("conf-services").value);
+                    Search.setFiltersByLayerPriority(document.getElementById("conf-layers").value);
                     Search.setFields(document.getElementById("conf-fields").value);
                     Search.setMaximumResponses(document.getElementById("conf-max").value);
                     Search.setFiltersByTMS(document.getElementById("conf-vector").value);

--- a/src/packages/CSS/Controls/SearchEngine/DSFRsearchEngineStyle.css
+++ b/src/packages/CSS/Controls/SearchEngine/DSFRsearchEngineStyle.css
@@ -158,6 +158,7 @@ dialog[id^=GPgeocodeResultsList] {
   position: absolute;
   height: fit-content;
   background-color: var(--background-default-grey);
+  max-height: unset;
 }
 
 div[id^=GPautoCompleteList] {

--- a/src/packages/Controls/Catalog/Catalog.js
+++ b/src/packages/Controls/Catalog/Catalog.js
@@ -13,6 +13,7 @@ import Draggable from "../../Utils/Draggable";
 import Config from "../../Utils/Config";
 
 // import local des layers
+import GeoportalWFS from "../../Layers/LayerWFS";
 import GeoportalWMS from "../../Layers/LayerWMS";
 import GeoportalWMTS from "../../Layers/LayerWMTS";
 import GeoportalMapBox from "../../Layers/LayerMapBox";
@@ -90,7 +91,6 @@ var logger = Logger.getLogger("widget");
  * @todo filtrage des couches
  * @todo type:service
  * @todo validation du schema
- * @fixme enregistrer et afficher du format WFS !?
  */
 var Catalog = class Catalog extends Control {
 
@@ -786,6 +786,12 @@ var Catalog = class Catalog extends Control {
                 layer = new GeoportalMapBox({
                     layer : name
                 });
+                break;
+            case "WFS":
+                layer = new GeoportalWFS({
+                    layer : name
+                });
+                break;
             default:
                 break;
         }
@@ -971,9 +977,9 @@ var Catalog = class Catalog extends Control {
         // - ajout ou pas de la couche à la carte
         // - envoi d'un evenement avec la conf tech
 
-        var id = e.target.id.split("_")[1];
-        var name = id.split("-")[0];
-        var service = id.split("-")[1];
+        var ds = e.target.dataset.layer;
+        var name = ds.substring(0, ds.lastIndexOf(":"));
+        var service = ds.substring(ds.lastIndexOf(":") + 1);
         var layer = {}; // TODO fournir la conf tech
 
         if (e.target.checked) {

--- a/src/packages/Controls/Catalog/CatalogDOM.js
+++ b/src/packages/Controls/Catalog/CatalogDOM.js
@@ -432,7 +432,7 @@ var CatalogDOM = {
                         type="checkbox"
                         data-layer="${name}:${service}"
                         aria-describedby="checkboxes-messages-${categoryId}-${i}_${name}-${service}">
-                    <label class="GPlabelActive fr-label" for="checkboxes-${categoryId}-${i}_${name}-${service}" title="${title}">
+                    <label class="GPlabelActive fr-label" for="checkboxes-${categoryId}-${i}_${name}-${service}" title="nom technique : ${name}">
                         ${title} (${service})
                     </label>
                     <div class="fr-messages-group" id="checkboxes-messages-${categoryId}-${i}_${name}-${service}" aria-live="assertive"></div>

--- a/src/packages/Controls/SearchEngine/SearchEngine.js
+++ b/src/packages/Controls/SearchEngine/SearchEngine.js
@@ -77,6 +77,7 @@ var logger = Logger.getLogger("searchengine");
  * @param {Object}  [options.searchOptions = {}] - options of search service
  * @param {Boolean} [options.searchOptions.addToMap = true] - add layer automatically to map, defaults to true.
  * @param {String}  [options.searchOptions.filterServices] - filter on a list of search services, each field is separated by a comma. "WMTS,TMS" by default
+ * @param {String}  [options.searchOptions.filterLayersPriority] - filter on priority layers in search, each field is separated by a comma. "PLAN.IGN,ORTHOIMAGERY.ORTHOPHOTOS" by default
  * @param {String}  [options.searchOptions.filterVectortiles] - filter on list of search layers only on service TMS, each field is separated by a comma. "PLAN.IGN, ..." by default
  * @param {Boolean} [options.searchOptions.updateVectortiles = false] - updating the list of search layers only on service TMS
  * @param {Object}  [options.searchOptions.serviceOptions] - options of search service
@@ -358,6 +359,9 @@ var SearchEngine = class SearchEngine extends Control {
                 }
                 if (this.options.searchOptions.filterServices) {
                     Search.setFiltersByService(this.options.searchOptions.filterServices);
+                }
+                if (this.options.searchOptions.filterLayersPriority) {
+                    Search.setFiltersByLayerPriority(this.options.searchOptions.filterLayersPriority);
                 }
                 if (this.options.searchOptions.filterVectortiles) {
                     Search.setFiltersByTMS(this.options.searchOptions.filterVectortiles);

--- a/src/packages/Controls/SearchEngine/SearchEngine.js
+++ b/src/packages/Controls/SearchEngine/SearchEngine.js
@@ -77,7 +77,8 @@ var logger = Logger.getLogger("searchengine");
  * @param {Object}  [options.searchOptions = {}] - options of search service
  * @param {Boolean} [options.searchOptions.addToMap = true] - add layer automatically to map, defaults to true.
  * @param {String}  [options.searchOptions.filterServices] - filter on a list of search services, each field is separated by a comma. "WMTS,TMS" by default
- * @param {String}  [options.searchOptions.filterLayersPriority] - filter on priority layers in search, each field is separated by a comma. "PLAN.IGN,ORTHOIMAGERY.ORTHOPHOTOS" by default
+ * @param {String}  [options.searchOptions.filterWMTSPriority] - filter on priority WMTS layer in search, each field is separated by a comma. "PLAN.IGN,ORTHOIMAGERY.ORTHOPHOTOS" by default
+ * @param {Boolean}  [options.searchOptions.filterLayersPriority = false] - filter on priority layers in search, false by default
  * @param {String}  [options.searchOptions.filterVectortiles] - filter on list of search layers only on service TMS, each field is separated by a comma. "PLAN.IGN, ..." by default
  * @param {Boolean} [options.searchOptions.updateVectortiles = false] - updating the list of search layers only on service TMS
  * @param {Object}  [options.searchOptions.serviceOptions] - options of search service
@@ -362,6 +363,9 @@ var SearchEngine = class SearchEngine extends Control {
                 }
                 if (this.options.searchOptions.filterLayersPriority) {
                     Search.setFiltersByLayerPriority(this.options.searchOptions.filterLayersPriority);
+                }
+                if (this.options.searchOptions.filterWMTSPriority) {
+                    Search.setFilterWMTSPriority(this.options.searchOptions.filterWMTSPriority);
                 }
                 if (this.options.searchOptions.filterVectortiles) {
                     Search.setFiltersByTMS(this.options.searchOptions.filterVectortiles);

--- a/src/packages/Controls/SearchEngine/SearchEngineDOM.js
+++ b/src/packages/Controls/SearchEngine/SearchEngineDOM.js
@@ -693,7 +693,7 @@ var SearchEngineDOM = {
         var container = document.createElement("select");
         container.id = this._addUID("GPautocompleteResultsLocation");
         container.className = "GPelementHidden gpf-hidden gpf-select";
-        container.size = 6;
+        container.size = 20;
         container.autofocus = true;
         return container;
     },
@@ -774,7 +774,7 @@ var SearchEngineDOM = {
         div.className = "GPautoCompleteProposal gpf-panel__items gpf-panel__items_searchengine";
         div.innerHTML = suggest.title + " (" + suggest.service + ")";
         div.dataset.layer = suggest.name;
-        div.title = suggest.description;
+        div.title = `${suggest.description} (nom technique : ${suggest.name})`;
         if (div.addEventListener) {
             div.addEventListener("click", function (e) {
                 self.onSearchedResultsItemClick(e);

--- a/src/packages/Layers/SourceWFS.js
+++ b/src/packages/Layers/SourceWFS.js
@@ -158,6 +158,7 @@ var SourceWFS = class SourceWFS extends VectorSource {
                 maxZoom : options.olParams.maxZoom || 21, 
                 tileSize : 512
             })),
+            crossOrigin : "anonymous"
         };
 
         // récupération des autres paramètres passés par l'utilisateur

--- a/src/packages/Layers/SourceWMS.js
+++ b/src/packages/Layers/SourceWMS.js
@@ -102,7 +102,6 @@ var SourceWMS = class SourceWMS extends TileWMSSource {
 
         var wmsSourceOptions = {
             // tracker extension openlayers
-            // FIXME : gp-ext version en mode AMD
             url : Gp.Helper.normalyzeUrl(wmsParams.url.replace(/(http|https):\/\//, protocol), urlParams, false),
             params : {
                 SERVICE : "WMS",
@@ -110,7 +109,8 @@ var SourceWMS = class SourceWMS extends TileWMSSource {
                 VERSION : wmsParams.version,
                 STYLES : wmsParams.styles,
                 FORMAT : wmsParams.format
-            }
+            },
+            crossOrigin : "anonymous"
             // ,
             // attributions : [
             //     new ol.Attribution({

--- a/src/packages/Layers/SourceWMTS.js
+++ b/src/packages/Layers/SourceWMTS.js
@@ -118,7 +118,8 @@ var SourceWMTS = class SourceWMTS extends WMTSExtended {
                 resolutions : wmtsParams.nativeResolutions,
                 matrixIds : wmtsParams.matrixIds,
                 origin : [Object.values(wmtsParams.tileMatrices)[0].topLeftCorner.x, Object.values(wmtsParams.tileMatrices)[0].topLeftCorner.y]
-            })
+            }),
+            crossOrigin : "anonymous"
         };
 
         // récupération des autres paramètres passés par l'utilisateur

--- a/src/packages/Services/Search.js
+++ b/src/packages/Services/Search.js
@@ -5,6 +5,8 @@
  * 
  * @module Search
  * @alias module:~services/Search
+ * @fixme en attente d'evolution du service pour le filtrage sur le type 
+ * afin d'écarter des reponses de la recherche (ex. DOWNLOAD)
  * @see https://geoservices.ign.fr/documentation/services/services-geoplateforme/service-geoplateforme-de-recherche
  */
 
@@ -18,22 +20,52 @@ let controller = new AbortController();
 /** index de recherche */
 let m_index = "geoplateforme";
 
-/** liste des champs de recherche */
+/** 
+ * liste des champs de recherche
+ * valeurs : "title, description, theme, keywords, layer_name"
+ */
 let m_fields = "title,layer_name";
 
 /** nombre de suggestions du service */
 let m_size = "1000";
 
 /** nombre maximum de réponses */
-let m_maximumResponses = 5;
+let m_maximumResponses = 10;
 
-/** liste des filtres sur les services */
+/** 
+ * liste des filtres sur les services
+ * @type {Array}
+ * @example
+ * valeurs : ["WMTS", "TMS", "WMS", "WFS", ...]
+ */
 let m_filterByService = ["WMTS", "TMS"];
 
-/** liste des couches à exclure avec ces projections */
+/** 
+ * liste des couches à exclure avec ces projections 
+ * @type {Array}
+ * @example
+ * ["EPSG:4326",...]
+ */
 let m_filterByProjection = [];
 
-/** filtres les services uniquement en TMS */
+/** 
+ * liste des couches priortaires dans la recherche
+ * sous la forme : [name]
+ * > mettre un poids au score des couches que l'on souhaite 
+ * > mettre en avant dans la recherche
+ * 
+ * @type {Array}
+ * @example
+ * "PLAN.IGN$GEOPORTAIL:GPP:TMS" ou "PLAN.IGN:TMS" ou "PLAN.IGN"
+ * 
+ */
+let m_filterByLayerPriority = [];
+
+/** 
+ * filtres les services uniquement en TMS
+ * @fixme en attente d'evolution du service pour determiner les "real" couches vecteurs
+ * @type {Array}
+ */
 let m_filterByTMS = [
     "ADMIN_EXPRESS",
     "ISOHYPSE",
@@ -61,7 +93,7 @@ const target = new EventTarget();
  * @returns {Object} json
  * @example
  * {
- *   "originators": {},
+ *   "attribution": {},
  *   "srs": [
  *     "EPSG:3857"
  *   ],
@@ -171,34 +203,45 @@ const suggest = async (text) => {
         return;
     }
 
-    // Attribution d'un score bonus aux couches WMTS puis retriage des résultats
+    // INFO
+    // Attribution d'un score bonus aux couches priortaires, puis retriage des résultats en fonction du score
     for (let i = 0; i < results.length; i++) {
         const result = results[i];
-        var scoreBonus = result.source.type === "WMTS" || result.source.type === "TMS" ? 10 : 0;
-        results[i].score += scoreBonus;
+        const found = m_filterByLayerPriority.findIndex((element) => { return element.includes(result.source.layer_name); });
+        if (found >= 0) {
+            results[i].score += 100;
+            console.log("found", result);
+        }
     }
     results.sort((a, b) => b.score - a.score);
 
     for (let i = 0; i < results.length; i++) {
         const result = results[i];
         var services = (m_filterByService.length === 0 || m_filterByService.includes(result.source.type));
+        // FIXME 
+        // utilisation le champ : result.source.open ?
         if (services) {
             if (unique().length >= m_maximumResponses) {
                 break;
             }
-            // FIXME champs possibles mais pas toujours remplis :
+            // INFO
+            // champs possibles mais pas toujours remplis :
             // srs[], attributions{}, extent{}, metada_url[]
             var o = {
-                originators : result.source.attribution || {},
+                attribution : result.source.attribution || {},
                 srs : result.source.srs || [],
                 keywords : result.source.keywords || [],
                 extent : result.source.extent || {},
-                metadata : result.source.metadata_urls || [],
-                name : result.source.layer_name,
-                title : result.source.title,
+                metadata : result.source.metadata_urls || [], // mapping ?
+                name : result.source.layer_name || "",
+                title : result.source.title || "",
                 description : result.source.description,
-                service : result.source.type,
-                url : result.source.url
+                service : result.source.type || "",
+                url : result.source.url || "",
+                tech : result.source.tech || {},
+                tags : result.source.tags || {},
+                theme : result.source.theme || "",
+                producer : result.source.producer || ""
             };
             if (m_filterByTMS.length) {
                 if ((o.service === "WMTS" && m_filterByTMS.includes(o.name)) ||
@@ -213,6 +256,7 @@ const suggest = async (text) => {
                 }
             }
             m_suggestions.push(o);
+            console.log("suggestion", result);
         }
     }
 
@@ -239,6 +283,18 @@ const unique = () => {
             t.description === value.description
         ))
     );
+    // INFO
+    // soit on trie, 
+    // soit on laisse le trie natif en fonction du score
+    // .sort((a, b) => {
+    //     // INFO
+    //     // titleA (WMTS)
+    //     // titleA (WMS)
+    //     // titleA (WFS)
+    //     // titleA (TMS)
+    //     // titleB (WMTS)
+    //     return a.title.localeCompare(b.title) || b.service - a.service;
+    // });
 };
 
 /**
@@ -317,7 +373,7 @@ const setMaximumResponses = (value) => {
 };
 /**
  * Filtre sur la liste des services à selectionner
- * @param {Array} value - liste de service
+ * @param {String} value - liste de service
  * @see m_filterByService
  */
 const setFiltersByService = (value) => {
@@ -325,15 +381,23 @@ const setFiltersByService = (value) => {
 };
 /**
  * Filtre sur les couches à exclure
- * @param {Array} value - liste des projections
+ * @param {String} value - liste des projections
  * @see m_filterByProjection
  */
 const setFiltersByProjection = (value) => {
     m_filterByProjection = value === "" ? [] : value.split(",");
 };
 /**
+ * Filtre sur les couches prioritaires dans la recherche
+ * @param {String} value - liste des couches prioritaires
+ * @see m_filterByLayerPriority
+ */
+const setFiltersByLayerPriority = (value) => {
+    m_filterByLayerPriority = value === "" ? [] : value.split(",");
+};
+/**
  * Filtre sur les "purs" couches vecteurs tuilés
- * @param {Array} value - liste des couches
+ * @param {String} value - liste des couches
  * @see m_filterByTMS
  */
 const setFiltersByTMS = (value) => {
@@ -382,5 +446,6 @@ export default {
     setFiltersByService,
     setFiltersByTMS,
     updateFilterByTMS,
-    setFiltersByProjection
+    setFiltersByProjection,
+    setFiltersByLayerPriority
 };

--- a/src/packages/Services/Search.js
+++ b/src/packages/Services/Search.js
@@ -342,7 +342,7 @@ const inventory = (results) => {
             inventory[name] ||= type === "WMTS";
         }
     }
-    console.log(inventory);
+    // console.log(inventory);
     return inventory;
 };
 


### PR DESCRIPTION
EDIT : fixes #269 (cf https://github.com/IGNF/geopf-extensions-openlayers/pull/267/commits/68bec559205a09587a7ef665ab1ad197dbf4997f)

# Divers améliorations sur le service de recherche et le widget **SearchEngine**

- issue #254 
```js
// au niveau du service
Search.setFilterWMTSPriority(true);

// option sur SearchEngine
var search = new ol.control.SearchEngine({
   searchOptions: {
      filterWMTSPriority : true
   }
});
```
avec ou sans option :
![image](https://github.com/user-attachments/assets/88838508-5606-4fc5-a33d-c837adc32732)
![image](https://github.com/user-attachments/assets/a73630ed-158b-410d-ae97-316c12ec066c)

- Mise en avant de couches dans la recherche

> ces couches seront proposées avec un score plus élevé afin qu'elles apparaissent en 1ere position
```js
// au niveau du service 
const lstLayers = "PLAN.IGN,GEOGRAPHICALGRIDSYSTEMS.MAPS.BDUNI.J1,GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2,CADASTRALPARCELS.PARCELLAIRE_EXPRESS,ORTHOIMAGERY.ORTHOPHOTOS";
Search.setFiltersByLayerPriority(lstLayers);

// option sur SearchEngine
var search = new ol.control.SearchEngine({
   searchOptions: {
      filterLayersPriority: lstLayers
   }
});
```
avec ou sans option :
![image](https://github.com/user-attachments/assets/0ed8808e-1e93-444b-84d2-e246e48b0038)
![image](https://github.com/user-attachments/assets/1cb0b3ac-3fe2-4b53-8ad0-ff11d313540a)

**note** : 
> Le nom de la couche à mettre en avant peut être de la forme : 
> "PLAN.IGN$GEOPORTAIL:GPP:TMS" ou "PLAN.IGN:TMS" ou "PLAN.IGN"

- La jsdoc est à jour sur le service de recherche 
![image](https://github.com/user-attachments/assets/151a8fa0-4eb7-4b8f-a46d-8930889160b0)

- hors périmètre de la PR : 
  -  le widget **Catalog** affiche et visualise les couches WFS
  - l'option **crossOrigin** est en place pour les couches du catalogue, ceci afin de répondre à un besoin d'imprimer le canvas
