### PR TITLE
Fix(LocationSelector/LayerImport) : Corrections sur la taille des fenêtres de résultats d'imports et d'autocomplétion

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -29,6 +29,8 @@ __DATE__
 
   - ContextMenu : correction pour affichage du menu en mode dark (#332, #333)
   - Export : mise en conformité DSFR du bouton Export (#334)
+  - LocationSelector : fenêtre transparente en mode classique et pas assez large en mode DSFR (#349)
+  - LayerImport : fenêtre d'affichage des getCapabilities agrandie (#349)
   
 * 🔒 [Security]
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.2-346",
-  "date": "03/02/2025",
+  "version": "1.0.0-beta.2-349",
+  "date": "07/02/2025",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/src/packages/CSS/Controls/LayerImport/DSFRlayerImportStyle.css
+++ b/src/packages/CSS/Controls/LayerImport/DSFRlayerImportStyle.css
@@ -11,5 +11,15 @@
 }
 
 div[id^="GPimportGetCapResults-"] {
-    width: inherit;
+  width: inherit;
+}
+
+div[id^="GPimportGetCapResults-"],
+div[id^="GPimportMapBoxResults-"] {
+    height: fit-content;
+    max-height: unset;
+}
+
+[id^="GPimportPanel-"]:has([id^="GPimportGetCapPanel-"].gpf-visible) {
+  height: 350px;
 }

--- a/src/packages/CSS/Controls/LayerImport/DSFRlayerImportStyle.css
+++ b/src/packages/CSS/Controls/LayerImport/DSFRlayerImportStyle.css
@@ -9,3 +9,7 @@
   list-style-type: none;
   height: auto;
 }
+
+div[id^="GPimportGetCapResults-"] {
+    width: inherit;
+}

--- a/src/packages/CSS/Controls/LayerImport/GPFlayerImport.css
+++ b/src/packages/CSS/Controls/LayerImport/GPFlayerImport.css
@@ -77,9 +77,6 @@ input[id^="GPimportSubmit-"] {
 div[id^="GPimportGetCapResults-"],
 div[id^="GPimportMapBoxResults-"] {
     background-color: #FFF;
-    height: 140px;
-    overflow-y: auto;
-    resize: vertical;
 }
 
 input[id^="GPimportGetCapRubrique-"],

--- a/src/packages/CSS/Controls/LayerImport/GPFlayerImportStyle.css
+++ b/src/packages/CSS/Controls/LayerImport/GPFlayerImportStyle.css
@@ -20,6 +20,13 @@ div[id^="GPimportChoice-"] {
   margin-bottom: 5px;
 }
 
+div[id^="GPimportGetCapResults-"],
+div[id^="GPimportMapBoxResults-"] {
+    height: 140px;
+    overflow-y: auto;
+    resize: vertical;
+}
+
 .GPshowImportPicto {
   background-image: url("img/GPimportOpen.png");
   background-repeat: no-repeat;

--- a/src/packages/CSS/Controls/LocationSelector/DSFRlocationStyle.css
+++ b/src/packages/CSS/Controls/LocationSelector/DSFRlocationStyle.css
@@ -78,3 +78,9 @@
   flex-basis: 33%;
   flex-grow: 1;
 }
+
+div[id^=GPlocationAutoCompleteResult] {
+  background-color: var(--background-default-grey);
+  border: 1px solid var(--grey-900-175);
+  width: 281px;
+}

--- a/src/packages/CSS/Controls/LocationSelector/GPFlocation.css
+++ b/src/packages/CSS/Controls/LocationSelector/GPFlocation.css
@@ -20,13 +20,10 @@ div[id^=GPlocationAutoCompleteResult] {
   left: 0px;
   max-height: 140px;
   overflow-y: auto;
-  background-color: var(--background-default-grey);;
-  border: 1px solid var(--grey-900-175);
   border-top: none;
 }
 
 div[id^=GPlocationAutoCompleteList] {
   position: absolute;
   z-index: 2;
-  width: calc(100% - 56px);
 }

--- a/src/packages/CSS/Controls/LocationSelector/GPFlocationStyle.css
+++ b/src/packages/CSS/Controls/LocationSelector/GPFlocationStyle.css
@@ -52,6 +52,11 @@ button.GPlocationOriginPointerImg[id*="GPlocationOriginPointerImg"] {
     margin-bottom: 5px;
 }
 
-div[id^=GPlocationAutoCompleteList] {
+div[id^=GPlocationAutoCompleteResult] {
+  background-color: #fff;
+  border: 1px solid grey;
+}
 
+div[id^=GPlocationAutoCompleteList] {
+  width: 100%;
 }

--- a/src/packages/CSS/Controls/ReverseGeocoding/DSFRreverseGeocodingStyle.css
+++ b/src/packages/CSS/Controls/ReverseGeocoding/DSFRreverseGeocodingStyle.css
@@ -15,3 +15,9 @@
   /* INFO : surcharge de .gpf-panel par defaut */
   width: 100%;
 }
+
+/* Result panel */
+
+div[id^=GPreverseGeocodingResultsList-] {
+  width: inherit;
+}

--- a/src/packages/CSS/Controls/SearchEngine/GPFsearchEngineStyle.css
+++ b/src/packages/CSS/Controls/SearchEngine/GPFsearchEngineStyle.css
@@ -18,7 +18,6 @@
 .position-container-bottom-left [id^="GPsearchEngine-"] > div[id^=GPautoCompleteList],
 .position-container-top-right [id^="GPsearchEngine-"] > div[id^=GPautoCompleteList],
 .position-container-bottom-right [id^="GPsearchEngine-"] > div[id^=GPautoCompleteList] {
-  width: 340px;
   position: relative;
   top: unset;
 }

--- a/src/packages/CSS/DSFRgeneralWidget.css
+++ b/src/packages/CSS/DSFRgeneralWidget.css
@@ -331,7 +331,7 @@ div:not(.position) > .gpf-widget > .gpf-btn-icon[aria-label]:hover::before {
 .gpf-panel__list,
 .gpf-panel__advancedlist {
   z-index: 2;
-  width: inherit;
+  /* width: inherit; */
   /* display: none; */
   position: absolute;
   max-height: 140px;

--- a/src/packages/CSS/DSFRgeneralWidget.css
+++ b/src/packages/CSS/DSFRgeneralWidget.css
@@ -168,6 +168,8 @@
   }
 }
 
+/* Affichage du tooltip au survol du bouton */
+
 .gpf-widget > .gpf-btn-icon[aria-label]:hover::before {
   content: attr(aria-label);
   position: absolute;

--- a/src/packages/Controls/LocationSelector/LocationSelectorDOM.js
+++ b/src/packages/Controls/LocationSelector/LocationSelectorDOM.js
@@ -483,6 +483,7 @@ var LocationSelectorDOM = {
         var div = document.createElement("div");
         div.id = this._addUID("AutoCompletedLocation_" + n);
         div.className = "GPautoCompleteProposal gpf-panel__items";
+        div.title = GeocodeUtils.getSuggestedLocationFreeform(location);
         div.innerHTML = GeocodeUtils.getSuggestedLocationFreeform(location);
 
         container.appendChild(div);


### PR DESCRIPTION
fix #344 
fix #345 

Tester en mode classique et DSFR : 
- location selector partout où ils sont (route, isochrone..)
- import de couches (getCap WMS/WMTS + TMS)

# LayerImport

## Panel résultats de getCap

La fenêtre des résultats n'est pas assez haute.

### DSFR
**AVANT**
![image](https://github.com/user-attachments/assets/9b3a1125-7daa-4834-a247-17dc678ba1b6)


**APRES**
![image](https://github.com/user-attachments/assets/6624caa9-44a7-48a1-80c2-1b8865c0a1b7)
![image](https://github.com/user-attachments/assets/1ed3dd86-a7aa-4f88-a3e1-bdfb240dda70)

### CLASSIC
**AVANT**
![image](https://github.com/user-attachments/assets/f1899c1f-b722-473d-a6c7-f5d2795fceb4)
![image](https://github.com/user-attachments/assets/d72b98b2-3a1f-4bc5-a847-72bea2a7510c)

**APRES**
![image](https://github.com/user-attachments/assets/b0d84bfa-11a8-408d-820e-80009557cbca)
![image](https://github.com/user-attachments/assets/35a88dd0-ff30-452b-89b2-4c076382c0a0)


# LocationSelector

## Panel résultats d'autocompéltion

Augmentation de la largeur
Ajout d'une infobulle au survol long
Correction de la fenêtre transparente en mode classic

### DSFR
**AVANT**
![image](https://github.com/user-attachments/assets/9e5d8887-b5da-4ae8-8288-28b8170de057)


**APRES**
![image](https://github.com/user-attachments/assets/31ea8aac-99fc-4706-be9b-197da61f3fa1)


### CLASSIC
**AVANT**
![image](https://github.com/user-attachments/assets/66177a36-75f9-44eb-9793-ad53de180f5d)

**APRES**
![image](https://github.com/user-attachments/assets/7ecf322f-557e-4363-ba1e-b0d94c8c2ca1)

