### PR TITLE
feat(catalog): Branchement du service de recherche pour constituer le catalogue

### DIFF
--- a/src/packages/Controls/Catalog/Catalog.js
+++ b/src/packages/Controls/Catalog/Catalog.js
@@ -88,8 +88,8 @@ var logger = Logger.getLogger("widget");
  * widget.on("catalog:layer:remove", (e) => { console.log(e); });
  * map.addControl(widget);
  *
- * @todo filtrage des couches
- * @todo type:service
+ * @todo ajouter des filtres sur les couches
+ * @todo mise en place du type:service afin de récuperer les themes, producteurs et/ou conf tech (extra)
  * @todo validation du schema
  */
 var Catalog = class Catalog extends Control {


### PR DESCRIPTION
# Evolutions du catalogue

## Branchement du service de recherche

Actuellement, pour constituer le catalogue de données, on branche des JSONs : 
* conf(s) technique(s)
* éditorial

Hors, on souhaite compléter le catalogue avec des informations disponibles dans le service de recherche.
* thèmes
* producteurs
* d'autres paramètres technique (extra)

Fonctionnement actuel avec des URLs sur les JSONs techniques et éditorial : 
```js
var catalog = new ol.control.Catalog({
     configuration : {
       type : "json",
       urls : [
            "https://raw.githubusercontent.com/IGNF/cartes.gouv.fr-entree-carto/main/public/data/layers.json",
            "https://raw.githubusercontent.com/IGNF/cartes.gouv.fr-entree-carto/main/public/data/edito.json"
        ]
     }
});
```

:warning: Trouver une solution **élégante** pour appeler le service de recherche : 
```js
var catalog = new ol.control.Catalog({
     configurations : [
       {
          type : "data",
          data : {<!-- JSON -->}
       },
       {
         type : "json",
         urls : [
            "https://raw.githubusercontent.com/IGNF/cartes.gouv.fr-entree-carto/main/public/data/layers.json",
            "https://raw.githubusercontent.com/IGNF/cartes.gouv.fr-entree-carto/main/public/data/edito.json"
         ]
      },
      {
        type : "service",
        urls : [
          "https:// data.geopf.fr/recherche/api/indexes/geoplateforme/suggest?text=${thematic}&fields=thematic",
          "https:// data.geopf.fr/recherche/api/indexes/geoplateforme/suggest?text=${producer}&fields=producer"
      }
   ]
});
```
## Validation du schema des réponses

> facultatif

Le catalogue est issu de plusieurs types de données ou service.
Il est donc important de valider les réponses avant de _merger_ les résultats.

## Ajouter des filtres sur les couches

On souhaite filtrer au préalable les données du catalogue.
Ex. on veut un catalogue de couches WMTS uniquement

Donc, on met en place une liste de filtres préalablement crèès : 
* projections
* services
* vecteurs tuilés

On ajoute la possibilité de mettre un filtre _custom_ pour un besoin très spécifique.

:information_source: les filtres sont implémentés dans l'outil **SearchEngine** ou **Search**