### PR TITLE
feat(controlList): add controllist widget

### DIFF
--- a/build/webpack/controls.webpack.config.js
+++ b/build/webpack/controls.webpack.config.js
@@ -17,10 +17,10 @@ module.exports = (env, argv) => {
         var name = names[index];
         var moduledir = name;
         var key = name;
-        
+
         switch (name) {
             case "GeoportalAttribution":
-                moduledir = "Attribution"; 
+                moduledir = "Attribution";
                 // ras
                 break;
             case "Drawing":
@@ -88,24 +88,27 @@ module.exports = (env, argv) => {
             case "Territories":
                 // ras
                 break;
+            case "ControlList":
+                // ras
+                break;
             case "Editor":
                 // ras
                 break;
             case "GeoportalZoom":
-                moduledir = "Zoom"; 
+                moduledir = "Zoom";
                 break;
             case "GeoportalFullScreen":
-                moduledir = "FullScreen"; 
+                moduledir = "FullScreen";
                 // ras
                 break;
             case "GeoportalOverviewMap":
-                moduledir = "OverviewMap"; 
+                moduledir = "OverviewMap";
                 // ras
                 break;
             default:
                 break;
         }
-    
+
         entries["GpfExtOl" + key] = path.join(rootdir, "src", "packages", "Controls", moduledir, name + ".js");
         console.log("####", key, entries["GpfExtOl" + key], externals);
     }

--- a/build/webpack/extend.themes.webpack.js
+++ b/build/webpack/extend.themes.webpack.js
@@ -32,7 +32,8 @@ module.exports = (env, argv) => {
                 path.join(rootdir, "src", "packages", "CSS", "Controls/OverviewMap", "GPFoverviewMapStyle.css"),
                 path.join(rootdir, "src", "packages", "CSS", "Controls/Legends", "GPFlegendsStyle.css"),
                 path.join(rootdir, "src", "packages", "CSS", "Controls/Catalog", "GPFcatalogStyle.css"),
-                path.join(rootdir, "src", "packages", "CSS", "Controls/Territories", "GPFterritoriesStyle.css")                
+                path.join(rootdir, "src", "packages", "CSS", "Controls/Territories", "GPFterritoriesStyle.css"),
+                path.join(rootdir, "src", "packages", "CSS", "Controls/ControlList", "GPFcontrolListStyle.css"),
             ],
             // CSS themes dsfr
             "Dsfr" : [
@@ -64,7 +65,8 @@ module.exports = (env, argv) => {
                 path.join(rootdir, "src", "packages", "CSS", "Controls/OverviewMap", "DSFRoverviewMapStyle.css"),
                 path.join(rootdir, "src", "packages", "CSS", "Controls/Legends", "DSFRlegendsStyle.css"),
                 path.join(rootdir, "src", "packages", "CSS", "Controls/Catalog", "DSFRcatalogStyle.css"),
-                path.join(rootdir, "src", "packages", "CSS", "Controls/Territories", "DSFRterritoriesStyle.css")
+                path.join(rootdir, "src", "packages", "CSS", "Controls/Territories", "DSFRterritoriesStyle.css"),
+                path.join(rootdir, "src", "packages", "CSS", "Controls/ControlList", "DSFRcontrolListStyle.css"),
             ],
         }
     };

