### PR TITLE
fix(drawing): Titre par défaut à la couche du croquis

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -22,6 +22,8 @@ __DATE__
 * 🔥 [Removed]
 
 * 🐛 [Fixed]
+
+  - Ajout d'un titre par défaut à la couche vectorielle du drawing (#296)
   
 * 🔒 [Security]
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.1",
-  "date": "10/12/2024",
+  "version": "1.0.0-beta.1-296",
+  "date": "11/12/2024",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/src/packages/Controls/Drawing/Drawing.js
+++ b/src/packages/Controls/Drawing/Drawing.js
@@ -765,7 +765,8 @@ var Drawing = class Drawing extends Control {
         var layer = new VectorLayer({
             source : new VectorSource({
                 features : features
-            })
+            }),
+            title : "Mon Croquis"
         });
         // on rajoute le champ gpResultLayerId permettant d'identifier une couche crée par le composant.
         layer.gpResultLayerId = "drawing";

--- a/src/packages/Controls/GetFeatureInfo/GetFeatureInfo.js
+++ b/src/packages/Controls/GetFeatureInfo/GetFeatureInfo.js
@@ -433,7 +433,7 @@ var GetFeatureInfo = class GetFeatureInfo extends Control {
             var src = layerProperties.source;
             var layerTitle = "";
             if (src) {
-                layerTitle = src._title || src.name || src.url_;
+                layerTitle = src._title || src.name || layerProperties.title || layerProperties.name || src.url_ || "Couche de données";
             }
         }
         return layerTitle;

--- a/src/packages/Controls/Isocurve/Isocurve.js
+++ b/src/packages/Controls/Isocurve/Isocurve.js
@@ -1348,21 +1348,24 @@ var Isocurve = class Isocurve extends Control {
         );
 
         // 2. ajout de la géométrie comme nouvelle couche vecteur à la carte
+        var method = (this._currentComputation === "time") ? "Isochrone" : "Isodistance";
+
         this._geojsonLayer = new VectorLayer({
             source : new VectorSource({
                 features : features
             }),
             style : this._defaultFeatureStyle,
-            opacity : 0.9
+            opacity : 0.9,
+            title : "Mon " + method
         });
         // ajout d'un identifiant à la couche
         var graph;
         if (this._currentTransport === "Pieton") {
             graph = "piéton";
-            this._geojsonLayer.gpResultLayerId = "Pieton$GEOPORTAIL:GPP:Isocurve";
+            this._geojsonLayer.gpResultLayerId = "compute:Pieton$GEOPORTAIL:GPP:Isocurve";
         } else {
             graph = "voiture";
-            this._geojsonLayer.gpResultLayerId = "Voiture$GEOPORTAIL:GPP:Isocurve";
+            this._geojsonLayer.gpResultLayerId = "compute:Voiture$GEOPORTAIL:GPP:Isocurve";
         }
         // ajout à la carte
         map.addLayer(this._geojsonLayer);

