### PR TITLE
fix(search): no autocomplete results on mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.1-317",
-  "date": "03/01/2025",
+  "version": "1.0.0-beta.1-318",
+  "date": "06/01/2025",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/src/packages/CSS/Controls/SearchEngine/DSFRsearchEngineStyle.css
+++ b/src/packages/CSS/Controls/SearchEngine/DSFRsearchEngineStyle.css
@@ -24,6 +24,7 @@
 .GPlabelTitle {
   background-color: var(--background-open-blue-france);
   font-size: 1.0em;
+  margin-bottom: 0;
 }
 
 dialog[id^=GPcoordinateSearchPanel],

--- a/src/packages/CSS/Controls/SearchEngine/DSFRsearchEngineStyle.css
+++ b/src/packages/CSS/Controls/SearchEngine/DSFRsearchEngineStyle.css
@@ -18,6 +18,7 @@
 .gpf-panel__items.GPautoCompleteProposal {
   height: 45px;
   box-sizing: border-box;
+  margin-bottom: 0;
 }
 
 .GPlabelTitle {

--- a/src/packages/CSS/Controls/SearchEngine/GPFsearchEngine.css
+++ b/src/packages/CSS/Controls/SearchEngine/GPFsearchEngine.css
@@ -141,6 +141,7 @@ input[id^=GPadvancedSearchSubmit] {
 
 .GPlabelTitle {
   font-weight: bold;
+  margin-bottom: 0;
 }
 
 [id^="GPautocompleteResults-"] {

--- a/src/packages/CSS/Controls/SearchEngine/GPFsearchEngineStyle.css
+++ b/src/packages/CSS/Controls/SearchEngine/GPFsearchEngineStyle.css
@@ -5,6 +5,24 @@
   align-items: center;
 }
 
+.position-container-top-left [id^="GPsearchEngine-"],
+.position-container-bottom-left [id^="GPsearchEngine-"],
+.position-container-top-right [id^="GPsearchEngine-"],
+.position-container-bottom-right [id^="GPsearchEngine-"] {
+  flex-direction: column;
+  align-items: flex-start;
+  height: 32px;
+}
+
+.position-container-top-left [id^="GPsearchEngine-"] > div[id^=GPautoCompleteList],
+.position-container-bottom-left [id^="GPsearchEngine-"] > div[id^=GPautoCompleteList],
+.position-container-top-right [id^="GPsearchEngine-"] > div[id^=GPautoCompleteList],
+.position-container-bottom-right [id^="GPsearchEngine-"] > div[id^=GPautoCompleteList] {
+  width: 340px;
+  position: relative;
+  top: unset;
+}
+
 .GPshowSearchEnginePicto {
   background-image: url("img/GPsearchEngineOpen.png");
   background-repeat: no-repeat;
@@ -64,6 +82,10 @@
 .GPsearchInputReset {
   background-image: url("img/GPsearchEngineClose.png");
   background-position: 0 center;
+}
+
+.gpf-select {
+  background-color: #FFF;
 }
 
 button[id^="GPshowSearchEnginePicto-"][aria-pressed="false"] + form[id^=GPsearchInput-] {

--- a/src/packages/CSS/GPFgeneralWidget.css
+++ b/src/packages/CSS/GPFgeneralWidget.css
@@ -407,6 +407,7 @@ input.GPsubmit:hover {
   white-space: nowrap;
   text-overflow:ellipsis;
   cursor: pointer;
+  margin-bottom: 0;
 }
 
 .GPautoCompleteProposal:hover {

--- a/src/packages/Controls/SearchEngine/SearchEngineDOM.js
+++ b/src/packages/Controls/SearchEngine/SearchEngineDOM.js
@@ -740,7 +740,7 @@ var SearchEngineDOM = {
     },
 
     _createSearchedSuggestContainer () {
-        var container = document.createElement("select");
+        var container = document.createElement("div");
         container.id = this._addUID("GPautocompleteResultsSuggest");
         container.className = "GPelementHidden gpf-hidden gpf-select";
         container.size = 6;

--- a/src/packages/Controls/SearchEngine/SearchEngineDOM.js
+++ b/src/packages/Controls/SearchEngine/SearchEngineDOM.js
@@ -690,7 +690,7 @@ var SearchEngineDOM = {
     },
 
     _createAutoCompletedLocationContainer () {
-        var container = document.createElement("select");
+        var container = document.createElement("div");
         container.id = this._addUID("GPautocompleteResultsLocation");
         container.className = "GPelementHidden gpf-hidden gpf-select";
         container.size = 20;
@@ -699,7 +699,7 @@ var SearchEngineDOM = {
     },
     _createAutoCompletedLocationTitleElement () {
         var container = document.getElementById(this._addUID("GPautocompleteResultsLocation"));
-        var label = document.createElement("option");
+        var label = document.createElement("p");
         label.className = "GPlabel GPlabelTitle gpf-label fr-label";
         label.innerHTML = "Lieux et adresses";
         container.appendChild(label);
@@ -720,7 +720,7 @@ var SearchEngineDOM = {
 
         var container = document.getElementById(this._addUID("GPautocompleteResultsLocation"));
 
-        var div = document.createElement("option");
+        var div = document.createElement("p");
         div.id = this._addUID("AutoCompletedLocation_" + id);
         div.className = "GPautoCompleteProposal gpf-panel__items gpf-panel__items_searchengine";
         var value = GeocodeUtils.getSuggestedLocationFreeform(location);
@@ -749,7 +749,7 @@ var SearchEngineDOM = {
     },
     _createSearchedSuggestTitleElement () {
         var container = document.getElementById(this._addUID("GPautocompleteResultsSuggest"));
-        var label = document.createElement("option");
+        var label = document.createElement("p");
         label.className = "GPlabel GPlabelTitle gpf-label fr-label";
         label.innerHTML = "Cartes et données";
         container.appendChild(label);
@@ -769,7 +769,7 @@ var SearchEngineDOM = {
 
         var container = document.getElementById(this._addUID("GPautocompleteResultsSuggest"));
 
-        var div = document.createElement("option");
+        var div = document.createElement("p");
         div.id = this._addUID("AutoCompletedSuggest_" + id);
         div.className = "GPautoCompleteProposal gpf-panel__items gpf-panel__items_searchengine";
         div.innerHTML = suggest.title + " (" + suggest.service + ")";


### PR DESCRIPTION
cf. https://github.com/IGNF/cartes.gouv.fr-entree-carto/issues/444

Conversion des `<select><options>` des résultats d'autocompletion, non affichés en mobile (normal), en `<div><p>`.

Pour tester : sur réseau perso, faire tourner les samples sur un PC. Se connecter en wifi avec le téléphone, et entrer l' https://<adresse_ip_du_pc>:<port_des_samples(8080)> dans la barre d'adresse de chrome.



Attention à bien tester en mode desktop.