--- a/build/webpack/modules.webpack.config.js
+++ b/build/webpack/modules.webpack.config.js
@@ -55,6 +55,7 @@ module.exports = (env, argv) => {
             "GpfExtOlLegends" : path.join(rootdir, "src", "packages", "Controls/Legends", "Legends.js"),
             "GpfExtOlCatalog" : path.join(rootdir, "src", "packages", "Controls/Catalog", "Catalog.js"),
             "GpfExtOlTerritories" : path.join(rootdir, "src", "packages", "Controls/Territories", "Territories.js"),
+            "GpfExtOlControlList" : path.join(rootdir, "src", "packages", "Controls/ControlList", "ControlList.js"),
             // Formats étendus
             "GpfExtOlFormats" : [
                 path.join(rootdir, "src", "packages", "Formats", "GeoJSON.js"),
@@ -227,7 +228,7 @@ module.exports = (env, argv) => {
         plugins : [
             /** EXECUTION DU LINTER */
             new ESLintWebpackPlugin({
-                
+
             }),
             /** CSS avec IMAGES en base64 */
             new MiniCssExtractPlugin({

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.0-268",
+  "version": "1.0.0-beta.0-272",
   "date": "22/11/2024",
   "module": "src/index.js",
   "directories": {},

--- a/samples-src/pages/tests/Default/pages-ol-modules-dsfr-default.html
+++ b/samples-src/pages/tests/Default/pages-ol-modules-dsfr-default.html
@@ -45,6 +45,8 @@
         <script src="{{ baseurl }}/dist/modules/GpfExtOlLegends.js"></script>
         <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlTerritories.css" />
         <script src="{{ baseurl }}/dist/modules/GpfExtOlTerritories.js"></script>
+        <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlControlList.css" />
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlControlList.js"></script>
 {{/content}}
 
 {{#content "head"}}
@@ -70,11 +72,8 @@
 {{#content "js"}}
             <script type="text/javascript">
               const scaleControl = new ol.control.ScaleLine({
-                  units: 'metric',
-                  bar: true,
-                  steps: 4,
-                  text: true,
-                  minWidth: 140,
+                units: 'metric',
+                bar: false,
               });
               var createMap = function () {
                 // on cache l'image de chargement du Géoportail.
@@ -154,7 +153,8 @@
 
                 var route = new ol.control.Route({
                   draggable: true,
-                  position : "bottom-right"
+                  position : "bottom-right",
+                  listable: true,
                 });
                 map.addControl(route);
 
@@ -165,7 +165,8 @@
 
                 var reverse = new ol.control.ReverseGeocode({
                   draggable: true,
-                  position : "top-right"
+                  position : "top-right",
+                  listable: true,
                 });
                 map.addControl(reverse);
 
@@ -211,9 +212,16 @@
                     position: "bottom-left",
                     direction: "vertical",
                     panel: true,
-                    auto: true
+                    auto: true,
+                    listable: true,
                 });
                 map.addControl(territories);
+
+                var controlList = new ol.control.ControlList({
+                    draggable: false,
+                    position: "bottom-right",
+                });
+                map.addControl(controlList);
               };
 
               Gp.Services.getConfig({

--- a/samples-src/pages/tests/Default/pages-ol-modules-dsfr-default.html
+++ b/samples-src/pages/tests/Default/pages-ol-modules-dsfr-default.html
@@ -155,6 +155,7 @@
                   draggable: true,
                   position : "bottom-right",
                   listable: true,
+                  description: "Calculez un itinéraire véhicule ou piéton entre deux ou plusieurs points",
                 });
                 map.addControl(route);
 

--- a/samples-src/pages/tests/Default/pages-ol-modules-dsfr-default.html
+++ b/samples-src/pages/tests/Default/pages-ol-modules-dsfr-default.html
@@ -221,6 +221,7 @@
                 var controlList = new ol.control.ControlList({
                     draggable: false,
                     position: "bottom-right",
+                    controlCatalogElement: document.getElementById("sampleLightDark"),
                 });
                 map.addControl(controlList);
               };

--- a/samples-src/templates/packages/ol-sample-bundle-dsfr-layout.hbs
+++ b/samples-src/templates/packages/ol-sample-bundle-dsfr-layout.hbs
@@ -17,7 +17,7 @@
     <body>
         <h1>Extension Géoportail pour OpenLayers</h1>
 
-        <button onclick="document.documentElement.dataset.frTheme = document.documentElement.dataset.frTheme == 'dark' ? 'light' : 'dark'">Toggle Darkmode / Lightmode</button>
+        <button id="sampleLightDark" onclick="document.documentElement.dataset.frTheme = document.documentElement.dataset.frTheme == 'dark' ? 'light' : 'dark'">Toggle Darkmode / Lightmode</button>
 
         {{#block "body"}}
         {{/block}}

--- a/samples-src/templates/packages/ol-sample-modules-dsfr-layout.hbs
+++ b/samples-src/templates/packages/ol-sample-modules-dsfr-layout.hbs
@@ -17,7 +17,7 @@
     <body>
         <h1>Extension Géoportail pour OpenLayers</h1>
 
-        <button onclick="document.documentElement.dataset.frTheme = document.documentElement.dataset.frTheme == 'dark' ? 'light' : 'dark'">Toggle Darkmode / Lightmode</button>
+        <button id="sampleLightDark" onclick="document.documentElement.dataset.frTheme = document.documentElement.dataset.frTheme == 'dark' ? 'light' : 'dark'">Toggle Darkmode / Lightmode</button>
 
         {{#block "body"}}
         {{/block}}

--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,7 @@ export { default as GeoportalOverviewMap } from "./packages/Controls/OverviewMap
 export { default as Legends } from "./packages/Controls/Legends/Legends";
 export { default as Catalog } from "./packages/Controls/Catalog/Catalog";
 export { default as Territories } from "./packages/Controls/Territories/Territories";
+export { default as ControlList } from "./packages/Controls/ControlList/ControlList";
 
 // proj4
 export { default as Proj4 } from "proj4";

--- a/src/packages/CSS/Controls/ControlList/DSFRcontrolListStyle.css
+++ b/src/packages/CSS/Controls/ControlList/DSFRcontrolListStyle.css
@@ -11,6 +11,10 @@ dialog[id^="GPcontrolListPanel-"] .gpf-panel__content {
   overflow: auto;
 }
 
+dialog[id^="GPcontrolListPanel-"] .gpf-panel__content:not(:has(~ .gpf-panel__footer)) {
+  padding-bottom: 2rem;
+}
+
 dialog[id^="GPcontrolListPanel-"] .gpf-panel__content > div {
   display: flex;
   flex-direction: row;

--- a/src/packages/CSS/Controls/ControlList/DSFRcontrolListStyle.css
+++ b/src/packages/CSS/Controls/ControlList/DSFRcontrolListStyle.css
@@ -1,0 +1,45 @@
+div[id^="GPcontrolList-"] .GPshowOpen > span {
+  font-size: 32px;
+  position: absolute;
+  transform: translate(-5px, -2px);
+}
+
+dialog[id^="GPcontrolListPanel-"] .gpf-panel__content {
+  display: flex;
+  flex-direction: column;
+  padding: 0 1.5rem;
+}
+
+dialog[id^="GPcontrolListPanel-"] .gpf-panel__content > div {
+  display: flex;
+  flex-direction: row;
+  column-gap: 1rem;
+  align-items: center;
+  padding: 0.5rem 0.5rem;
+}
+
+dialog[id^="GPcontrolListPanel-"] .gpf-panel__content > div:hover {
+  background-color: var(--hover);
+}
+
+dialog[id^="GPcontrolListPanel-"] .gpf-panel__content > div:hover > button {
+  background-color: var(--hover);
+}
+
+dialog[id^="GPcontrolListPanel-"] .gpf-panel__content > div > button {
+  height: 40px;
+  width: 40px;
+}
+
+dialog[id^="GPcontrolListPanel-"] .gpf-panel__content > div > button::after {
+  background-color: var(--text-default-grey);
+}
+
+dialog[id^="GPcontrolListPanel-"] .gpf-panel__footer {
+  padding: 2rem;
+}
+
+dialog[id^="GPcontrolListPanel-"] .gpf-panel__footer > button {
+  width: 100%;
+  justify-content: center;
+}

--- a/src/packages/CSS/Controls/ControlList/DSFRcontrolListStyle.css
+++ b/src/packages/CSS/Controls/ControlList/DSFRcontrolListStyle.css
@@ -8,6 +8,7 @@ dialog[id^="GPcontrolListPanel-"] .gpf-panel__content {
   display: flex;
   flex-direction: column;
   padding: 0 1.5rem;
+  overflow: auto;
 }
 
 dialog[id^="GPcontrolListPanel-"] .gpf-panel__content > div {
@@ -46,7 +47,8 @@ dialog[id^="GPcontrolListPanel-"] .gpf-panel__content > div > div > span:nth-chi
 }
 
 dialog[id^="GPcontrolListPanel-"] .gpf-panel__footer {
-  padding: 2rem;
+  padding: 1rem 2rem 2rem 2rem;
+  background-color: var(--background-lifted-grey);
 }
 
 dialog[id^="GPcontrolListPanel-"] .gpf-panel__footer > button {

--- a/src/packages/CSS/Controls/ControlList/DSFRcontrolListStyle.css
+++ b/src/packages/CSS/Controls/ControlList/DSFRcontrolListStyle.css
@@ -35,6 +35,16 @@ dialog[id^="GPcontrolListPanel-"] .gpf-panel__content > div > button::after {
   background-color: var(--text-default-grey);
 }
 
+dialog[id^="GPcontrolListPanel-"] .gpf-panel__content > div > div {
+  display: flex;
+  flex-direction: column;
+}
+
+dialog[id^="GPcontrolListPanel-"] .gpf-panel__content > div > div > span:nth-child(2) {
+  color: var(--text-mention-grey);
+  font-size: 0.75rem;
+}
+
 dialog[id^="GPcontrolListPanel-"] .gpf-panel__footer {
   padding: 2rem;
 }

--- a/src/packages/CSS/Controls/ControlList/GPFcontrolList.css
+++ b/src/packages/CSS/Controls/ControlList/GPFcontrolList.css
@@ -1,0 +1,25 @@
+/* Showing/hiding */
+
+button[id^=GPshowControlListPicto][aria-pressed="false"] + dialog {
+  display: none;
+  visibility: hidden;
+  opacity: 0%;
+}
+
+button[id^="GPshowControlListPicto-"][aria-pressed="true"] + dialog {
+  display: flex;
+  flex-direction: column;
+  visibility: visible;
+  opacity: 100%;
+  width: 370px;
+  height: initial;
+  max-height: inherit;
+}
+
+dialog[id^="GPcontrolListPanel-"] {
+  position: absolute;
+  left: 34px;
+  top: 0px;
+  height: inherit;
+}
+

--- a/src/packages/CSS/Controls/ControlList/GPFcontrolList.css
+++ b/src/packages/CSS/Controls/ControlList/GPFcontrolList.css
@@ -12,8 +12,6 @@ button[id^="GPshowControlListPicto-"][aria-pressed="true"] + dialog {
   visibility: visible;
   opacity: 100%;
   width: 370px;
-  height: initial;
-  max-height: inherit;
 }
 
 dialog[id^="GPcontrolListPanel-"] {

--- a/src/packages/CSS/DSFRgeneralWidget.css
+++ b/src/packages/CSS/DSFRgeneralWidget.css
@@ -147,12 +147,12 @@
   background-color: var(--background-default-grey);
 }
 
-.gpf-btn-icon:not([class*=--tertiary])[aria-pressed="true"] {
+.gpf-btn-icon[aria-pressed="true"] {
   background-color: var(--hover-tint);
   position: relative;
 }
 
-.gpf-widget:has(.gpf-btn-icon:not([class*=--tertiary])[aria-pressed="true"])::after {
+.gpf-widget:has(.gpf-btn-icon[aria-pressed="true"])::after {
   background-color: var(--background-action-high-blue-france);
   content: "";
   width: 3px;
@@ -163,7 +163,7 @@
 }
 
 @supports(-moz-appearance:none) {
-  .gpf-widget:has(.gpf-btn-icon:not([class*=--tertiary])[aria-pressed="true"])::after {
+  .gpf-widget:has(.gpf-btn-icon[aria-pressed="true"])::after {
     transform: unset;
   }
 }

--- a/src/packages/Controls/Catalog/Catalog.js
+++ b/src/packages/Controls/Catalog/Catalog.js
@@ -156,12 +156,7 @@ var Catalog = class Catalog extends Control {
         options = options || {};
 
         // call ol.control.Control constructor
-        super({
-            element : options.element,
-            target : options.target,
-            render : options.render,
-            listable : options.listable,
-        });
+        super(options);
 
         if (!(this instanceof Catalog)) {
             throw new TypeError("ERROR CLASS_CONSTRUCTOR");
@@ -260,7 +255,7 @@ var Catalog = class Catalog extends Control {
         if (this.options.position) {
             this.setPosition(this.options.position);
         }
-        
+
         // reunion du bouton avec le précédent
         if (this.options.gutter === false) {
             this.getContainer().classList.add("gpf-button-no-gutter");

--- a/src/packages/Controls/Catalog/Catalog.js
+++ b/src/packages/Controls/Catalog/Catalog.js
@@ -159,7 +159,8 @@ var Catalog = class Catalog extends Control {
         super({
             element : options.element,
             target : options.target,
-            render : options.render
+            render : options.render,
+            listable : options.listable,
         });
 
         if (!(this instanceof Catalog)) {
@@ -484,7 +485,6 @@ var Catalog = class Catalog extends Control {
         widgetPanelDiv.appendChild(widgetContentDiv);
 
         container.appendChild(widgetPanel);
-        logger.log(container);
 
         return container;
     }

--- a/src/packages/Controls/Control.js
+++ b/src/packages/Controls/Control.js
@@ -5,6 +5,12 @@ var ControlExtended = class ControlExtended extends Control {
 
     constructor (options) {
         super(options);
+        // Can the control appear in the ControlList control
+        if (options && options.listable) {
+            this.listable = true;
+        } else {
+            this.listable = false;
+        }
     }
 
     setPosition (pos) {

--- a/src/packages/Controls/Control.js
+++ b/src/packages/Controls/Control.js
@@ -4,12 +4,23 @@ import checkDsfr from "./Utils/CheckDsfr";
 var ControlExtended = class ControlExtended extends Control {
 
     constructor (options) {
-        super(options);
+        options = options || {};
+        super({
+            element : options.element,
+            target : options.target,
+            render : options.render
+        });
         // Can the control appear in the ControlList control
         if (options && options.listable) {
             this.listable = true;
         } else {
             this.listable = false;
+        }
+        // Set the control desctiption
+        if (options && options.description) {
+            this.description = options.description;
+        } else {
+            this.description = "";
         }
     }
 

--- a/src/packages/Controls/ControlList/ControlList.js
+++ b/src/packages/Controls/ControlList/ControlList.js
@@ -1,0 +1,292 @@
+// import CSS
+import "../../CSS/Controls/ControlList/GPFcontrolList.css";
+// import OpenLayers
+import Widget from "../Widget";
+import Control from "../Control";
+
+// import geoportal library access
+import Gp from "geoportal-access-lib";
+// import local
+import Logger from "../../Utils/LoggerByDefault";
+import Utils from "../../Utils/Helper";
+import SelectorID from "../../Utils/SelectorID";
+import Draggable from "../../Utils/Draggable";
+import Interactions from "../Utils/Interactions";
+// import local with ol dependencies
+import checkDsfr from "../Utils/CheckDsfr";
+
+// DOM
+import ControlListDOM from "./ControlListDOM";
+
+var logger = Logger.getLogger("controlList");
+
+/**
+ * @classdesc
+ *
+ * ControlList Control.
+ *
+ * @constructor
+ * @alias ol.control.ControlList
+ * @type {ol.control.ControlList}
+ * @extends {ol.control.ControlList}
+ * @param {Object} options - ControlList control options
+ */
+var ControlList = class ControlList extends Control {
+
+    /**
+     * See {@link ol.control.ControlList}
+     * @module ControlList
+     * @alias module:~controls/ControlList
+     * @param {*} options - options
+     * @example
+     * import ControlList from from "gpf-ext-ol/controls/ControlList"
+     * ou
+     * import { ControlList } from "gpf-ext-ol"
+     */
+    constructor (options) {
+        options = options || {};
+
+        // call ol.control.Control constructor
+        super({
+            element : options.element,
+            target : options.target,
+            render : options.render
+        });
+
+        if (!(this instanceof ControlList)) {
+            throw new TypeError("ERROR CLASS_CONSTRUCTOR");
+        }
+
+        // initialisation du composant
+        this.initialize(options);
+        // // Widget main DOM container
+        this._container = this._initContainer();
+
+        // ajout du container
+        (this.element) ? this.element.appendChild(this._container) : this.element = this._container;
+
+        return this;
+    }
+
+    /**
+     * Overwrite OpenLayers setMap method
+     *
+     * @param {ol.Map} map - Map.
+     */
+    setMap (map) {
+        if (map) {
+            // mode "draggable"
+            if (this.draggable) {
+                Draggable.dragElement(
+                    this._ControlListPanelContainer,
+                    this._ControlListPanelHeaderContainer,
+                    map.getTargetElement()
+                );
+            }
+
+            // mode "collapsed"
+            if (!this.collapsed) {
+                this._pictoControlListButton.setAttribute("aria-pressed", true);
+            }
+        }
+
+        // on appelle la méthode setMap originale d'OpenLayers
+        super.setMap(map);
+
+        // position
+        if (this.options.position) {
+            this.setPosition(this.options.position);
+        }
+    }
+
+    // ################################################################### //
+    // ##################### public methods ############################## //
+    // ################################################################### //
+
+    /**
+     * Returns true if widget is collapsed (minimized), false otherwise
+     *
+     * @returns {Boolean} collapsed - true if widget is collapsed
+     */
+    getCollapsed () {
+        return this.collapsed;
+    }
+
+    /**
+     * Collapse or display widget main container
+     *
+     * @param {Boolean} collapsed - True to collapse widget, False to display it
+     */
+    setCollapsed (collapsed) {
+        if (collapsed === undefined) {
+            logger.log("[ERROR] ControlList:setCollapsed - missing collapsed parameter");
+            return;
+        }
+        if ((collapsed && this.collapsed) || (!collapsed && !this.collapsed)) {
+            return;
+        }
+        if (collapsed) {
+            document.getElementById("GPcontrolListPanelClose-" + this._uid).click();
+        } else {
+            this._pictoIsoButton.click();
+        }
+        this.collapsed = collapsed;
+    }
+
+    /**
+     * Get container
+     *
+     * @returns {DOMElement} container
+     */
+    getContainer () {
+        return this._container;
+    }
+
+    /**
+     * Clean UI : reinit control
+     */
+    clean () {
+        this._clearIsoInputs();
+        // INFO
+        // le comportement est surchargé, ceci supprime la couche !?
+        // cf. _createIsoPanelFormPointElement()
+        this._originPoint.clearResults();
+        document.getElementById("GPlocationPoint_1-" + this._uid).style.cssText = "";
+        document.getElementById("GPlocationOriginCoords_1-" + this._uid).value = "";
+        document.getElementById("GPlocationOrigin_1-" + this._uid).value = "";
+        document.getElementById("GPlocationPoint_1-" + this._uid).style.cssText = "";
+        document.getElementById("GPlocationOriginPointer_1-" + this._uid).checked = false;
+        document.getElementById("GPlocationOrigin_1-" + this._uid).className = "GPlocationOriginVisible gpf-visible";
+        document.getElementById("GPlocationOriginCoords_1-" + this._uid).className = "GPlocationOriginHidden gpf-hidden";
+        this._currentIsoResults = null;
+        this.setLayer();
+    }
+
+    // ################################################################### //
+    // ##################### init component ############################## //
+    // ################################################################### //
+
+    /**
+     * Initialize control (called by constructor)
+     *
+     * @param {Object} options - constructor options
+     * @private
+     */
+    initialize (options) {
+        // collapsed
+        if (options.collapsed === "true") {
+            options.collapsed = true;
+        }
+        if (options.collapsed === "false") {
+            options.collapsed = false;
+        }
+
+        // set default options
+        this.options = {
+            collapsed : true,
+            draggable : false,
+        };
+
+        // merge with user options
+        Utils.assign(this.options, options);
+
+        /** {Boolean} specify if control is collapsed (true) or not (false) */
+        this.collapsed = this.options.collapsed;
+
+        /** {Boolean} specify if control is draggable (true) or not (false) */
+        this.draggable = this.options.draggable;
+
+        // identifiant du contrôle : utile pour suffixer les identifiants CSS (pour gérer le cas où il y en a plusieurs dans la même page)
+        this._uid = SelectorID.generate();
+    }
+
+    // ################################################################### //
+    // ######################## DOM initialize ########################### //
+    // ################################################################### //
+
+    /**
+     * initialize component container (DOM)
+     * @returns {DOMElement} DOM element
+     *
+     * @private
+     */
+    _initContainer () {
+        // creation du container principal
+        var container = this._createMainContainerElement();
+
+        var picto = this._pictoControlListButton = this._createShowControlListPictoElement();
+        container.appendChild(picto);
+
+        // panneau
+        var panel = this._ControlListPanelContainer = this._createControlListPanelElement();
+        var panelDiv = this._createControlListPanelDivElement();
+        panel.appendChild(panelDiv);
+
+        // header
+        var header = this._ControlListPanelHeaderContainer = this._createControlListPanelHeaderElement();
+        panelDiv.appendChild(header);
+
+        // content
+        var content = this._ControlListPanelContentContainer = this._createControlListPanelContentElement();
+        panelDiv.appendChild(content);
+
+        // footer
+        var footer = this._createControlListPanelFooterElement();
+        panelDiv.appendChild(footer);
+
+        container.appendChild(panel);
+        return container;
+    }
+
+    // ################################################################### //
+    // ####################### handlers events to dom #################### //
+    // ################################################################### //
+
+    /**
+     * this method is called by event 'click' on 'GPshowControlListPicto' picto
+     * (cf. this._createShowControlListPictoElement),
+     *
+     * @param { event } e évènement associé au clic
+     * @private
+     */
+    onShowControlListPanelClick (e) {
+        if (e.target.ariaPressed === "true") {
+            this.onPanelOpen();
+        }
+        var map = this.getMap();
+        // on supprime toutes les interactions
+        Interactions.unset(map);
+        var opened = this._pictoControlListButton.ariaPressed;
+        this.collapsed = !(opened === "true");
+        // on génère nous même l'evenement OpenLayers de changement de propriété
+        // (utiliser ol.control.ControlList.on("change:collapsed", function ) pour s'abonner à cet évènement)
+        this.dispatchEvent("change:collapsed");
+        // on recalcule la position
+        if (this.options.position && !this.collapsed) {
+            this.updatePosition(this.options.position);
+        }
+        if (!this.collapsed) {
+            const controls = this.getMap().getControls().getArray();
+            controls.forEach(control => {
+                if (control.listable) {
+                    let element = this._createControlListPanelControl(control);
+                    this._ControlListPanelContentContainer.appendChild(element);
+                }
+            });
+        } else {
+            this._ControlListPanelContentContainer.innerHTML = "";
+        }
+    }
+
+};
+
+// on récupère les méthodes de la classe commune ControlList
+Object.assign(ControlList.prototype, ControlListDOM);
+Object.assign(ControlList.prototype, Widget);
+
+export default ControlList;
+
+// Expose ControlList as ol.control.ControlList (for a build bundle)
+if (window.ol && window.ol.control) {
+    window.ol.control.ControlList = ControlList;
+}

--- a/src/packages/Controls/ControlList/ControlList.js
+++ b/src/packages/Controls/ControlList/ControlList.js
@@ -47,11 +47,7 @@ var ControlList = class ControlList extends Control {
         options = options || {};
 
         // call ol.control.Control constructor
-        super({
-            element : options.element,
-            target : options.target,
-            render : options.render
-        });
+        super(options);
 
         if (!(this instanceof ControlList)) {
             throw new TypeError("ERROR CLASS_CONSTRUCTOR");

--- a/src/packages/Controls/ControlList/ControlList.js
+++ b/src/packages/Controls/ControlList/ControlList.js
@@ -53,6 +53,12 @@ var ControlList = class ControlList extends Control {
             throw new TypeError("ERROR CLASS_CONSTRUCTOR");
         }
 
+        if (options.controlCatalogElement) {
+            this.controlCatalogElement = options.controlCatalogElement;
+        } else {
+            this.controlCatalogElement = null;
+        }
+
         // initialisation du composant
         this.initialize(options);
         // // Widget main DOM container
@@ -226,9 +232,11 @@ var ControlList = class ControlList extends Control {
         var content = this._ControlListPanelContentContainer = this._createControlListPanelContentElement();
         panelDiv.appendChild(content);
 
-        // footer
-        var footer = this._createControlListPanelFooterElement();
-        panelDiv.appendChild(footer);
+        if (this.controlCatalogElement) {
+            // footer
+            var footer = this._createControlListPanelFooterElement(this.controlCatalogElement);
+            panelDiv.appendChild(footer);
+        }
 
         container.appendChild(panel);
         return container;

--- a/src/packages/Controls/ControlList/ControlListDOM.js
+++ b/src/packages/Controls/ControlList/ControlListDOM.js
@@ -1,0 +1,200 @@
+import checkDsfr from "../Utils/CheckDsfr";
+
+var ControlListDOM = {
+
+    /**
+    * Add uuid to the tag ID
+    * @param {String} id - id selector
+    * @returns {String} uid - id selector with an unique id
+    */
+    _addUID : function (id) {
+        var uid = (this._uid) ? id + "-" + this._uid : id;
+        return uid;
+    },
+
+    /**
+     * Main container (DOM)
+     *
+     * @returns {DOMElement} DOM element
+     */
+    _createMainContainerElement : function () {
+        var container = document.createElement("div");
+        container.id = this._addUID("GPcontrolList");
+        container.className = "GPwidget gpf-widget gpf-widget-button gpf-mobile-fullscreen";
+        return container;
+    },
+
+    // ################################################################### //
+    // ################# Methods to display Main Panel ################### //
+    // ################################################################### //
+
+    /**
+     * Show control
+     * see event !
+     *
+     * @returns {DOMElement} DOM element
+     */
+    _createShowControlListPictoElement : function () {
+        // contexte d'execution
+        var context = this;
+
+        var button = document.createElement("button");
+        // INFO: Ajout d'une SPAN pour enlever des marges de 6px dans CHROMIUM (?!)
+        var span = document.createElement("span");
+        button.appendChild(span);
+        span.innerText = "+";
+        button.id = this._addUID("GPshowControlListPicto");
+        button.className = "GPshowOpen GPshowAdvancedToolPicto GPshowControlListPicto gpf-btn gpf-btn--tertiary gpf-btn-icon gpf-btn-icon-controllist fr-btn fr-btn--tertiary";
+        button.setAttribute("aria-label", "Tous mes outils");
+        button.setAttribute("tabindex", "0");
+        button.setAttribute("aria-pressed", false);
+        button.setAttribute("type", "button");
+
+        // gestionnaire d'evenement :
+        // on ouvre le menu
+        if (button.addEventListener) {
+            button.addEventListener("click", function (e) {
+                var status = (e.target.ariaPressed === "true");
+                e.target.setAttribute("aria-pressed", !status);
+                context.onShowControlListPanelClick(e);
+            });
+        } else if (button.attachEvent) {
+            button.attachEvent("onclick", function (e) {
+                var status = (e.target.ariaPressed === "true");
+                e.target.setAttribute("aria-pressed", !status);
+                context.onShowControlListPanelClick(e);
+            });
+        }
+
+        return button;
+    },
+
+
+    // ################################################################### //
+    // ################## Methods to display Inputs Panel ################ //
+    // ################################################################### //
+
+    /**
+     * Create Container Panel
+     * @returns {DOMElement} DOM element
+     */
+    _createControlListPanelElement : function () {
+        var dialog = document.createElement("dialog");
+        dialog.id = this._addUID("GPcontrolListPanel");
+        dialog.className = "GPpanel gpf-panel fr-modal";
+
+        return dialog;
+    },
+
+    _createControlListPanelDivElement : function () {
+        var div = document.createElement("div");
+        div.className = "gpf-panel__body fr-modal__body";
+        return div;
+    },
+
+    /**
+     * Create Header Panel
+     *
+     * @returns {DOMElement} DOM element
+     */
+    _createControlListPanelHeaderElement : function () {
+        var self = this;
+
+        var container = document.createElement("div");
+        container.className = "GPpanelHeader gpf-panel__header fr-modal__header";
+
+        var div = document.createElement("div");
+        div.className = "GPpanelTitle gpf-panel__title fr-modal__title fr-pt-4w";
+        div.innerHTML = "Mes outils";
+        container.appendChild(div);
+
+        var divClose = document.createElement("button");
+        divClose.id = this._addUID("GPcontrolListPanelClose");
+        divClose.className = "GPpanelClose GPcontrolListPanelClose gpf-btn gpf-btn-icon-close fr-btn--close fr-btn fr-btn--tertiary-no-outline fr-m-1w";
+        divClose.title = "Fermer le panneau";
+
+        // Link panel close / visibility checkbox
+        if (divClose.addEventListener) {
+            divClose.addEventListener("click", function () {
+                document.getElementById(self._addUID("GPshowControlListPicto")).click();
+            }, false);
+        } else if (divClose.attachEvent) {
+            divClose.attachEvent("onclick", function () {
+                document.getElementById(self._addUID("GPshowControlListPicto")).click();
+            });
+        }
+
+        var span = document.createElement("span");
+        span.className = "GPelementHidden gpf-visible"; // afficher en dsfr
+        span.innerText = "Fermer";
+
+        divClose.appendChild(span);
+
+        container.appendChild(divClose);
+
+        return container;
+    },
+
+    /**
+     * Create Content Panel
+     *
+     * @returns {DOMElement} DOM element
+     */
+    _createControlListPanelContentElement : function () {
+        var container = document.createElement("div");
+        container.className = "gpf-panel__content fr-modal__content";
+        return container;
+    },
+
+    /**
+     * Create Footer Panel
+     *
+     * @returns {DOMElement} DOM element
+     */
+    _createControlListPanelFooterElement : function () {
+        var container = document.createElement("div");
+        container.className = "GPpanelFooter gpf-panel__footer fr-modal__footer";
+        var addToolsBtn = document.createElement("button");
+        addToolsBtn.classList.add("gpf-btn", "gpf-btn--tertiary", "fr-btn", "fr-btn--tertiary");
+        addToolsBtn.innerText = "+ Ajouter plus d'outils";
+        container.appendChild(addToolsBtn);
+        return container;
+    },
+
+    /**
+     * Create div for control
+     *
+     * @param {ol.Control} control control to add in the panel
+     * @returns {DOMElement} DOM element
+     */
+    _createControlListPanelControl : function (control) {
+        const controlContainer = control.getContainer();
+        console.log(controlContainer);
+        var container = document.createElement("div");
+        var btn = controlContainer.querySelector(".GPshowOpen").cloneNode();
+        btn.id = btn.id + "-controllist";
+        btn.classList.add("inside-control-list");
+        container.appendChild(btn);
+        var divText = document.createElement("div");
+        var spanTitle = document.createElement("span");
+        divText.appendChild(spanTitle);
+        if (controlContainer.querySelector(".GPpanelTitle")) {
+            spanTitle.innerText = controlContainer.querySelector(".GPpanelTitle").innerText;
+        } else {
+            spanTitle.innerText = controlContainer.querySelector("[class^='gpf-btn-header-']").title;
+        }
+        if (control.description) {
+            var spanDescription = document.createElement("span");
+            divText.appendChild(spanDescription);
+        }
+        container.appendChild(divText);
+
+        container.addEventListener("click", function () {
+            controlContainer.querySelector(".GPshowOpen").click();
+        });
+        return container;
+    },
+
+};
+
+export default ControlListDOM;

--- a/src/packages/Controls/ControlList/ControlListDOM.js
+++ b/src/packages/Controls/ControlList/ControlListDOM.js
@@ -185,6 +185,7 @@ var ControlListDOM = {
         }
         if (control.description) {
             var spanDescription = document.createElement("span");
+            spanDescription.innerText = control.description;
             divText.appendChild(spanDescription);
         }
         container.appendChild(divText);

--- a/src/packages/Controls/ControlList/ControlListDOM.js
+++ b/src/packages/Controls/ControlList/ControlListDOM.js
@@ -149,14 +149,18 @@ var ControlListDOM = {
     /**
      * Create Footer Panel
      *
+     * @param {DOMElement} controlCatalogelement - DOM element
      * @returns {DOMElement} DOM element
      */
-    _createControlListPanelFooterElement : function () {
+    _createControlListPanelFooterElement : function (controlCatalogelement) {
         var container = document.createElement("div");
         container.className = "GPpanelFooter gpf-panel__footer fr-modal__footer";
         var addToolsBtn = document.createElement("button");
         addToolsBtn.classList.add("gpf-btn", "gpf-btn--tertiary", "fr-btn", "fr-btn--tertiary");
         addToolsBtn.innerText = "+ Ajouter plus d'outils";
+        addToolsBtn.addEventListener("click", function () {
+            controlCatalogelement.click();
+        });
         container.appendChild(addToolsBtn);
         return container;
     },

--- a/src/packages/Controls/Drawing/Drawing.js
+++ b/src/packages/Controls/Drawing/Drawing.js
@@ -184,7 +184,8 @@ var Drawing = class Drawing extends Control {
         super({
             element : options.element,
             target : options.target,
-            render : options.render
+            render : options.render,
+            listable : options.listable,
         });
 
         if (!(this instanceof Drawing)) {

--- a/src/packages/Controls/Drawing/Drawing.js
+++ b/src/packages/Controls/Drawing/Drawing.js
@@ -181,12 +181,7 @@ var Drawing = class Drawing extends Control {
         options = options || {};
 
         // call ol.control.Control constructor
-        super({
-            element : options.element,
-            target : options.target,
-            render : options.render,
-            listable : options.listable,
-        });
+        super(options);
 
         if (!(this instanceof Drawing)) {
             throw new TypeError("ERROR CLASS_CONSTRUCTOR");

--- a/src/packages/Controls/ElevationPath/ElevationPath.js
+++ b/src/packages/Controls/ElevationPath/ElevationPath.js
@@ -133,12 +133,7 @@ var ElevationPath = class ElevationPath extends Control {
         options = options || {};
 
         // call ol.control.Control constructor
-        super({
-            element : options.element,
-            target : options.target,
-            render : options.render,
-            listable : options.listable,
-        });
+        super(options);
 
         if (!(this instanceof ElevationPath)) {
             throw new TypeError("ERROR CLASS_CONSTRUCTOR");

--- a/src/packages/Controls/ElevationPath/ElevationPath.js
+++ b/src/packages/Controls/ElevationPath/ElevationPath.js
@@ -136,7 +136,8 @@ var ElevationPath = class ElevationPath extends Control {
         super({
             element : options.element,
             target : options.target,
-            render : options.render
+            render : options.render,
+            listable : options.listable,
         });
 
         if (!(this instanceof ElevationPath)) {

--- a/src/packages/Controls/GetFeatureInfo/GetFeatureInfo.js
+++ b/src/packages/Controls/GetFeatureInfo/GetFeatureInfo.js
@@ -55,7 +55,8 @@ var GetFeatureInfo = class GetFeatureInfo extends Control {
         super({
             element : options.element,
             target : options.target,
-            render : options.render
+            render : options.render,
+            listable : options.listable,
         });
 
         if (!(this instanceof GetFeatureInfo)) {

--- a/src/packages/Controls/GetFeatureInfo/GetFeatureInfo.js
+++ b/src/packages/Controls/GetFeatureInfo/GetFeatureInfo.js
@@ -52,12 +52,7 @@ var GetFeatureInfo = class GetFeatureInfo extends Control {
     constructor (options) {
         options = options || {};
         // call ol.control.Control constructor
-        super({
-            element : options.element,
-            target : options.target,
-            render : options.render,
-            listable : options.listable,
-        });
+        super(options);
 
         if (!(this instanceof GetFeatureInfo)) {
             throw new TypeError("ERROR CLASS_CONSTRUCTOR");

--- a/src/packages/Controls/Isocurve/Isocurve.js
+++ b/src/packages/Controls/Isocurve/Isocurve.js
@@ -116,7 +116,8 @@ var Isocurve = class Isocurve extends Control {
         super({
             element : options.element,
             target : options.target,
-            render : options.render
+            render : options.render,
+            listable : options.listable,
         });
 
         if (!(this instanceof Isocurve)) {

--- a/src/packages/Controls/Isocurve/Isocurve.js
+++ b/src/packages/Controls/Isocurve/Isocurve.js
@@ -113,12 +113,7 @@ var Isocurve = class Isocurve extends Control {
         options = options || {};
 
         // call ol.control.Control constructor
-        super({
-            element : options.element,
-            target : options.target,
-            render : options.render,
-            listable : options.listable,
-        });
+        super(options);
 
         if (!(this instanceof Isocurve)) {
             throw new TypeError("ERROR CLASS_CONSTRUCTOR");

--- a/src/packages/Controls/LayerImport/LayerImport.js
+++ b/src/packages/Controls/LayerImport/LayerImport.js
@@ -158,12 +158,7 @@ var LayerImport = class LayerImport extends Control {
         options = options || {};
 
         // call ol.control.Control constructor
-        super({
-            element : options.element,
-            target : options.target,
-            render : options.render,
-            listable : options.listable,
-        });
+        super(options);
 
         if (!(this instanceof LayerImport)) {
             throw new TypeError("ERROR CLASS_CONSTRUCTOR");
@@ -283,7 +278,7 @@ var LayerImport = class LayerImport extends Control {
         if (this.options.position) {
             this.setPosition(this.options.position);
         }
-        
+
         // reunion du bouton avec le précédent
         if (this.options.gutter === false) {
             this.getContainer().classList.add("gpf-button-no-gutter");

--- a/src/packages/Controls/LayerImport/LayerImport.js
+++ b/src/packages/Controls/LayerImport/LayerImport.js
@@ -161,7 +161,8 @@ var LayerImport = class LayerImport extends Control {
         super({
             element : options.element,
             target : options.target,
-            render : options.render
+            render : options.render,
+            listable : options.listable,
         });
 
         if (!(this instanceof LayerImport)) {

--- a/src/packages/Controls/LayerSwitcher/LayerSwitcher.js
+++ b/src/packages/Controls/LayerSwitcher/LayerSwitcher.js
@@ -104,7 +104,8 @@ var LayerSwitcher = class LayerSwitcher extends Control {
         super({
             element : _options.element,
             target : _options.target,
-            render : _options.render
+            render : _options.render,
+            listable : _options.listable,
         });
 
         if (!(this instanceof LayerSwitcher)) {

--- a/src/packages/Controls/Legends/Legends.js
+++ b/src/packages/Controls/Legends/Legends.js
@@ -53,7 +53,8 @@ var Legends = class Legends extends Control {
         super({
             element : options.element,
             target : options.target,
-            render : options.render
+            render : options.render,
+            listable : options.listable,
         });
 
         if (!(this instanceof Legends)) {

--- a/src/packages/Controls/Legends/Legends.js
+++ b/src/packages/Controls/Legends/Legends.js
@@ -50,12 +50,7 @@ var Legends = class Legends extends Control {
         options = options || {};
 
         // call ol.control.Control constructor
-        super({
-            element : options.element,
-            target : options.target,
-            render : options.render,
-            listable : options.listable,
-        });
+        super(options);
 
         if (!(this instanceof Legends)) {
             throw new TypeError("ERROR CLASS_CONSTRUCTOR");

--- a/src/packages/Controls/Measures/MeasureArea.js
+++ b/src/packages/Controls/Measures/MeasureArea.js
@@ -56,12 +56,7 @@ var MeasureArea = class MeasureArea extends Control {
         options = options || {};
 
         // call ol.control.Control constructor
-        super({
-            element : options.element,
-            target : options.target,
-            render : options.render,
-            listable : options.listable,
-        });
+        super(options);
 
         if (!(this instanceof MeasureArea)) {
             throw new TypeError("ERROR CLASS_CONSTRUCTOR");

--- a/src/packages/Controls/Measures/MeasureArea.js
+++ b/src/packages/Controls/Measures/MeasureArea.js
@@ -59,7 +59,8 @@ var MeasureArea = class MeasureArea extends Control {
         super({
             element : options.element,
             target : options.target,
-            render : options.render
+            render : options.render,
+            listable : options.listable,
         });
 
         if (!(this instanceof MeasureArea)) {
@@ -173,7 +174,7 @@ var MeasureArea = class MeasureArea extends Control {
     getContainer () {
         return this._container;
     }
-    
+
     // ################################################################### //
     // ##################### init component ############################## //
     // ################################################################### //

--- a/src/packages/Controls/Measures/MeasureAzimuth.js
+++ b/src/packages/Controls/Measures/MeasureAzimuth.js
@@ -59,7 +59,8 @@ var MeasureAzimuth = class MeasureAzimuth extends Control {
         super({
             element : options.element,
             target : options.target,
-            render : options.render
+            render : options.render,
+            listable : options.listable,
         });
 
         if (!(this instanceof MeasureAzimuth)) {
@@ -191,7 +192,7 @@ var MeasureAzimuth = class MeasureAzimuth extends Control {
     getContainer () {
         return this._container;
     }
-    
+
     // ################################################################### //
     // ##################### init component ############################## //
     // ################################################################### //

--- a/src/packages/Controls/Measures/MeasureAzimuth.js
+++ b/src/packages/Controls/Measures/MeasureAzimuth.js
@@ -56,12 +56,7 @@ var MeasureAzimuth = class MeasureAzimuth extends Control {
         options = options || {};
 
         // call ol.control.Control constructor
-        super({
-            element : options.element,
-            target : options.target,
-            render : options.render,
-            listable : options.listable,
-        });
+        super(options);
 
         if (!(this instanceof MeasureAzimuth)) {
             throw new TypeError("ERROR CLASS_CONSTRUCTOR");

--- a/src/packages/Controls/Measures/MeasureLength.js
+++ b/src/packages/Controls/Measures/MeasureLength.js
@@ -53,12 +53,7 @@ var MeasureLength = class MeasureLength extends Control {
         options = options || {};
 
         // call ol.control.Control constructor
-        super({
-            element : options.element,
-            target : options.target,
-            render : options.render,
-            listable : options.listable,
-        });
+        super(options);
 
         if (!(this instanceof MeasureLength)) {
             throw new TypeError("ERROR CLASS_CONSTRUCTOR");

--- a/src/packages/Controls/Measures/MeasureLength.js
+++ b/src/packages/Controls/Measures/MeasureLength.js
@@ -56,7 +56,8 @@ var MeasureLength = class MeasureLength extends Control {
         super({
             element : options.element,
             target : options.target,
-            render : options.render
+            render : options.render,
+            listable : options.listable,
         });
 
         if (!(this instanceof MeasureLength)) {
@@ -167,7 +168,7 @@ var MeasureLength = class MeasureLength extends Control {
     getContainer () {
         return this._container;
     }
-    
+
     // ################################################################### //
     // ##################### init component ############################## //
     // ################################################################### //

--- a/src/packages/Controls/MousePosition/MousePosition.js
+++ b/src/packages/Controls/MousePosition/MousePosition.js
@@ -138,7 +138,8 @@ var MousePosition = class MousePosition extends Control {
         super({
             element : options.element,
             target : options.target,
-            render : options.render
+            render : options.render,
+            listable : options.listable,
         });
 
         if (!(this instanceof MousePosition)) {

--- a/src/packages/Controls/MousePosition/MousePosition.js
+++ b/src/packages/Controls/MousePosition/MousePosition.js
@@ -135,12 +135,7 @@ var MousePosition = class MousePosition extends Control {
         options = options || {};
 
         // call ol.control.Control constructor
-        super({
-            element : options.element,
-            target : options.target,
-            render : options.render,
-            listable : options.listable,
-        });
+        super(options);
 
         if (!(this instanceof MousePosition)) {
             throw new TypeError("ERROR CLASS_CONSTRUCTOR");

--- a/src/packages/Controls/ReverseGeocode/ReverseGeocode.js
+++ b/src/packages/Controls/ReverseGeocode/ReverseGeocode.js
@@ -91,12 +91,7 @@ var ReverseGeocode = class ReverseGeocode extends Control {
         options = options || {};
 
         // call ol.control.Control constructor
-        super({
-            element : options.element,
-            target : options.target,
-            render : options.render,
-            listable : options.listable,
-        });
+        super(options);
 
         if (!(this instanceof ReverseGeocode)) {
             throw new TypeError("ERROR CLASS_CONSTRUCTOR");

--- a/src/packages/Controls/ReverseGeocode/ReverseGeocode.js
+++ b/src/packages/Controls/ReverseGeocode/ReverseGeocode.js
@@ -94,7 +94,8 @@ var ReverseGeocode = class ReverseGeocode extends Control {
         super({
             element : options.element,
             target : options.target,
-            render : options.render
+            render : options.render,
+            listable : options.listable,
         });
 
         if (!(this instanceof ReverseGeocode)) {

--- a/src/packages/Controls/Route/Route.js
+++ b/src/packages/Controls/Route/Route.js
@@ -124,7 +124,8 @@ var Route = class Route extends Control {
         super({
             element : options.element,
             target : options.target,
-            render : options.render
+            render : options.render,
+            listable : options.listable,
         });
 
         if (!(this instanceof Route)) {

--- a/src/packages/Controls/Route/Route.js
+++ b/src/packages/Controls/Route/Route.js
@@ -121,12 +121,7 @@ var Route = class Route extends Control {
         options = options || {};
 
         // call ol.control.Control constructor
-        super({
-            element : options.element,
-            target : options.target,
-            render : options.render,
-            listable : options.listable,
-        });
+        super(options);
 
         if (!(this instanceof Route)) {
             throw new TypeError("ERROR CLASS_CONSTRUCTOR");

--- a/src/packages/Controls/SearchEngine/SearchEngine.js
+++ b/src/packages/Controls/SearchEngine/SearchEngine.js
@@ -179,12 +179,7 @@ var SearchEngine = class SearchEngine extends Control {
         options = options || {};
 
         // call ol.control.Control constructor
-        super({
-            element : options.element,
-            target : options.target,
-            render : options.render,
-            listable : options.listable,
-        });
+        super(options);
 
         if (!(this instanceof SearchEngine)) {
             throw new TypeError("ERROR CLASS_CONSTRUCTOR");

--- a/src/packages/Controls/SearchEngine/SearchEngine.js
+++ b/src/packages/Controls/SearchEngine/SearchEngine.js
@@ -182,7 +182,8 @@ var SearchEngine = class SearchEngine extends Control {
         super({
             element : options.element,
             target : options.target,
-            render : options.render
+            render : options.render,
+            listable : options.listable,
         });
 
         if (!(this instanceof SearchEngine)) {

--- a/src/packages/Controls/Territories/Territories.js
+++ b/src/packages/Controls/Territories/Territories.js
@@ -65,7 +65,8 @@ var Territories = class Territories extends Control {
         super({
             element : options.element,
             target : options.target,
-            render : options.render
+            render : options.render,
+            listable : options.listable,
         });
 
         if (!(this instanceof Territories)) {

--- a/src/packages/Controls/Territories/Territories.js
+++ b/src/packages/Controls/Territories/Territories.js
@@ -62,12 +62,7 @@ var Territories = class Territories extends Control {
         options = options || {};
 
         // call ol.control.Control constructor
-        super({
-            element : options.element,
-            target : options.target,
-            render : options.render,
-            listable : options.listable,
-        });
+        super(options);
 
         if (!(this instanceof Territories)) {
             throw new TypeError("ERROR CLASS_CONSTRUCTOR");

--- a/src/packages/bundle.js
+++ b/src/packages/bundle.js
@@ -98,6 +98,7 @@ import GeoportalFullScreen from "./Controls/FullScreen/GeoportalFullScreen";
 import GeoportalOverviewMap from "./Controls/OverviewMap/GeoportalOverviewMap";
 import Legends from "./Controls/Legends/Legends";
 import Territories from "./Controls/Territories/Territories";
+import ControlList from "./Controls/ControlList/ControlList";
 import Catalog from "./Controls/Catalog/Catalog";
 
 import Proj4 from "proj4";
@@ -270,10 +271,11 @@ Ol.control.GeoportalOverviewMap = GeoportalOverviewMap;
 Ol.control.Legends = Legends;
 Ol.control.Catalog = Catalog;
 Ol.control.Territories = Territories;
+Ol.control.ControlList = ControlList;
 
 export {
-    /** 
-     * Expose extensions openlayers extended 
+    /**
+     * Expose extensions openlayers extended
      * @see ol.control.LayerSwitcher
      * @see ol.control.GeoportalAttribution
      * @see ol.control.GetFeatureInfo
@@ -304,7 +306,7 @@ export {
      * @see ol.format.KMLExtended
      * @see ol.format.GPXExtended
      * @see ol.format.GeoJSONExtended
-     * @see ol.style.Editor 
+     * @see ol.style.Editor
      * @see ol.includeProjections
      */
     Ol as olExtended


### PR DESCRIPTION
fixes https://github.com/IGNF/geopf-extensions-openlayers/issues/270

Ajout d'un nouveau control, appelé `ControlList`.

Pour son fonctionnement, ajout dans la class `ControlExtended` d'une option booléenne, `listable`, par défaut `false`.
Un contrôle créé avec l'option `listable: true,` pourra apparaître dans la liste des contrôles ouverte via le nouveau Widget.

![image](https://github.com/user-attachments/assets/68ecf3d8-5b49-43bd-85a6-ee46c56b7cf6)

Ici, avec seulement Territories, ReverseGeocode et Route listables :

![image](https://github.com/user-attachments/assets/a81a9e37-1347-4b5e-852d-d96c68cf13b3)
![image](https://github.com/user-attachments/assets/297dbddc-d190-4d77-b295-a53a16c20b48)

Au clic sur l'entrée de la liste, ouverture du widget correspondant

![image](https://github.com/user-attachments/assets/6b78e1ee-a118-4739-a7e5-496574608f31)
