### PR TITLE
feat(searchEngine): ajout d'un filtre par projection des données

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -16,11 +16,12 @@ __DATE__
 * ✨ [Added]
 
   - LayerSwitcher : ajout d'un bouton d'édition des données de type vecteur via l'option `options.allowEdit:true` (#342)
+  - SearchEngine : ajout d'un filtre sur les données en fonction de leur projection (#353) 
 
 * 🔨 [Changed]
 
-    - ContextMenu: refacto et documentation du code du menu contextuel (#340)
-    - ContextMenu: Adresse : affichage du nom de commune quand il n'y a pas d'adresse (#351)
+  - ContextMenu: refacto et documentation du code du menu contextuel (#340)
+  - ContextMenu: Adresse : affichage du nom de commune quand il n'y a pas d'adresse (#351)
 
 * 🔥 [Deprecated]
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.2-352",
-  "date": "12/02/2025",
+  "version": "1.0.0-beta.2-353",
+  "date": "13/02/2025",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/samples-src/pages/tests/SearchEngine/pages-ol-searchengine-modules-dsfr-default.html
+++ b/samples-src/pages/tests/SearchEngine/pages-ol-searchengine-modules-dsfr-default.html
@@ -65,7 +65,7 @@
                         searchOptions: {
                             addToMap: true,
                             filterServices : "WMTS,WMS,TMS,WFS",
-                            // filterProjections: "IGNF:LAMB93",
+                            // filterProjections: "IGNF:LAMB93,EPSG:2154",
                             // filterLayers : ["GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2"],
                             filterLayersPriority : "PLAN.IGN,GEOGRAPHICALGRIDSYSTEMS.MAPS.BDUNI.J1,GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2,CADASTRALPARCELS.PARCELLAIRE_EXPRESS,ORTHOIMAGERY.ORTHOPHOTOS",
                             filterWMTSPriority : true,

--- a/samples-src/pages/tests/SearchEngine/pages-ol-searchengine-modules-dsfr-default.html
+++ b/samples-src/pages/tests/SearchEngine/pages-ol-searchengine-modules-dsfr-default.html
@@ -65,6 +65,7 @@
                         searchOptions: {
                             addToMap: true,
                             filterServices : "WMTS,WMS,TMS,WFS",
+                            // filterProjections: "IGNF:LAMB93",
                             // filterLayers : ["GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2"],
                             filterLayersPriority : "PLAN.IGN,GEOGRAPHICALGRIDSYSTEMS.MAPS.BDUNI.J1,GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2,CADASTRALPARCELS.PARCELLAIRE_EXPRESS,ORTHOIMAGERY.ORTHOPHOTOS",
                             filterWMTSPriority : true,

--- a/src/packages/Controls/SearchEngine/SearchEngine.js
+++ b/src/packages/Controls/SearchEngine/SearchEngine.js
@@ -79,17 +79,17 @@ var logger = Logger.getLogger("searchengine");
  * @param {Boolean} [options.resources.search = false] - false to disable search service, by default : "false"
  * @param {Object}  [options.searchOptions = {}] - options of search service
  * @param {Boolean} [options.searchOptions.addToMap = true] - add layer automatically to map, defaults to true.
- * @param {String}  [options.searchOptions.filterServices] - filter on a list of search services, each field is separated by a comma. "WMTS,TMS" by default
- * @param {String}  [options.searchOptions.filterWMTSPriority] - filter on priority WMTS layer in search, each field is separated by a comma. "PLAN.IGN,ORTHOIMAGERY.ORTHOPHOTOS" by default
- * @param {String}  [options.searchOptions.filterProjections] - filter on a list of projections : the searchEngine ignore the suggestions with one of the projections listed. Each field is separated by a comma.
+ * @param {String[]}  [options.searchOptions.filterServices] - filter on a list of search services, each field is separated by a comma. "WMTS,TMS" by default
+ * @param {String[]}  [options.searchOptions.filterWMTSPriority] - filter on priority WMTS layer in search, each field is separated by a comma. "PLAN.IGN,ORTHOIMAGERY.ORTHOPHOTOS" by default
+ * @param {String[]}  [options.searchOptions.filterProjections] - filter on a list of projections : the searchEngine ignore the suggestions with one of the projections listed. Each field is separated by a comma.
  * @param {Boolean}  [options.searchOptions.filterLayersPriority = false] - filter on priority layers in search, false by default
- * @param {String}  [options.searchOptions.filterVectortiles] - filter on list of search layers only on service TMS, each field is separated by a comma. "PLAN.IGN, ..." by default
- * @param {String}  [options.searchOptions.filterLayers] - filter on list of search layers list. By Default, the layers available in Config.configuration.layers
+ * @param {String[]}  [options.searchOptions.filterVectortiles] - filter on list of search layers only on service TMS, each field is separated by a comma. "PLAN.IGN, ..." by default
+ * @param {String[]}  [options.searchOptions.filterLayers] - filter on list of search layers list. By Default, the layers available in Config.configuration.layers
  * @param {Boolean} [options.searchOptions.updateVectortiles = false] - updating the list of search layers only on service TMS
  * @param {Object}  [options.searchOptions.serviceOptions] - options of search service
- * @param {Sring}   [options.searchOptions.serviceOptions.url] - url of service
+ * @param {String}   [options.searchOptions.serviceOptions.url] - url of service
  * @param {String}  [options.searchOptions.serviceOptions.index] - index of search, "standard" by default
- * @param {String}  [options.searchOptions.serviceOptions.fields] - list of search fields, each field is separated by a comma. "title,layer_name" by default
+ * @param {String[]}  [options.searchOptions.serviceOptions.fields] - list of search fields, each field is separated by a comma. "title,layer_name" by default
  * @param {Number}  [options.searchOptions.serviceOptions.size] - number of response in the service. 1000 by default
  * @param {Number}  [options.searchOptions.serviceOptions.maximumResponses] - number of results in the response. 10 by default
  * @param {Object}  [options.geocodeOptions = {}] - options of geocode service (see {@link http://ignf.github.io/geoportal-access-lib/latest/jsdoc/module-Services.html#~geocode Gp.Services.geocode})

--- a/src/packages/Controls/SearchEngine/SearchEngine.js
+++ b/src/packages/Controls/SearchEngine/SearchEngine.js
@@ -81,6 +81,7 @@ var logger = Logger.getLogger("searchengine");
  * @param {Boolean} [options.searchOptions.addToMap = true] - add layer automatically to map, defaults to true.
  * @param {String}  [options.searchOptions.filterServices] - filter on a list of search services, each field is separated by a comma. "WMTS,TMS" by default
  * @param {String}  [options.searchOptions.filterWMTSPriority] - filter on priority WMTS layer in search, each field is separated by a comma. "PLAN.IGN,ORTHOIMAGERY.ORTHOPHOTOS" by default
+ * @param {String}  [options.searchOptions.filterProjections] - filter on a list of projections : the searchEngine ignore the suggestions with one of the projections listed. Each field is separated by a comma.
  * @param {Boolean}  [options.searchOptions.filterLayersPriority = false] - filter on priority layers in search, false by default
  * @param {String}  [options.searchOptions.filterVectortiles] - filter on list of search layers only on service TMS, each field is separated by a comma. "PLAN.IGN, ..." by default
  * @param {String}  [options.searchOptions.filterLayers] - filter on list of search layers list. By Default, the layers available in Config.configuration.layers
@@ -378,6 +379,9 @@ var SearchEngine = class SearchEngine extends Control {
                 }
                 if (this.options.searchOptions.filterWMTSPriority) {
                     Search.setFilterWMTSPriority(this.options.searchOptions.filterWMTSPriority);
+                }
+                if (this.options.searchOptions.filterProjections) {
+                    Search.setFiltersByProjection(this.options.searchOptions.filterProjections);
                 }
                 if (this.options.searchOptions.filterVectortiles) {
                     Search.setFiltersByTMS(this.options.searchOptions.filterVectortiles);


### PR DESCRIPTION
Interfacage du filtre par projection.

Le paramètre filterProjection passé au SearchEngine permet d'ignorer les couches ayant l'une des projections listées.

EX. options pour que l'autocomplétion ne renvoie aucune couche en lambert 93.

```javascript
                        searchOptions: {
                            filterProjections: "IGNF:LAMB93"
                            }
                        },
```

Voir ligne commentée dans exemple searchengine dsfr