### PR TITLE
fix(compute:widgets): precision regle css sur dialog

### DIFF
--- a/src/packages/CSS/Controls/ElevationPath/GPFelevationPath.css
+++ b/src/packages/CSS/Controls/ElevationPath/GPFelevationPath.css
@@ -28,7 +28,7 @@ button[id^="GPshowElevationPathPicto-"][aria-pressed="true"] + dialog {
   background-position: -50px center;
 }
 
-[id^=GPelevationPathPanel-] {
+dialog[id^=GPelevationPathPanel-] {
   position : absolute;
   top : 6px;
   left: 32px;

--- a/src/packages/CSS/Controls/ElevationPath/GPFelevationPathStyle.css
+++ b/src/packages/CSS/Controls/ElevationPath/GPFelevationPathStyle.css
@@ -143,7 +143,7 @@ div.tooltip-d3 {
     pointer-events: none;
 }
 
-[id^=GPelevationPathPanel-] {
+dialog[id^=GPelevationPathPanel-] {
   width: 280px;
 }
 

--- a/src/packages/CSS/Controls/Isochron/GPFisochron.css
+++ b/src/packages/CSS/Controls/Isochron/GPFisochron.css
@@ -22,7 +22,7 @@ button[id^="GPshowIsochronPicto-"][aria-pressed="true"] + dialog {
 
 /* General panels */
 
-[id^=GPisochronPanel-] {
+dialog[id^=GPisochronPanel-] {
   position: absolute;
   height: inherit;
   top: 0px;

--- a/src/packages/CSS/Controls/Isochron/GPFisochronStyle.css
+++ b/src/packages/CSS/Controls/Isochron/GPFisochronStyle.css
@@ -1,5 +1,5 @@
 /* ISOCHRON */
-[id^=GPisochronPanel-] {
+dialog[id^=GPisochronPanel-] {
   width: 280px;
 }
 

--- a/src/packages/CSS/Controls/Route/GPFroute.css
+++ b/src/packages/CSS/Controls/Route/GPFroute.css
@@ -22,7 +22,7 @@ button[id^="GPshowRoutePicto-"][aria-pressed="true"] + dialog {
 
 /* General panels */
 
-[id^=GProutePanel-] {
+dialog[id^=GProutePanel-] {
   position: absolute;
   height: inherit;
   top: 0px;

--- a/src/packages/CSS/Controls/Route/GPFrouteStyle.css
+++ b/src/packages/CSS/Controls/Route/GPFrouteStyle.css
@@ -1,5 +1,5 @@
 /* ROUTE */
-[id^=GProutePanel-] {
+dialog[id^=GProutePanel-] {
   width: 320px;
 }
 


### PR DESCRIPTION
Précision d'une règle css sur les dialog itinéraire, isochrone, profil alti.

Côté entrée carto, l'acceptation Eulerian ajoutait un id à une div title. La règle css s'appliquait alors à cette div, ce qui provoquait https://github.com/IGNF/cartes.gouv.fr-entree-carto/issues/558

En précisant dialog, on corrigele problème