### PR TITLE
feat(measures): ajout option pour forcer unité d'affichage

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -16,6 +16,7 @@ __DATE__
 * ✨ [Added]
 
   - ajout du widget ControlList en mode classique (#300)
+  - ajout d'une option unit au widget de mesure de distance (#317)
 
 * 🔨 [Changed]
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.1-316",
-  "date": "31/12/2024",
+  "version": "1.0.0-beta.1-317",
+  "date": "03/01/2025",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/samples-src/pages/tests/Measures/pages-ol-measures-modules-default.html
+++ b/samples-src/pages/tests/Measures/pages-ol-measures-modules-default.html
@@ -54,9 +54,7 @@
                   })
                 });
 
-                var measureLength = new ol.control.MeasureLength({
-                  unit : "km"
-                });
+                var measureLength = new ol.control.MeasureLength();
                 map.addControl(measureLength);
                 var measureArea = new ol.control.MeasureArea();
                 map.addControl(measureArea);

--- a/samples-src/pages/tests/Measures/pages-ol-measures-modules-default.html
+++ b/samples-src/pages/tests/Measures/pages-ol-measures-modules-default.html
@@ -54,7 +54,9 @@
                   })
                 });
 
-                var measureLength = new ol.control.MeasureLength();
+                var measureLength = new ol.control.MeasureLength({
+                  unit : "km"
+                });
                 map.addControl(measureLength);
                 var measureArea = new ol.control.MeasureArea();
                 map.addControl(measureArea);

--- a/src/packages/Controls/Measures/MeasureLength.js
+++ b/src/packages/Controls/Measures/MeasureLength.js
@@ -34,6 +34,7 @@ var logger = Logger.getLogger("measurelength");
  * @param {Object} options - options for function call.
  * @param {Number} [options.id] - Ability to add an identifier on the widget (advanced option)
  * @param {Boolean} [options.geodesic = true] - If true, length will be computed on the global sphere using the {@link https://openlayers.org/en/latest/apidoc/module-ol_sphere.html#haversineDistance ol.Sphere.haversineDistance()} function. Otherwise, length will be computed on the projected plane.
+ * @param {String} [options.unit] - If not specified, the measure will be displayed in m until 999m, then in km. Values possible : m or km.
  * @param {Object} [options.styles = {}] - styles used when drawing. Specified with following properties.
  * @param {Object} [options.styles.pointer = {}] - Style for mouse pointer when drawing the path. Specified with an {@link https://openlayers.org/en/latest/apidoc/module-ol_style_Image-ImageStyle.html ol.style.Image} subclass object.
  * @param {Object} [options.styles.start = {}] - Line Style when drawing. Specified with an {@link https://openlayers.org/en/latest/apidoc/module-ol_style_Style-Style.htmll ol.style.Style} object.
@@ -182,6 +183,7 @@ var MeasureLength = class MeasureLength extends Control {
         // liste des options
         this.options = {};
         this.options.geodesic = (typeof options.geodesic !== "undefined") ? options.geodesic : true;
+        this.options.unit = (typeof options.unit !== "undefined") ? options.unit : null;
         this.options.position = (typeof options.position !== "undefined") ? options.position : null;
         this.options.target = (typeof options.target !== "undefined") ? options.target : null;
         this.options.render = (typeof options.render !== "undefined") ? options.render : null;
@@ -280,10 +282,18 @@ var MeasureLength = class MeasureLength extends Control {
         }
 
         var output;
-        if (measure > 1000) {
+        // si option unit spécifiée, on force l'unité
+        // sinon on est en mode automatique entre m et km.
+        if (this.options.unit === "km") {
             output = (Math.round(measure / 1000 * 100) / 100) + " " + "km";
-        } else {
+        } else if (this.options.unit === "m") {
             output = (Math.round(measure * 100) / 100) + " " + "m";
+        } else {
+            if (measure > 1000) {
+                output = (Math.round(measure / 1000 * 100) / 100) + " " + "km";
+            } else {
+                output = (Math.round(measure * 100) / 100) + " " + "m";
+            }
         }
         return output;
     }


### PR DESCRIPTION
fix #293

### Ajout de l'option unit qui peut prendre les valeurs "m" ou "km".

**Si "m" :** 

```
                var measureLength = new ol.control.MeasureLength({
                  unit : "m"
                });
```
Les mesures de plus de 1000m s'affichent en m : 
![image](https://github.com/user-attachments/assets/c6c5c1b9-bac5-4fec-b1c4-df0cd7b6ce75)



**Si "km" :** 

```
                var measureLength = new ol.control.MeasureLength({
                  unit : "km"
                });
```
Les mesures de plus de 1000m s'affichent en m : 
![image](https://github.com/user-attachments/assets/bcbfceab-363c-4458-b876-910486bf54e8)


**Si pas d'option unit spécifiée :** 

Le comportement actuel est conservé.

