### PR TITLE
fix(advanced-search): tout était cassé

### DIFF
--- a/src/packages/CSS/Controls/SearchEngine/DSFRsearchEngineStyle.css
+++ b/src/packages/CSS/Controls/SearchEngine/DSFRsearchEngineStyle.css
@@ -159,10 +159,10 @@ button[id^="GPshowSearchEnginePicto-"] {
   background-position: -25px center;
 }
 
+dialog[id^=GPgeocodeResultsList],
 dialog[id^=GPcoordinateSearchPanel],
 dialog[id^="GPadvancedSearchPanel"] {
   position: absolute;
-  top: 66px;
   width: inherit;
 }
 
@@ -172,8 +172,7 @@ dialog[id^="GPadvancedSearchPanel"] {
   border: 1px solid var(--background-open-blue-france);
 }
 
-div[id^=GPautoCompleteList],
-dialog[id^=GPgeocodeResultsList] {
+div[id^=GPautoCompleteList] {
   width: 320px;
   position: absolute;
   height: fit-content;
@@ -208,10 +207,10 @@ div[id^=GPautoCompleteList] {
 }
 
 dialog[id^=GPgeocodeResultsList] {
-  position: absolute;
-  top: 55px;
-  border-radius: 4px;
   overflow: hidden;
+  max-height: unset;
+  height: inherit;
+  bottom: unset;
 }
 
 div[id^=GPgeocodeResults-] {

--- a/src/packages/CSS/Controls/SearchEngine/GPFsearchEngine.css
+++ b/src/packages/CSS/Controls/SearchEngine/GPFsearchEngine.css
@@ -150,8 +150,7 @@ input[id^=GPadvancedSearchSubmit] {
   width: 100%;
 }
 
-[id^="GPautoCompleteList"],
-dialog[id^="GPgeocodeResultsList"] {
+[id^="GPautoCompleteList"] {
   margin-left: 33px;
 }
 
@@ -159,12 +158,6 @@ dialog[id^="GPgeocodeResultsList"] {
   /* overflow-y: auto; */
 }
 
-dialog[id^="GPgeocodeResultsList"] {
-  top: 35px;
-  border-radius: 4px;
-  height: inherit;
-  bottom: unset; /* fix dsfr */
-}
 
 [id^="GPautocompleteResultsSuggest"],
 [id^="GPautocompleteResultsLocation"] {

--- a/src/packages/CSS/Controls/SearchEngine/GPFsearchEngineStyle.css
+++ b/src/packages/CSS/Controls/SearchEngine/GPFsearchEngineStyle.css
@@ -162,6 +162,7 @@ dialog[id^=GPgeocodeResultsList] {
   background-color: var(--background-default-grey);
 }
 
+
 div[id^=GPautoCompleteList] {
   top: 35px;
 }
@@ -171,7 +172,9 @@ dialog[id^=GPgeocodeResultsList] {
   top: 35px;
   border-radius: 4px;
   overflow: hidden;
+  margin-left: 33px;
 }
+
 
 div[id^=GPgeocodeResults-] {
   width: 100%;

--- a/src/packages/Controls/SearchEngine/SearchEngine.js
+++ b/src/packages/Controls/SearchEngine/SearchEngine.js
@@ -2180,6 +2180,16 @@ var SearchEngine = class SearchEngine extends Control {
         if (this._currentGeocodingCode === "CadastralParcel") {
             _location = "";
         }
+        console.log(this._currentGeocodingCode);
+        console.log(data);
+        if (this._currentGeocodingCode === "StreetAddress") {
+            _location = `${_filterOptions.address} ${_filterOptions.postcode} ${_filterOptions.city}`;
+            _filterOptions = {};
+        }
+        if (this._currentGeocodingCode === "PositionOfInterest") {
+            _location = _filterOptions.q;
+            delete _filterOptions.q;
+        }
 
         // on met en place l'affichage des resultats dans une fenetre de recherche.
         var context = this;

--- a/src/packages/Controls/SearchEngine/SearchEngineDOM.js
+++ b/src/packages/Controls/SearchEngine/SearchEngineDOM.js
@@ -590,8 +590,6 @@ var SearchEngineDOM = {
         div.id = this._addUID("GPgeocodeResultsList");
         div.className = "GPpanel GPelementHidden gpf-panel gpf-hidden fr-modal";
 
-        div.appendChild(this._createGeocodeResultsHeaderElement());
-
         // FIXME on decompose la fonction pour les besoins du controle,
         // on ajoutera ces childs à la main...
         // div.appendChild(this._createGeocodeResultsListElement ());
@@ -602,6 +600,8 @@ var SearchEngineDOM = {
     _createGeocodeResultsDivElement : function () {
         var div = document.createElement("div");
         div.className = "gpf-panel__body fr-modal__body";
+        div.appendChild(this._createGeocodeResultsHeaderElement());
+
         return div;
     },
 

--- a/src/packages/Utils/SearchEngineUtils.js
+++ b/src/packages/Utils/SearchEngineUtils.js
@@ -17,6 +17,10 @@ var SearchEngineUtils = {
     advancedSearchFiltersByDefault : {
         PositionOfInterest : [
             {
+                name : "q",
+                title : "Chercher un lieu"
+            },
+            {
                 name : "category",
                 title : "Type",
                 value : [
@@ -39,7 +43,8 @@ var SearchEngineUtils = {
                     "zone d'habitation",
                     "lieu-dit non habité"
                 ]
-            }, {
+            },
+            {
                 name : "postcode",
                 title : "Code postal"
             }, {
@@ -49,14 +54,15 @@ var SearchEngineUtils = {
         ],
         StreetAddress : [
             {
+                name : "address",
+                title : "Adresse"
+            },
+            {
                 name : "city",
                 title : "Ville"
             }, {
                 name : "postcode",
                 title : "Code postal"
-            }, {
-                name : "citycode",
-                title : "Code INSEE"
             }
         ],
         CadastralParcel : [


### PR DESCRIPTION
fixes https://github.com/IGNF/geopf-extensions-openlayers/issues/321

- ajout d'un champ texte dans lieux et adresses
- la recherche d'adresse renvoie désormais des résultats
- (dsfr) modification du css pour éviter la confusion (champ de recherche caché)
- (dsfr) amélioration du css des résultats