### PR TITLE
Correction sur la pop-up affichée au clic des markers du searchEngine

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -17,6 +17,9 @@ __DATE__
 
 * 🔨 [Changed]
 
+    - Ajout d'une croix de fermeture au pop-up issue du clic sur les markers de searchEngine (#313)
+    - Augmentation du niveau de zoom lors du centrage par geolocalisation (#313)
+
 * 🔥 [Deprecated]
 
 * 🔥 [Removed]
@@ -24,7 +27,7 @@ __DATE__
 * 🐛 [Fixed]
 
   - Ajout d'un titre par défaut à la couche vectorielle du drawing (#296)
-  
+ 
 * 🔒 [Security]
 
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.1-308",
-  "date": "18/12/2024",
+  "version": "1.0.0-beta.1-313",
+  "date": "24/12/2024",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/src/packages/CSS/Controls/Drawing/DSFRdrawingStyle.css
+++ b/src/packages/CSS/Controls/Drawing/DSFRdrawingStyle.css
@@ -18,10 +18,6 @@
   width: 100%;
 }
 
-.gp-styling-button.closer {
-  display: none;
-}
-
 .gp-styling-option.fr-range--sm[data-fr-js-range]::before,
 .gp-styling-option.fr-range--sm[data-fr-js-range]::after {
   top: 1.74rem;

--- a/src/packages/Controls/SearchEngine/SearchEngine.js
+++ b/src/packages/Controls/SearchEngine/SearchEngine.js
@@ -737,8 +737,11 @@ var SearchEngine = class SearchEngine extends Control {
         var context = this;
         var element = document.createElement("div");
         element.className = "gp-feature-info-div gpf-widget-color";
+        // bouton de fermeture de la pop-up
         var closer = document.createElement("button");
-        closer.className = "gp-styling-button closer";
+        closer.title = "Fermer la pop-up";
+        closer.className = "gp-styling-button closer gpf-btn gpf-btn-icon-close fr-btn--close fr-btn fr-btn--tertiary-no-outline fr-mt-1v fr-mr-2v";
+
         // on closer click : remove popup
         closer.onclick = function () {
             if (context._popupOverlay != null) {
@@ -1548,7 +1551,7 @@ var SearchEngine = class SearchEngine extends Control {
                     this._setMarker();
                     return;
                 }
-                this._setPosition(coordinates, 10); // FIXME zoom fixe !
+                this._setPosition(coordinates, 15); // FIXME zoom fixe !
                 if (this._displayMarker) {
                     var markerInfo = "<h6> Ma position </h6> longitude : " + coordinates_4326[0] + "<br/> latitude : " + coordinates_4326[1];
                     this._setMarker(coordinates, markerInfo);


### PR DESCRIPTION
Fixes https://github.com/IGNF/cartes.gouv.fr-entree-carto/issues/434

1 - le zoom sur sa geolocalisation est augmentée
![image](https://github.com/user-attachments/assets/ae5e2a5e-0235-4549-9d67-4461106be11e)



2 - une croix de fermeture aux pop-ups affichées au clic sur les markers du searchEngine est ajoutée en mode DSFR
![Capture d’écran du 2024-12-24 16-43-12](https://github.com/user-attachments/assets/55553885-56da-4e2a-aa60-496e66ff2e5f)
![Capture d’écran du 2024-12-24 16-43-26](https://github.com/user-attachments/assets/ca95f79e-0380-4d97-931e-64d369672f98)


Attention : 
- partie pris de ne pas afficher "Fermer" en toutes lettres, car le résultat est un peu indigeste. Voir si c'est acceptable en terme d'accessibilité

![Capture d’écran du 2024-12-24 15-51-21](https://github.com/user-attachments/assets/c39bad5c-68c9-4be7-815f-154b4148a519)
