### PR TITLE
fix(LayerSwitcher) : Zoom sur l'étendu du format MapBox importé

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -35,6 +35,7 @@ __DATE__
   - Positionnement de la fenêtre de résultats d'autocomplétion du searchEngine (#307)
   - Mauvais rendu du profil altimétrique (#303) 
   - Correction du rendu et du comportement du bouton "retour" du layerImport et du geocodage inverse (#316)
+  - Zoom sur l'étendu pour le format MapBox importé (#320)
     
 * 🔒 [Security]
 

--- a/build/webpack/bundle.webpack.config.js
+++ b/build/webpack/bundle.webpack.config.js
@@ -85,6 +85,7 @@ module.exports = (env, argv) => {
         devtool : "source-map",
         stats : "normal",
         devServer : {
+            webSocketServer: false,
             server : "https",
             open : ["samples/index-bundle.html"],
             static : {

--- a/build/webpack/modules.webpack.config.js
+++ b/build/webpack/modules.webpack.config.js
@@ -124,6 +124,7 @@ module.exports = (env, argv) => {
         ],
         devtool : "source-map",
         devServer : {
+            webSocketServer: false,
             server : "https",
             open : ["samples/index-modules.html"],
             static : {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.1-318",
+  "version": "1.0.0-beta.1-320",
   "date": "06/01/2025",
   "module": "src/index.js",
   "directories": {},

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "geoportal-access-lib": "3.4.6",
     "loglevel": "^1.9.1",
     "markdown-toc": "^1.2.0",
-    "ol": "10.3.1",
+    "ol": "8.2.0",
     "ol-mapbox-style": "12.4.0",
     "proj4": "2.15.0",
     "sortablejs": "1.15.3",

--- a/src/packages/Controls/LayerImport/LayerImport.js
+++ b/src/packages/Controls/LayerImport/LayerImport.js
@@ -1469,8 +1469,14 @@ var LayerImport = class LayerImport extends Control {
                                     // TODO : appeler fonction commune
                                     // zoom sur l'étendue des entités récupérées (si possible)
                                     var source = p.layer.getSource();
-                                    if (map.getView() && map.getSize() && source.getExtent) {
-                                        var sourceExtent = source.getExtent();
+                                    if (map.getView() && map.getSize()) {
+                                        var sourceExtent = null;
+                                        if (source && source.getExtent) {
+                                            sourceExtent = source.getExtent();
+                                        } else {
+                                            sourceExtent = source.getTileGrid().getExtent();
+                                        }
+                                        
                                         if (sourceExtent && sourceExtent[0] !== Infinity) {
                                             map.getView().fit(sourceExtent, map.getSize());
                                         }

--- a/src/packages/Controls/LayerSwitcher/LayerSwitcher.js
+++ b/src/packages/Controls/LayerSwitcher/LayerSwitcher.js
@@ -1229,14 +1229,29 @@ var LayerSwitcher = class LayerSwitcher extends Control {
         var error = null;
 
         var map = this.getMap();
-        // cas d'un layer vecteur importé, d'un croquis, d'une couche de calcul
+        // cas d'un layer vecteur 
+        // - importé, 
+        // - d'un croquis, 
+        // - d'une couche de calcul
+        // - enregistré sur l'espace personnel
         if (data.layer.hasOwnProperty("gpResultLayerId") && 
-            (data.layer.gpResultLayerId.split(":")[0] === "layerimport" || data.layer.gpResultLayerId.split(":")[0] === "drawing"
-            || data.layer.gpResultLayerId.split(":")[0] === "compute")) {
+            (data.layer.gpResultLayerId.split(":")[0] === "layerimport" || 
+            data.layer.gpResultLayerId.split(":")[0] === "drawing" || 
+            data.layer.gpResultLayerId.split(":")[0] === "compute" ||
+            data.layer.gpResultLayerId.split(":")[0] === "bookmark"
+            )) {
             // TODO : appeler fonc  tion commune
             // zoom sur l'étendue des entités récupérées (si possible)
             if (map.getView() && map.getSize()) {
-                var sourceExtent = data.layer.getExtent() || data.layer.getSource().getExtent();
+                var sourceExtent = data.layer.getExtent();
+                if (!sourceExtent) {
+                    var source = data.layer.getSource();
+                    if (source && source.getExtent) {
+                        sourceExtent = source.getExtent();
+                    } else {
+                        sourceExtent = source.getTileGrid().getExtent();
+                    }
+                }
                 if (sourceExtent && sourceExtent[0] !== Infinity) {
                     map.getView().fit(sourceExtent, map.getSize());
                 }


### PR DESCRIPTION
cf. issue #235 et #51 

Pour le format **MapBox** importé, on peut utiliser le _zoom2Extent_ du **LayerSwitcher**.
Le calcul est réalisé via la grille des tuiles.

Pour tester, il suffit d'importer un fichier MapBox, le zoom sur l'étendu est realisé automatiquement.
Ensuite, on zoom et on se déplace sur la carte, et on procède à un zoom sur l'étendu dans le gestionnaire de couches.