--- a/src/packages/Controls/LayerSwitcher/LayerSwitcher.js
+++ b/src/packages/Controls/LayerSwitcher/LayerSwitcher.js
@@ -1229,9 +1229,11 @@ var LayerSwitcher = class LayerSwitcher extends Control {
         var error = null;
 
         var map = this.getMap();
-        // cas d'un layer vecteur importé
-        if (data.layer.hasOwnProperty("gpResultLayerId") && (data.layer.gpResultLayerId.split(":")[0] === "layerimport" || data.layer.gpResultLayerId.split(":")[0] === "drawing")) {
-            // TODO : appeler fonction commune
+        // cas d'un layer vecteur importé, d'un croquis, d'une couche de calcul
+        if (data.layer.hasOwnProperty("gpResultLayerId") && 
+            (data.layer.gpResultLayerId.split(":")[0] === "layerimport" || data.layer.gpResultLayerId.split(":")[0] === "drawing"
+            || data.layer.gpResultLayerId.split(":")[0] === "compute")) {
+            // TODO : appeler fonc  tion commune
             // zoom sur l'étendue des entités récupérées (si possible)
             if (map.getView() && map.getSize()) {
                 var sourceExtent = data.layer.getExtent() || data.layer.getSource().getExtent();
@@ -1240,7 +1242,7 @@ var LayerSwitcher = class LayerSwitcher extends Control {
                 }
             }
         } else {
-            try {
+            try {   
                 // Check if configuration is loaded
                 if (!Config.isConfigLoaded()) {
                     throw "ERROR : contract key configuration has to be loaded to load Geoportal layers.";

--- a/src/packages/Controls/LayerSwitcher/LayerSwitcher.js
+++ b/src/packages/Controls/LayerSwitcher/LayerSwitcher.js
@@ -1230,7 +1230,7 @@ var LayerSwitcher = class LayerSwitcher extends Control {
 
         var map = this.getMap();
         // cas d'un layer vecteur importé
-        if (data.layer.hasOwnProperty("gpResultLayerId") && data.layer.gpResultLayerId.split(":")[0] === "layerimport") {
+        if (data.layer.hasOwnProperty("gpResultLayerId") && (data.layer.gpResultLayerId.split(":")[0] === "layerimport" || data.layer.gpResultLayerId.split(":")[0] === "drawing")) {
             // TODO : appeler fonction commune
             // zoom sur l'étendue des entités récupérées (si possible)
             if (map.getView() && map.getSize()) {

--- a/src/packages/Controls/LayerSwitcher/LayerSwitcher.js
+++ b/src/packages/Controls/LayerSwitcher/LayerSwitcher.js
@@ -1401,11 +1401,11 @@ var LayerSwitcher = class LayerSwitcher extends Control {
             var layerProperties = layer.getProperties();
             var src = layerProperties.source;
             if (src) {
-                layerInfo._title = src._title || layerProperties.id || "";
-                layerInfo._description = src._description || "";
-                layerInfo._quicklookUrl = src._quicklookUrl || "";
-                layerInfo._metadata = src._metadata || [];
-                layerInfo._legends = src._legends || [];
+                layerInfo._title = src._title || layerProperties.title || layerProperties.id || "";
+                layerInfo._description = src._description || layerProperties.description || "";
+                layerInfo._quicklookUrl = src._quicklookUrl || layerProperties.quicklookUrl || "";
+                layerInfo._metadata = src._metadata || layerProperties.metadata || [];
+                layerInfo._legends = src._legends || layerProperties.legends || [];
             }
         }
         return layerInfo;

--- a/src/packages/Controls/Route/Route.js
+++ b/src/packages/Controls/Route/Route.js
@@ -1656,7 +1656,8 @@ var Route = class Route extends Control {
             source : new VectorSource({
                 features : features
             }),
-            style : style
+            style : style,
+            title : "Mon Itinéraire"
         });
         map.addLayer(this._geojsonRoute);
     }
@@ -1776,16 +1777,17 @@ var Route = class Route extends Control {
                 features : features
             }),
             style : style,
-            opacity : 0.9
+            opacity : 0.9,
+            title : "Mon Itinéraire"
         });
 
         var graph;
         if (this._currentTransport === "Pieton") {
             graph = "piéton";
-            this._geojsonSections.gpResultLayerId = "Pieton$OGC:OPENLS;Itineraire";
+            this._geojsonSections.gpResultLayerId = "compute:Pieton$OGC:OPENLS;Itineraire";
         } else {
             graph = "voiture";
-            this._geojsonSections.gpResultLayerId = "Voiture$OGC:OPENLS;Itineraire";
+            this._geojsonSections.gpResultLayerId = "compute:Voiture$OGC:OPENLS;Itineraire";
         }
         // ajout à la carte
         map.addLayer(this._geojsonSections);


### PR DESCRIPTION
Problème : 

- le GFI sur le Drawing renvoie comme nom de couche "undefined"

On ajoute donc le nom "Mon Croquis" par défaut à la VectorLayer, que l'on transmet au GFI.

cf.  https://github.com/IGNF/cartes.gouv.fr-entree-carto/issues/415


On en profite pour corriger le zoomToExtent du layerSwitcher sur les croquis