### PR TITLE
fix(gfi): retrait de propriétés liées aux labels dans la fenetre gfi

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -35,6 +35,7 @@ __DATE__
   - LayerImport : fenêtre d'affichage des getCapabilities agrandie (#349)
   - Search : ajout wfs fonctionnel et filtre automatique des suggests selon la configuration si liste non spécifiée (#352)
   - AdvancedSearch : correction de la recherche avancée et évolution de  l'UX (#354)
+  - GetFeatureInfo : ajout de propriétés liées au style des labels à ignorer dans l'affichage (#357)
  
 * 🔒 [Security]
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.2-354",
-  "date": "14/02/2025",
+  "version": "1.0.0-beta.2-357",
+  "date": "17/02/2025",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/src/packages/Controls/GetFeatureInfo/GetFeatureInfo.js
+++ b/src/packages/Controls/GetFeatureInfo/GetFeatureInfo.js
@@ -583,6 +583,13 @@ var GetFeatureInfo = class GetFeatureInfo extends Control {
                     // styles
                     "fill",
                     "fill-opacity",
+                    "label-fill",
+                    "label-fill-opacity",
+                    "label-stroke",
+                    "label-stroke-opacity",
+                    "label-stroke-width",
+                    "label-font",
+                    "label-textAlign",
                     "stroke",
                     "stroke-opacity",
                     "stroke-width",

--- a/src/packages/Controls/Utils/Gfi.js
+++ b/src/packages/Controls/Utils/Gfi.js
@@ -227,6 +227,7 @@ var Gfi = {
                     // styles
                     "fill",
                     "fill-opacity",
+                    "label-stroke",
                     "stroke",
                     "stroke-opacity",
                     "stroke-width",


### PR DESCRIPTION
AVANT : 
![image](https://github.com/user-attachments/assets/59635f90-5529-4216-91df-7340efb0bb5a)


APRES : 
![image](https://github.com/user-attachments/assets/717b0791-0ca2-481b-bb4e-2dd5d50cdb7b)

Fichier kml test : 
[test.txt](https://github.com/user-attachments/files/18827908/test.txt)
