### PR TITLE
fix(Catalog): vérification qu'on a bien la propriété serviceParams

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -29,7 +29,8 @@ __DATE__
 * 🐛 [Fixed]
 
   - export : le menu d'export des calculs n'apparait qu'une fois le calcul réalisé (#364)
-  
+  - catalog : verification que la configuration des couches est disponible (#369)
+ 
 * 🔒 [Security]
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.3-364",
+  "version": "1.0.0-beta.3-369",
   "date": "11/03/2025",
   "module": "src/index.js",
   "directories": {},

--- a/src/packages/Controls/Catalog/Catalog.js
+++ b/src/packages/Controls/Catalog/Catalog.js
@@ -611,9 +611,15 @@ var Catalog = class Catalog extends Control {
             for (const key in data.layers) {
                 if (Object.prototype.hasOwnProperty.call(data.layers, key)) {
                     const layer = data.layers[key];
-                    var service = layer.serviceParams.id.split(":").slice(-1)[0]; // beurk!
-                    layer.service = service; // new proprerty !
-                    layer.categories = []; // new property ! vide pour le moment
+                    if (layer.serviceParams) {
+                        // si la couche a bien une configuration valide liée au service
+                        var service = layer.serviceParams.id.split(":").slice(-1)[0]; // beurk!
+                        layer.service = service; // new proprerty !
+                        layer.categories = []; // new property ! vide pour le moment
+                    } else {
+                        // sinon on supprime l'entrée car pas de configuration valide
+                        delete data.layers[key];
+                    }                
                 }
             }
 
@@ -683,9 +689,15 @@ var Catalog = class Catalog extends Control {
                 for (const key in data.layers) {
                     if (Object.prototype.hasOwnProperty.call(data.layers, key)) {
                         const layer = data.layers[key];
-                        var service = layer.serviceParams.id.split(":").slice(-1)[0]; // beurk!
-                        layer.service = service; // new proprerty !
-                        layer.categories = []; // new property ! vide pour le moment
+                        if (layer.serviceParams) {
+                            // si la couche a bien une configuration valide liée au service
+                            var service = layer.serviceParams.id.split(":").slice(-1)[0]; // beurk!
+                            layer.service = service; // new proprerty !
+                            layer.categories = []; // new property ! vide pour le moment
+                        } else {
+                            // sinon on supprime l'entrée car pas de configuration valide
+                            delete data.layers[key];
+                        }
                     }
                 }
 


### PR DESCRIPTION
Correction du catalogue (widget) : si une couche n'a pas de propriété serviceParams, on l'ignore, car non affichable.

Le problème se pose si une couche de la configuration du widget n'est pas chargée dans la configuration des couches de la carte.

C'est l'équivalent côté entrée carto de la vérification que tous les id dans edito.json sont bien dans layers.json