### PR TITLE
Feature/filter layers search by config

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -31,7 +31,7 @@ __DATE__
   - Export : mise en conformité DSFR du bouton Export (#334)
   - LocationSelector : fenêtre transparente en mode classique et pas assez large en mode DSFR (#349)
   - LayerImport : fenêtre d'affichage des getCapabilities agrandie (#349)
-  - Search : ajout wfs fonctionnel et filtre automatique des suggests selon la configuration si liste non spécifiée (#351)
+  - Search : ajout wfs fonctionnel et filtre automatique des suggests selon la configuration si liste non spécifiée (#352)
  
 * 🔒 [Security]
 

--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -31,7 +31,8 @@ __DATE__
   - Export : mise en conformité DSFR du bouton Export (#334)
   - LocationSelector : fenêtre transparente en mode classique et pas assez large en mode DSFR (#349)
   - LayerImport : fenêtre d'affichage des getCapabilities agrandie (#349)
-  
+  - Search : ajout wfs fonctionnel et filtre automatique des suggests selon la configuration si liste non spécifiée (#351)
+ 
 * 🔒 [Security]
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.2-351",
+  "version": "1.0.0-beta.2-352",
   "date": "12/02/2025",
   "module": "src/index.js",
   "directories": {},

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.2-349",
-  "date": "07/02/2025",
+  "version": "1.0.0-beta.2-351",
+  "date": "12/02/2025",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/samples-src/pages/tests/SearchEngine/pages-ol-searchengine-modules-dsfr-default.html
+++ b/samples-src/pages/tests/SearchEngine/pages-ol-searchengine-modules-dsfr-default.html
@@ -14,25 +14,12 @@
         <style>
             div#map {
                 width: 100%;
-                height: 500px;
+                height: 800px;
             }
         </style>
 {{/content}}
 
 {{#content "body"}}
-            <h2>Ajout du moteur de recherche avec les options par défaut</h2>
-            <p>
-                Liste des couches prioritaires :
-                <pre> 
-                PLAN.IGN,
-                GEOGRAPHICALGRIDSYSTEMS.MAPS.BDUNI.J1,
-                GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2,
-                CADASTRALPARCELS.PARCELLAIRE_EXPRESS,
-                ORTHOIMAGERY.ORTHOPHOTOS
-                </pre>
-
-                Ex. si on saisie 'ortho', la couche "photographies aeriennes" devrait sortir en 1ere position.
-            </p>
             <!-- map -->
             <div id="map">
             </div>

--- a/samples-src/pages/tests/SearchEngine/pages-ol-searchengine-modules-dsfr-default.html
+++ b/samples-src/pages/tests/SearchEngine/pages-ol-searchengine-modules-dsfr-default.html
@@ -65,6 +65,7 @@
                         searchOptions: {
                             addToMap: true,
                             filterServices : "WMTS,WMS,TMS,WFS",
+                            // filterLayers : ["GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2"],
                             filterLayersPriority : "PLAN.IGN,GEOGRAPHICALGRIDSYSTEMS.MAPS.BDUNI.J1,GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2,CADASTRALPARCELS.PARCELLAIRE_EXPRESS,ORTHOIMAGERY.ORTHOPHOTOS",
                             filterWMTSPriority : true,
                             serviceOptions: {

--- a/src/packages/Controls/SearchEngine/SearchEngine.js
+++ b/src/packages/Controls/SearchEngine/SearchEngine.js
@@ -82,6 +82,7 @@ var logger = Logger.getLogger("searchengine");
  * @param {String}  [options.searchOptions.filterWMTSPriority] - filter on priority WMTS layer in search, each field is separated by a comma. "PLAN.IGN,ORTHOIMAGERY.ORTHOPHOTOS" by default
  * @param {Boolean}  [options.searchOptions.filterLayersPriority = false] - filter on priority layers in search, false by default
  * @param {String}  [options.searchOptions.filterVectortiles] - filter on list of search layers only on service TMS, each field is separated by a comma. "PLAN.IGN, ..." by default
+ * @param {String}  [options.searchOptions.filterLayers] - filter on list of search layers list. By Default, the layers available in Config.configuration.layers
  * @param {Boolean} [options.searchOptions.updateVectortiles = false] - updating the list of search layers only on service TMS
  * @param {Object}  [options.searchOptions.serviceOptions] - options of search service
  * @param {Sring}   [options.searchOptions.serviceOptions.url] - url of service
@@ -387,7 +388,11 @@ var SearchEngine = class SearchEngine extends Control {
             // abonnement au service
             Search.target.addEventListener("suggest", (e) => {
                 logger.debug(e);
-                this._fillSearchedSuggestListContainer(e.detail);
+                let suggestResults = e.detail;
+                console.log(Config);
+                
+                suggestResults = this._filterResultsFromConfigLayers(suggestResults);
+                this._fillSearchedSuggestListContainer(suggestResults);
             });
         }
 
@@ -1112,6 +1117,30 @@ var SearchEngine = class SearchEngine extends Control {
                 const suggest = suggests[i];
                 this._createSearchedSuggestElement(suggest, i);
             }
+        }
+    }
+
+    /**
+     * this method is called by this.() (case of success)
+     * and clean the results of the suggest list from a list of layers
+     * by default, the Config.layers list.
+     *
+     * @param {Array} suggests - Array of suggested corresponding to search results list
+     * @private
+     */
+    _filterResultsFromConfigLayers (suggests) {
+        var layerList;
+        if (this.options.searchOptions.filterLayers) {
+            return;
+        } else {
+            console.log(Config);
+            var layersObject = Config.configuration.layers;
+            for (let layer in layersObject) {
+                if (layersObject.hasOwnProperty(layer)) {
+                    layerList.push(Gp.Config.layers[layer].name);
+                }
+            }       
+            console.log(layerList);
         }
     }
 

--- a/src/packages/Controls/SearchEngine/SearchEngine.js
+++ b/src/packages/Controls/SearchEngine/SearchEngine.js
@@ -27,6 +27,7 @@ import CRS from "../../CRS/CRS";
 // import local des layers
 import GeoportalWMS from "../../Layers/LayerWMS";
 import GeoportalWMTS from "../../Layers/LayerWMTS";
+import GeoportalWFS from "../../Layers/LayerWFS";
 import GeoportalMapBox from "../../Layers/LayerMapBox";
 // Service
 import Search from "../../Services/Search";
@@ -1126,22 +1127,29 @@ var SearchEngine = class SearchEngine extends Control {
      * by default, the Config.layers list.
      *
      * @param {Array} suggests - Array of suggested corresponding to search results list
+     * @returns {Array} suggests - Array of suggested corresponding to search results list filtered by Config
      * @private
      */
     _filterResultsFromConfigLayers (suggests) {
-        var layerList;
+        var layerList = [];
         if (this.options.searchOptions.filterLayers) {
-            return;
+            layerList = this.options.searchOptions.filterLayers;
         } else {
-            console.log(Config);
-            var layersObject = Config.configuration.layers;
+            var layersObject = window.Gp.Config.layers;
             for (let layer in layersObject) {
                 if (layersObject.hasOwnProperty(layer)) {
-                    layerList.push(Gp.Config.layers[layer].name);
+                    layerList.push(layersObject[layer].name);
                 }
-            }       
-            console.log(layerList);
+            }
         }
+        let i = suggests.length;
+        while (i--) {                
+            if (!layerList.includes(suggests[i].name)) {
+                suggests.splice(i, 1);
+            }
+        }  
+        Search.setSuggestions(suggests);
+        return suggests;
     }
 
     /**
@@ -1997,6 +2005,11 @@ var SearchEngine = class SearchEngine extends Control {
                         break;
                     case "WMTS":
                         layer = new GeoportalWMTS({
+                            layer : name
+                        });
+                        break;
+                    case "WFS":
+                        layer = new GeoportalWFS({
                             layer : name
                         });
                         break;

--- a/src/packages/Controls/SearchEngine/SearchEngine.js
+++ b/src/packages/Controls/SearchEngine/SearchEngine.js
@@ -390,8 +390,7 @@ var SearchEngine = class SearchEngine extends Control {
             Search.target.addEventListener("suggest", (e) => {
                 logger.debug(e);
                 let suggestResults = e.detail;
-                console.log(Config);
-                
+                // filtre des suggestions selon la configuration ou l'option filterLayers                
                 suggestResults = this._filterResultsFromConfigLayers(suggestResults);
                 this._fillSearchedSuggestListContainer(suggestResults);
             });

--- a/src/packages/Services/Search.js
+++ b/src/packages/Services/Search.js
@@ -389,6 +389,14 @@ const setFields = (value) => {
     m_fields = value;
 };
 /**
+ * Renseigne la liste des suggestions
+ * @param {Array} value - liste des suggestions
+ * @see m_suggestions
+ */
+const setSuggestions = (value) => {
+    m_suggestions = value;
+};
+/**
  * Renseigne le nombre de suggestions du service
  * @param {Number} value - le nombre de suggestions du service
  * @see m_size
@@ -488,6 +496,7 @@ export default {
     getTitles,
     setIndex,
     setFields,
+    setSuggestions,
     setSize,
     setUrl,
     setMaximumResponses,


### PR DESCRIPTION
### 1 - Filtrage des données par Config

Ajout d'un filtrage des résultats affichés pour la recherche de données en autocomplétion par la barre de recherche.

Par défaut, ce filtrage va comparer les couches proposées (suggests) après filtrage par le service Search avec les couches listées dans Gp.Config.Layers (on compare layer.name, un filtrage permettant d'éviter les doublons par service étant déjà effectué auparavant))

Si une couche de suggests n'est pas dans Gp.Config, on la retire des entrées à afficher.

### 2 - Filtrage des données par liste en paramètre

L'option du SearchEngine searchOptions.filterLayers est ajoutée. Elle prend un tableau de layerNames, et filtre les suggests dessus.

ex. L'autocomplétion ne renverra que l'entrée ayant le layerName "GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2"
```javascript
searchOptions: {
    filterLayers : ["GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2"]
}
```

Utilisée dans l'entrée carto (cf https://github.com/IGNF/cartes.gouv.fr-entree-carto/pull/483) pour mettre en cohérence les résultats de l'autocomplétion avec le catalogue : on lui donne la liste des couches du dataStore.

### 3 - Affichage des WFS

Jusqu'à présent, les WFS peuvent être renvoyés dans les suggests si on ne filtre pas pour les retirer.

ex.
```javascript
searchOptions: {
        filterServices : "WMTS,WMS,TMS,WFS"
}
```
Problème : ils ne sont pas affichés au clic car non interfacés par le SearchEngine. Le travail d'ajout de la classe GeoportalWFS ayant déjà été réalisé, il suffit de traiter le cas où _service = WFS_ dans la fonction _onSearchedResultsItemClick_ : 

```javascript
                    case "WFS":
                        layer = new GeoportalWFS({
                            layer : name
                        });
                    break;
```