### PR TITLE
feat(catalog): Méthode publique pour intégrer à la volée une conf dans le composant

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -15,7 +15,10 @@ __DATE__
 
 * ✨ [Added]
 
+  - Catalog: Ajout de méthodes publiques pour ajouter une config partielle, activer ou desactiver l'affichage d'une couche (#378)
+  
 * 🔨 [Changed]
+
 
 * 🔥 [Deprecated]
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.4-376",
-  "date": "14/05/2025",
-
+  "version": "1.0.0-beta.4-378",
+  "date": "16/05/2025",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/samples-src/pages/tests/Catalog/pages-ol-catalog-modules-dsfr-type-data-without-config.html
+++ b/samples-src/pages/tests/Catalog/pages-ol-catalog-modules-dsfr-type-data-without-config.html
@@ -28,7 +28,9 @@
             <div id="map">
             </div>
                 <div style="display: flex;flex-direction: column;align-items: center;width: 150px;">
-                    <button type="button" class="fr-btn" id="addLayerConfigWFS">Ajouter une couche WFS</button>
+                    <button type="button" class="fr-btn" id="addLayerConfigWFS">Ajouter des couches WFS</button>
+                    <button type="button" class="fr-btn" id="activeLayerWMTS">Activer la couche WMTS</button>
+                    <button type="button" class="fr-btn" id="disableLayerWMTS">Desactiver la couche WMTS</button>
                 </div>
 {{/content}}
 
@@ -140,7 +142,15 @@
                         }
                     });
                 };
+                const activeLayerWMTS = (e) => {
+                    catalog.activeLayerByID("GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2$GEOPORTAIL:OGC:WMTS");
+                };
+                const disableLayerWMTS = (e) => {
+                    catalog.disableLayerByID("GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2$GEOPORTAIL:OGC:WMTS");
+                };
                 document.getElementById("addLayerConfigWFS").onclick = addLayerConfigWFS;
+                document.getElementById("activeLayerWMTS").onclick = activeLayerWMTS;
+                document.getElementById("disableLayerWMTS").onclick = disableLayerWMTS;
            </script>
 {{/content}}
 

--- a/samples-src/pages/tests/Catalog/pages-ol-catalog-modules-dsfr-type-data-without-config.html
+++ b/samples-src/pages/tests/Catalog/pages-ol-catalog-modules-dsfr-type-data-without-config.html
@@ -1,0 +1,147 @@
+{{#extend "ol-sample-modules-dsfr-layout"}}
+
+{{#content "vendor"}}
+
+        <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlCatalog.css" />
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlCatalog.js"></script>
+{{/content}}
+
+{{#content "head"}}
+        <title>Sample OpenLayers Drawing</title>
+{{/content}}
+
+{{#content "style"}}
+        <style>
+            div#map {
+                width: 100%;
+                height: 500px;
+                background-image:url("{{ resources }}/geoportail-waiting.gif");
+                background-position:center center;
+                background-repeat:no-repeat;
+            }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+            <h2>Ajout du gestionnaire de catalogue avec option sur la configuration</h2>
+            <!-- map -->
+            <div id="map">
+            </div>
+                <div style="display: flex;flex-direction: column;align-items: center;width: 150px;">
+                    <button type="button" class="fr-btn" id="addLayerConfigWFS">Ajouter une couche WFS</button>
+                </div>
+{{/content}}
+
+{{#content "js"}}
+            <script type="text/javascript">
+                if (window.Gp) {
+                    // activation des loggers
+                    Gp.Logger.enableAll();
+                }
+                async function getData () {
+                    var response = await fetch("{{ resources }}/data/configuration/sample.json", {});
+                    var data = await response.json();
+                    if (response.status !== 200) {
+                        throw new Error("Erreur de récupération du JSON !");
+                    }
+                    return data;
+                }
+                var data = getData();
+                var map;
+                var catalog;
+                var createMap = function() {
+                    // on cache l'image de chargement du Géoportail.
+                    document.getElementById('map').style.backgroundImage = 'none';
+
+                    //Création de la map
+                    map = new ol.Map({
+                        target : "map",
+                        layers : [
+                            new ol.layer.Tile({
+                                source: new ol.source.OSM(),
+                                opacity: 0.5
+                            })
+                        ],
+                        view : new ol.View({
+                            center : [288074.8449901076, 6247982.515792289],
+                            zoom : 8
+                        })
+                    });
+                    data.then( data => {
+                        catalog = new ol.control.Catalog({
+                            position: "top-left",
+                            configuration : {
+                                type : "json",
+                                data : data
+                            }
+                        });
+                        map.addControl(catalog);
+                    })
+                };
+                createMap();
+
+                const addLayerConfigWFS = (e) => {
+                    catalog.addLayerConfig({
+                        "BDTOPO_V3:departement$GEOPORTAIL:OGC:WFS" : {
+                            "name": "BDTOPO_V3:departement",
+                            "title": "BDTOPO : Départements",
+                            "description": "Départements − BDTOPO",
+                            "globalConstraint": {
+                                "minScaleDenominator": 0,
+                                "maxScaleDenominator": 62236752975597,
+                                "bbox": {
+                                    "left": -63.28125,
+                                    "right": 55.8984375,
+                                    "top": 51.9734375,
+                                    "bottom": -21.77265625
+                                }
+                            },
+                            "serviceParams": {
+                                "id": "OGC:WFS",
+                                "version": "2.0.0",
+                                "serverUrl": {
+                                    "full": "https://data.geopf.fr/wfs/wfs"
+                                }
+                            },
+                            "defaultProjection": "EPSG:4326",
+                            "queryable": false,
+                            "metadata": [],
+                            "styles": [],
+                            "legends": [],
+                            "formats": []
+                        },
+                        "BDTOPO_V3:commune$GEOPORTAIL:OGC:WFS" : {
+                            "name": "BDTOPO_V3:commune",
+                            "title": "BDTOPO : Communes",
+                            "description": "Communes − BDTOPO",
+                            "globalConstraint": {
+                                "minScaleDenominator": 0,
+                                "maxScaleDenominator": 62236752975597,
+                                "bbox": {
+                                    "left": -63.28125,
+                                    "right": 55.8984375,
+                                    "top": 51.9734375,
+                                    "bottom": -21.77265625
+                                }
+                            },
+                            "serviceParams": {
+                                "id": "OGC:WFS",
+                                "version": "2.0.0",
+                                "serverUrl": {
+                                    "full": "https://data.geopf.fr/wfs/wfs"
+                                }
+                            },
+                            "defaultProjection": "EPSG:4326",
+                            "queryable": false,
+                            "metadata": [],
+                            "styles": [],
+                            "legends": [],
+                            "formats": []
+                        }
+                    });
+                };
+                document.getElementById("addLayerConfigWFS").onclick = addLayerConfigWFS;
+           </script>
+{{/content}}
+
+{{/extend}}

--- a/samples-src/resources/data/configuration/sample.json
+++ b/samples-src/resources/data/configuration/sample.json
@@ -1,7 +1,7 @@
 {
     "generalOptions": {
       "apiKeys": {
-        "cartes": [
+        "full": [
           "GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2$GEOPORTAIL:OGC:WMTS",
           "GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2$GEOPORTAIL:OGC:WMS",
           "PLAN.IGN$GEOPORTAIL:GPP:TMS",
@@ -28,7 +28,7 @@
           "id": "OGC:WMTS",
           "version": "1.0.0",
           "serverUrl": {
-            "cartes": "https://data.geopf.fr/wmts"
+            "full": "https://data.geopf.fr/wmts"
           }
         },
         "defaultProjection": "EPSG:3857",
@@ -197,7 +197,7 @@
           "id": "OGC:WMS",
           "version": "1.3.0",
           "serverUrl": {
-            "cartes": "https://data.geopf.fr/wms-r/wms"
+            "full": "https://data.geopf.fr/wms-r/wms"
           }
         },
         "defaultProjection": "EPSG:3857",
@@ -245,7 +245,7 @@
           "id": "GPP:TMS",
           "version": "1.0.0",
           "serverUrl": {
-            "cartes": "https://data.geopf.fr/tms/1.0.0/"
+            "full": "https://data.geopf.fr/tms/1.0.0/"
           }
         },
         "name": "PLAN.IGN",

--- a/samples-src/templates/partials/packages/partials-ol-bundle-dsfr-head.hbs
+++ b/samples-src/templates/partials/packages/partials-ol-bundle-dsfr-head.hbs
@@ -2,7 +2,7 @@
         <link rel="stylesheet" href="{{ resources }}/vendor/ol/v10.4.0/ol.css" />
         <script src="{{ resources }}/vendor/ol/v10.4.0/ol.js"></script>
         <!-- Library Access Geoportal Service -->
-        <script src="{{ baseurl }}/node_modules/geoportal-access-lib/dist/GpServices.js"></script>
+        <script src="{{ baseurl }}/node_modules/geoportal-access-lib/dist/GpServices-src.js"></script>
         <!-- DSFR theme -->
         <link rel="stylesheet" href="{{ baseurl }}/node_modules/@gouvfr/dsfr/dist/dsfr.css" />
         <link rel="stylesheet" href="{{ baseurl }}/node_modules/@gouvfr/dsfr/dist/utility/icons/icons.css" />

--- a/samples-src/templates/partials/packages/partials-ol-bundle-head.hbs
+++ b/samples-src/templates/partials/packages/partials-ol-bundle-head.hbs
@@ -2,7 +2,7 @@
         <link rel="stylesheet" href="{{ resources }}/vendor/ol/v10.4.0/ol.css" />
         <script src="{{ resources }}/vendor/ol/v10.4.0/ol.js"></script>
         <!-- Library Access Geoportal Service -->
-        <script src="{{ baseurl }}/node_modules/geoportal-access-lib/dist/GpServices.js"></script>
+        <script src="{{ baseurl }}/node_modules/geoportal-access-lib/dist/GpServices-src.js"></script>
         <!-- Classic IGN theme -->
         <link rel="stylesheet" href="{{ baseurl }}/dist/bundle/Classic.css" />
         <!-- CSS & Modules IGN -->

--- a/samples-src/templates/partials/packages/partials-ol-modules-dsfr-head.hbs
+++ b/samples-src/templates/partials/packages/partials-ol-modules-dsfr-head.hbs
@@ -2,7 +2,7 @@
         <link rel="stylesheet" href="{{ resources }}/vendor/ol/v10.4.0/ol.css" />
         <script src="{{ resources }}/vendor/ol/v10.4.0/ol.js"></script>
         <!-- Library Access Geoportal Service -->
-        <script src="{{ baseurl }}/node_modules/geoportal-access-lib/dist/GpServices.js"></script>
+        <script src="{{ baseurl }}/node_modules/geoportal-access-lib/dist/GpServices-src.js"></script>
         <!-- DSFR theme -->
         <link rel="stylesheet" href="{{ baseurl }}/node_modules/@gouvfr/dsfr/dist/dsfr.css" />
         <link rel="stylesheet" href="{{ baseurl }}/node_modules/@gouvfr/dsfr/dist/utility/icons/icons.css" />

--- a/samples-src/templates/partials/packages/partials-ol-modules-head.hbs
+++ b/samples-src/templates/partials/packages/partials-ol-modules-head.hbs
@@ -2,7 +2,7 @@
         <link rel="stylesheet" href="{{ resources }}/vendor/ol/v10.4.0/ol.css" />
         <script src="{{ resources }}/vendor/ol/v10.4.0/ol.js"></script>
         <!-- Library Access Geoportal Service -->
-        <script src="{{ baseurl }}/node_modules/geoportal-access-lib/dist/GpServices.js"></script>
+        <script src="{{ baseurl }}/node_modules/geoportal-access-lib/dist/GpServices-src.js"></script>
         <!-- Classic IGN theme -->
         <link rel="stylesheet" href="{{ baseurl }}/dist/modules/Classic.css" />
         <!-- CSS & Modules IGN -->

--- a/src/packages/Controls/Catalog/Catalog.js
+++ b/src/packages/Controls/Catalog/Catalog.js
@@ -295,6 +295,47 @@ var Catalog = class Catalog extends Control {
         this.createCatalogContentEntries(this.layersList);
     }
 
+    activeLayerByID (id) {
+        var name = id.split("$")[0];
+        var service = id.split(":").slice(-1)[0];
+        this.activeLayer(name, service);
+    }
+    disableLayerByID (id) {
+        var name = id.split("$")[0];
+        var service = id.split(":").slice(-1)[0];
+        this.disableLayer(name, service);
+    }
+    activeLayer (name, service) {
+        // cf. this.onSelectCatalogEntryClick
+        var id = this.getLayerId(name, service);
+        if (id) {
+            var layer = {}; // conf tech
+            if (this.options.addToMap) {
+                layer = this.addLayer(name, service);
+            }
+            this.dispatchEvent({
+                type : "catalog:layer:add",
+                name : name,
+                service : service,
+                layer : layer
+            });
+        }
+    }
+    disableLayer (name, service) {
+        var id = this.getLayerId(name, service);
+        if (id) {
+            var layer = {}; // conf tech
+            if (this.options.addToMap) {
+                layer = this.removeLayer(name, service);
+            }
+            this.dispatchEvent({
+                type : "catalog:layer:remove",
+                name : name,
+                service : service,
+                layer : layer
+            });
+        }
+    }
     // ################################################################### //
     // ################### getters / setters ############################# //
     // ################################################################### //
@@ -306,6 +347,29 @@ var Catalog = class Catalog extends Control {
      */
     getContainer () {
         return this.container;
+    }
+
+    /**
+     * Get long layer ID
+     * @param {*} name 
+     * @param {*} service 
+     * @returns {String} - long layer ID
+     */
+    getLayerId (name, service) {
+        if (!this.layersList || typeof this.layersList !== "object") {
+            return null;
+        }
+
+        var regex = new RegExp(name + ".*" + service);
+        for (const key in this.layersList) {
+            if (Object.prototype.hasOwnProperty.call(this.layersList, key)) {
+                if (regex.test(key)) {
+                    return key;
+                }
+            }
+        }
+
+        return null;
     }
 
     // ################################################################### //
@@ -748,8 +812,9 @@ var Catalog = class Catalog extends Control {
             content.appendChild(this._createCatalogContentCategoryTabContent(categories[i], layersCategorised));
         }
     }
+
     // ################################################################### //
-    // ######################## methods on map ########################### //
+    // ######################## methods on listeners ##################### //
     // ################################################################### //
 
     /**
@@ -807,28 +872,9 @@ var Catalog = class Catalog extends Control {
         delete this.eventsListeners["map:remove"];
     }
 
-    /**
-     * Get long layer ID
-     * @param {*} name 
-     * @param {*} service 
-     * @returns {String} - long layer ID
-     */
-    getLayerId (name, service) {
-        if (!this.layersList || typeof this.layersList !== "object") {
-            return null;
-        }
-
-        var regex = new RegExp(name + ".*" + service);
-        for (const key in this.layersList) {
-            if (Object.prototype.hasOwnProperty.call(this.layersList, key)) {
-                if (regex.test(key)) {
-                    return key;
-                }
-            }
-        }
-
-        return null;
-    }
+    // ################################################################### //
+    // ######################## methods on map ########################### //
+    // ################################################################### //
 
     /**
      * Add layer on map
@@ -925,6 +971,7 @@ var Catalog = class Catalog extends Control {
     showWaiting () {
         this.waitingContainer.className = "GPwaitingContainerVisible gpf-waiting--visible";
     }
+
     // ################################################################### //
     // ######################## methods search ########################### //
     // ################################################################### //

--- a/src/packages/Controls/Catalog/Catalog.js
+++ b/src/packages/Controls/Catalog/Catalog.js
@@ -11,6 +11,7 @@ import SelectorID from "../../Utils/SelectorID";
 import Logger from "../../Utils/LoggerByDefault";
 import Draggable from "../../Utils/Draggable";
 import Config from "../../Utils/Config";
+import LayerConfig from "../../Utils/LayerConfigUtils";
 
 // import local des layers
 import GeoportalWFS from "../../Layers/LayerWFS";
@@ -266,6 +267,32 @@ var Catalog = class Catalog extends Control {
         if (this.options.gutter === false) {
             this.getContainer().classList.add("gpf-button-no-gutter");
         }
+    }
+
+    /**
+     * Add a layer config
+     * @param {*} conf 
+     */
+    addLayerConfig (conf) {
+        for (const key in conf) {
+            if (Object.prototype.hasOwnProperty.call(conf, key)) {
+                const layer = conf[key];
+                if (layer.serviceParams) {
+                    // si la couche a bien une configuration valide liée au service
+                    var service = layer.serviceParams.id.split(":").slice(-1)[0]; // beurk!
+                    layer.service = service; // new proprerty !
+                    layer.categories = []; // new property ! vide pour le moment
+                    this.layersList[key] = layer;
+                }
+            }
+        }
+        // clean container
+        var element = document.getElementById("GPcatalogContainerTabs");
+        if (element) {
+            element.remove();
+        }
+        // on va recréer le container
+        this.createCatalogContentEntries(this.layersList);
     }
 
     // ################################################################### //
@@ -524,65 +551,6 @@ var Catalog = class Catalog extends Control {
     async initLayersList () {
         var data = null; // reponse brute du service
 
-        var self = this;
-        const createCatalogContentEntries = (layers) => {
-            var container = self.contentCatalogContainer;
-
-            var widgetContentEntryTabs = self._createCatalogContentCategoriesTabs(this.categories);
-            container.appendChild(widgetContentEntryTabs);
-
-            var categories = []; // remise à plat des catégories / sous-categories
-            self.categories.forEach((category) => {
-                if (category.items) {
-                    for (let i = 0; i < category.items.length; i++) {
-                        const element = category.items[i];
-                        categories.push(element);
-                    }
-                } else {
-                    categories.push(category);
-                }
-            });
-            // INFO
-            // les containers de contenu sont definis à partir
-            // de l'ordre des catégories / sous-categories
-            // il y'a autant de catégories / sous-categories que de containers
-            var contents = container.querySelectorAll(".tabcontent");
-            for (let i = 0; i < contents.length; i++) {
-                const content = contents[i];
-                var layersCategorised = getLayersByCategory(categories[i], layers);
-                content.appendChild(self._createCatalogContentCategoryTabContent(categories[i], layersCategorised));
-            }
-        };
-
-        // traitement du contenu (liste de couches) d'une categorie
-        // en fonction d'un filtre
-        const getLayersByCategory = (category, layers) => {
-            // INFO
-            // comment gerer les listes de layers filtrées pour chaque categorie ?
-            // on doit les stocker si l'on souhaite faire des requêtes
-            // avec l'outil de recherche par la suite
-            var layersCategorised = layers;
-            var filter = category.filter;
-            if (filter) {
-                layersCategorised = {};
-                for (const key in layers) {
-                    if (Object.prototype.hasOwnProperty.call(layers, key)) {
-                        const layer = layers[key];
-                        if (layer[filter.field]) { // FIXME impl. clef multiple : property.property !
-                            var condition = Array.isArray(filter.value) ? filter.value.includes(layer[filter.field].toString()) : (filter.value === "*" || layer[filter.field].toString() === filter.value);
-                            if (condition) {
-                                layersCategorised[key] = layer;
-                                // on ajoute l'appartenance de la couche à une categorie
-                                this.layersList[key].categories.push(category.id);
-                            }
-                        }
-                    }
-                }
-            }
-
-            return layersCategorised;
-        };
-
         // TODO filtre sur la liste de couches à prendre en compte
         const getLayersByFilter = (filter, layers) => {
             // INFO
@@ -629,7 +597,7 @@ var Catalog = class Catalog extends Control {
             // sauvegarde de la liste des couches
             this.layersList = layers;
 
-            createCatalogContentEntries(layers);
+            this.createCatalogContentEntries(layers);
             return new Promise((resolve, reject) => {
                 resolve(data);
             });
@@ -707,7 +675,7 @@ var Catalog = class Catalog extends Control {
                 // sauvegarde de la liste des couches
                 this.layersList = layers;
 
-                createCatalogContentEntries(layers);
+                this.createCatalogContentEntries(layers);
                 return await new Promise((resolve, reject) => {
                     resolve(data);
                 });
@@ -719,6 +687,67 @@ var Catalog = class Catalog extends Control {
         }
     }
 
+    /**
+     * Create DOM content categories and entries
+     * @param {*} layers 
+     */
+    createCatalogContentEntries (layers) {
+        // traitement du contenu (liste de couches) d'une categorie
+        // en fonction d'un filtre
+        const getLayersByCategory = (category, layers) => {
+            // INFO
+            // comment gerer les listes de layers filtrées pour chaque categorie ?
+            // on doit les stocker si l'on souhaite faire des requêtes
+            // avec l'outil de recherche par la suite
+            var layersCategorised = layers;
+            var filter = category.filter;
+            if (filter) {
+                layersCategorised = {};
+                for (const key in layers) {
+                    if (Object.prototype.hasOwnProperty.call(layers, key)) {
+                        const layer = layers[key];
+                        if (layer[filter.field]) { // FIXME impl. clef multiple : property.property !
+                            var condition = Array.isArray(filter.value) ? filter.value.includes(layer[filter.field].toString()) : (filter.value === "*" || layer[filter.field].toString() === filter.value);
+                            if (condition) {
+                                layersCategorised[key] = layer;
+                                // on ajoute l'appartenance de la couche à une categorie
+                                this.layersList[key].categories.push(category.id);
+                            }
+                        }
+                    }
+                }
+            }
+
+            return layersCategorised;
+        };
+                
+        var container = this.contentCatalogContainer;
+
+        var widgetContentEntryTabs = this._createCatalogContentCategoriesTabs(this.categories);
+        container.appendChild(widgetContentEntryTabs);
+
+        var categories = []; // remise à plat des catégories / sous-categories
+        this.categories.forEach((category) => {
+            if (category.items) {
+                for (let i = 0; i < category.items.length; i++) {
+                    const element = category.items[i];
+                    categories.push(element);
+                }
+            } else {
+                categories.push(category);
+            }
+        });
+        // INFO
+        // les containers de contenu sont definis à partir
+        // de l'ordre des catégories / sous-categories
+        // il y'a autant de catégories / sous-categories que de containers
+        var contents = container.querySelectorAll(".tabcontent");
+        for (let i = 0; i < contents.length; i++) {
+            const content = contents[i];
+            var layersCategorised = getLayersByCategory(categories[i], layers);
+            content.appendChild(this._createCatalogContentCategoryTabContent(categories[i], layersCategorised));
+        }
+    }
     // ################################################################### //
     // ######################## methods on map ########################### //
     // ################################################################### //
@@ -779,6 +808,29 @@ var Catalog = class Catalog extends Control {
     }
 
     /**
+     * Get long layer ID
+     * @param {*} name 
+     * @param {*} service 
+     * @returns {String} - long layer ID
+     */
+    getLayerId (name, service) {
+        if (!this.layersList || typeof this.layersList !== "object") {
+            return null;
+        }
+
+        var regex = new RegExp(name + ".*" + service);
+        for (const key in this.layersList) {
+            if (Object.prototype.hasOwnProperty.call(this.layersList, key)) {
+                if (regex.test(key)) {
+                    return key;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Add layer on map
      *
      * @param {*} name - layer name
@@ -789,27 +841,36 @@ var Catalog = class Catalog extends Control {
     addLayer (name, service) {
         var layerConf = null;
         var layer = null;
+        var id = this.getLayerId(name, service);
+        if (!id) {
+            return;
+        }
+        var c = (!Config.isConfigLoaded()) ? LayerConfig.getLayerConfig(this.layersList[id]) : null;
         switch (service) {
             case "WMS":
                 layer = new GeoportalWMS({
-                    layer : name
+                    layer : name,
+                    configuration : c
                 });
                 break;
             case "WMTS":
                 layer = new GeoportalWMTS({
-                    layer : name
+                    layer : name,
+                    configuration : c
                 });
                 break;
             case "TMS":
                 layer = new GeoportalMapBox({
-                    layer : name
+                    layer : name,
+                    configuration : c
                 },{
                     declutter : true
                 });
                 break;
             case "WFS":
                 layer = new GeoportalWFS({
-                    layer : name
+                    layer : name,
+                    configuration : c
                 });
                 break;
             default:

--- a/src/packages/Controls/Catalog/CatalogDOM.js
+++ b/src/packages/Controls/Catalog/CatalogDOM.js
@@ -332,7 +332,7 @@ var CatalogDOM = {
 
         var strContainer = `
         <!-- onglets -->
-        <div class="catalog-container-tabs">
+        <div id="GPcatalogContainerTabs" class="catalog-container-tabs">
             <div class="GPtabs fr-tabs">
                 <ul class="GPtabsList fr-tabs__list" role="tablist" aria-label="[A modifier | nom du système d'onglet]">
                     ${strTabButtons}

--- a/src/packages/Controls/Catalog/sample.json
+++ b/src/packages/Controls/Catalog/sample.json
@@ -1,7 +1,7 @@
 {
     "generalOptions": {
       "apiKeys": {
-        "cartes": [
+        "full": [
           "GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2$GEOPORTAIL:OGC:WMTS",
           "GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2$GEOPORTAIL:OGC:WMS",
           "PLAN.IGN$GEOPORTAIL:GPP:TMS"
@@ -27,7 +27,7 @@
           "id": "OGC:WMTS",
           "version": "1.0.0",
           "serverUrl": {
-            "cartes": "https://data.geopf.fr/wmts"
+            "full": "https://data.geopf.fr/wmts"
           }
         },
         "defaultProjection": "EPSG:3857",
@@ -196,7 +196,7 @@
           "id": "OGC:WMS",
           "version": "1.3.0",
           "serverUrl": {
-            "cartes": "https://data.geopf.fr/wms-r/wms"
+            "full": "https://data.geopf.fr/wms-r/wms"
           }
         },
         "defaultProjection": "EPSG:3857",
@@ -244,7 +244,7 @@
           "id": "GPP:TMS",
           "version": "1.0.0",
           "serverUrl": {
-            "cartes": "https://data.geopf.fr/tms/1.0.0/"
+            "full": "https://data.geopf.fr/tms/1.0.0/"
           }
         },
         "name": "PLAN.IGN",
@@ -319,6 +319,34 @@
         },
         "layerId": "PLAN.IGN$GEOPORTAIL:GPP:TMS",
         "defaultProjection": "EPSG:3857"
+      },
+      "BDTOPO_V3:batiment$GEOPORTAIL:OGC:WFS": {
+        "name": "BDTOPO_V3:batiment",
+        "title": "BDTOPO : Bâtiments",
+        "description": "Bâtiments - BDTOPO",
+        "globalConstraint": {
+          "minScaleDenominator": 0.0,
+          "maxScaleDenominator": 62236752975597,
+          "bbox": {
+            "left": -63.28125,
+            "right": 55.8984375,
+            "top": 51.9734375,
+            "bottom": -21.77265625
+          }
+        },
+        "serviceParams": {
+          "id": "OGC:WFS",
+          "version": "2.0.0",
+          "serverUrl": {
+            "full": "https://data.geopf.fr/wfs/ows"
+          }
+        },
+        "defaultProjection": "EPSG:4326",
+        "queryable": false,
+        "metadata": [],
+        "styles": [],
+        "legends": [],
+        "formats": []
       }
     },
     "tileMatrixSets": {

--- a/src/packages/Layers/SourceWFS.js
+++ b/src/packages/Layers/SourceWFS.js
@@ -102,7 +102,7 @@ var SourceWFS = class SourceWFS extends VectorSource {
             urlParams["apikey"] = key;
         }
 
-        var loadFeatures = (self, url, success, failure) => {
+        var loadFeatures = (self, url, extent, success, failure) => {
             const xhr = new XMLHttpRequest();
             xhr.open("GET", url);
             const onError = function () {
@@ -129,7 +129,7 @@ var SourceWFS = class SourceWFS extends VectorSource {
                         for (let i = 0; i < response.links.length; i++) {
                             const link = response.links[i];
                             if (link.rel === "next") {
-                                loadFeatures(self, link.href, success, failure);
+                                loadFeatures(self, link.href, extent, success, failure);
                             }
                         }
                     }
@@ -153,7 +153,7 @@ var SourceWFS = class SourceWFS extends VectorSource {
                     "bbox=" + extent.join(",") + "," + proj
                     + "&maxFeatures=" + maxFeatures + "&count=" + maxFeatures + "&startIndex=0";
 
-                loadFeatures(self, url, success, failure);
+                loadFeatures(self, url, extent, success, failure);
             },
             strategy : olLoadingstrategyTile(olTilegrid.createXYZ({
                 minZoom : options.olParams.minZoom || 15, 

--- a/src/packages/Utils/LayerConfigUtils.js
+++ b/src/packages/Utils/LayerConfigUtils.js
@@ -1,0 +1,71 @@
+import TMS from "./TMS.json";
+
+var LayerConfigUtils = {
+    /**
+     * ...
+     * @param {*} config 
+     * @returns 
+     */
+    getLayerConfig : function (config) {
+        var params = {};
+        if (config) {
+            var service = config.serviceParams.id.split(/:/)[1];
+            var key = Object.keys(config.serviceParams.serverUrl)[0]; // la 1ere par defaut
+            params.url = config.serviceParams.serverUrl[key];
+            if (service !== "WFS") {
+                const wmsTypeRegex = /\/v\//;
+                // WMS vector style always empty (not in getCap)
+                if (wmsTypeRegex.test(params.url)) {
+                    params.styles = " ";
+                } else {
+                    // WMS raster style is defined in getCap
+                    params.styles = config.styles[0].name;
+                }
+            }
+            params.version = config.serviceParams.version;
+            params.format = (config.formats && config.formats.length) ? config.formats[0].name : "";
+            params.projection = config.defaultProjection;
+    
+            // get layer info and constraints
+            params.minScale = config.globalConstraint ? config.globalConstraint.minScaleDenominator : null;
+            params.maxScale = config.globalConstraint ? config.globalConstraint.maxScaleDenominator : null;
+            params.extent = config.globalConstraint ? config.globalConstraint.bbox : null;
+            params.legends = config.legends;
+            params.title = config.title;
+            params.description = config.description;
+            if (service === "WMS") {
+                params.metadata = config.metadata;
+            }
+            // WMTS : get the tileMatrixSetLimits
+            if (config.wmtsOptions) {
+                params.tileMatrixSetLimits = config.wmtsOptions.tileMatrixSetLimits;
+                var TMSLink = config.wmtsOptions.tileMatrixSetLink;
+                if (TMSLink) {
+                    params.TMSLink = TMSLink;
+                    var tmsConf = this.getTMSConfig(TMSLink);
+                    // Get matrix origin : Gp.Point = Object{x:Float, y:Float}
+                    // params.matrixOrigin = tmsConf.getTopLeftCorner();
+                    params.matrixIds = Object.keys(tmsConf.tileMatrices);
+                    params.tileMatrices = tmsConf.tileMatrices;
+                    // by default, pseudo mercator resolutions
+                    params.nativeResolutions = tmsConf.nativeResolutions || this.getTMSConfig("PM").nativeResolutions;
+                }
+            }
+        }
+        return {
+            params : params
+        };
+    },
+
+    /**
+     * ...
+     * @param {*} id 
+     * @returns 
+     */
+    getTMSConfig : function (id) {
+        return TMS[id];
+    },
+
+};
+
+export default LayerConfigUtils;

--- a/src/packages/Utils/TMS.json
+++ b/src/packages/Utils/TMS.json
@@ -1,0 +1,6064 @@
+{
+    "2154_10cm": {
+        "projection": "EPSG:2154",
+        "nativeResolutions": [
+            "209715.2",
+            "104857.6",
+            "52428.8",
+            "26214.4",
+            "13107.2",
+            "6553.6",
+            "3276.8",
+            "1638.4",
+            "819.2",
+            "409.6",
+            "204.8",
+            "102.4",
+            "51.2",
+            "25.6",
+            "12.8",
+            "6.4",
+            "3.2",
+            "1.6",
+            "0.8",
+            "0.4",
+            "0.2",
+            "0.1"
+        ],
+        "tileMatrices": {
+            "0": {
+                "matrixId": "0",
+                "matrixHeight": 1,
+                "matrixWidth": 1,
+                "scaleDenominator": 748982857.1428572,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "1": {
+                "matrixId": "1",
+                "matrixHeight": 1,
+                "matrixWidth": 1,
+                "scaleDenominator": 374491428.5714286,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "2": {
+                "matrixId": "2",
+                "matrixHeight": 1,
+                "matrixWidth": 1,
+                "scaleDenominator": 187245714.2857143,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "3": {
+                "matrixId": "3",
+                "matrixHeight": 2,
+                "matrixWidth": 1,
+                "scaleDenominator": 93622857.14285715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "4": {
+                "matrixId": "4",
+                "matrixHeight": 4,
+                "matrixWidth": 1,
+                "scaleDenominator": 46811428.571428575,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "5": {
+                "matrixId": "5",
+                "matrixHeight": 7,
+                "matrixWidth": 1,
+                "scaleDenominator": 23405714.285714287,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "6": {
+                "matrixId": "6",
+                "matrixHeight": 13,
+                "matrixWidth": 2,
+                "scaleDenominator": 11702857.142857144,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "7": {
+                "matrixId": "7",
+                "matrixHeight": 26,
+                "matrixWidth": 4,
+                "scaleDenominator": 5851428.571428572,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "8": {
+                "matrixId": "8",
+                "matrixHeight": 52,
+                "matrixWidth": 7,
+                "scaleDenominator": 2925714.285714286,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "9": {
+                "matrixId": "9",
+                "matrixHeight": 103,
+                "matrixWidth": 13,
+                "scaleDenominator": 1462857.142857143,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "10": {
+                "matrixId": "10",
+                "matrixHeight": 206,
+                "matrixWidth": 25,
+                "scaleDenominator": 731428.5714285715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "11": {
+                "matrixId": "11",
+                "matrixHeight": 411,
+                "matrixWidth": 50,
+                "scaleDenominator": 365714.28571428574,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "12": {
+                "matrixId": "12",
+                "matrixHeight": 822,
+                "matrixWidth": 99,
+                "scaleDenominator": 182857.14285714287,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "13": {
+                "matrixId": "13",
+                "matrixHeight": 1643,
+                "matrixWidth": 197,
+                "scaleDenominator": 91428.57142857143,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "14": {
+                "matrixId": "14",
+                "matrixHeight": 3285,
+                "matrixWidth": 394,
+                "scaleDenominator": 45714.28571428572,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "15": {
+                "matrixId": "15",
+                "matrixHeight": 6569,
+                "matrixWidth": 788,
+                "scaleDenominator": 22857.14285714286,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "16": {
+                "matrixId": "16",
+                "matrixHeight": 13138,
+                "matrixWidth": 1575,
+                "scaleDenominator": 11428.57142857143,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "17": {
+                "matrixId": "17",
+                "matrixHeight": 26276,
+                "matrixWidth": 3150,
+                "scaleDenominator": 5714.285714285715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "18": {
+                "matrixId": "18",
+                "matrixHeight": 52552,
+                "matrixWidth": 6300,
+                "scaleDenominator": 2857.1428571428573,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "19": {
+                "matrixId": "19",
+                "matrixHeight": 105102,
+                "matrixWidth": 12600,
+                "scaleDenominator": 1428.5714285714287,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "20": {
+                "matrixId": "20",
+                "matrixHeight": 210205,
+                "matrixWidth": 25200,
+                "scaleDenominator": 714.2857142857143,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "21": {
+                "matrixId": "21",
+                "matrixHeight": 420409,
+                "matrixWidth": 50400,
+                "scaleDenominator": 357.14285714285717,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            }
+        }
+    },
+    "2154_10cm_10_20": {
+        "projection": "EPSG:2154",
+        "nativeResolutions": [
+            "204.8",
+            "102.4",
+            "51.2",
+            "25.6",
+            "12.8",
+            "6.4",
+            "3.2",
+            "1.6",
+            "0.8",
+            "0.4",
+            "0.2"
+        ],
+        "tileMatrices": {
+            "10": {
+                "matrixId": "10",
+                "matrixHeight": 206,
+                "matrixWidth": 25,
+                "scaleDenominator": 731428.5714285715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "11": {
+                "matrixId": "11",
+                "matrixHeight": 411,
+                "matrixWidth": 50,
+                "scaleDenominator": 365714.28571428574,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "12": {
+                "matrixId": "12",
+                "matrixHeight": 822,
+                "matrixWidth": 99,
+                "scaleDenominator": 182857.14285714287,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "13": {
+                "matrixId": "13",
+                "matrixHeight": 1643,
+                "matrixWidth": 197,
+                "scaleDenominator": 91428.57142857143,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "14": {
+                "matrixId": "14",
+                "matrixHeight": 3285,
+                "matrixWidth": 394,
+                "scaleDenominator": 45714.28571428572,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "15": {
+                "matrixId": "15",
+                "matrixHeight": 6569,
+                "matrixWidth": 788,
+                "scaleDenominator": 22857.14285714286,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "16": {
+                "matrixId": "16",
+                "matrixHeight": 13138,
+                "matrixWidth": 1575,
+                "scaleDenominator": 11428.57142857143,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "17": {
+                "matrixId": "17",
+                "matrixHeight": 26276,
+                "matrixWidth": 3150,
+                "scaleDenominator": 5714.285714285715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "18": {
+                "matrixId": "18",
+                "matrixHeight": 52552,
+                "matrixWidth": 6300,
+                "scaleDenominator": 2857.1428571428573,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "19": {
+                "matrixId": "19",
+                "matrixHeight": 105102,
+                "matrixWidth": 12600,
+                "scaleDenominator": 1428.5714285714287,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "20": {
+                "matrixId": "20",
+                "matrixHeight": 210205,
+                "matrixWidth": 25200,
+                "scaleDenominator": 714.2857142857143,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            }
+        }
+    },
+    "2154_10cm_6_19": {
+        "projection": "EPSG:2154",
+        "nativeResolutions": [
+            "3276.8",
+            "1638.4",
+            "819.2",
+            "409.6",
+            "204.8",
+            "102.4",
+            "51.2",
+            "25.6",
+            "12.8",
+            "6.4",
+            "3.2",
+            "1.6",
+            "0.8",
+            "0.4"
+        ],
+        "tileMatrices": {
+            "6": {
+                "matrixId": "6",
+                "matrixHeight": 13,
+                "matrixWidth": 2,
+                "scaleDenominator": 11702857.142857144,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "7": {
+                "matrixId": "7",
+                "matrixHeight": 26,
+                "matrixWidth": 4,
+                "scaleDenominator": 5851428.571428572,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "8": {
+                "matrixId": "8",
+                "matrixHeight": 52,
+                "matrixWidth": 7,
+                "scaleDenominator": 2925714.285714286,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "9": {
+                "matrixId": "9",
+                "matrixHeight": 103,
+                "matrixWidth": 13,
+                "scaleDenominator": 1462857.142857143,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "10": {
+                "matrixId": "10",
+                "matrixHeight": 206,
+                "matrixWidth": 25,
+                "scaleDenominator": 731428.5714285715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "11": {
+                "matrixId": "11",
+                "matrixHeight": 411,
+                "matrixWidth": 50,
+                "scaleDenominator": 365714.28571428574,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "12": {
+                "matrixId": "12",
+                "matrixHeight": 822,
+                "matrixWidth": 99,
+                "scaleDenominator": 182857.14285714287,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "13": {
+                "matrixId": "13",
+                "matrixHeight": 1643,
+                "matrixWidth": 197,
+                "scaleDenominator": 91428.57142857143,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "14": {
+                "matrixId": "14",
+                "matrixHeight": 3285,
+                "matrixWidth": 394,
+                "scaleDenominator": 45714.28571428572,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "15": {
+                "matrixId": "15",
+                "matrixHeight": 6569,
+                "matrixWidth": 788,
+                "scaleDenominator": 22857.14285714286,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "16": {
+                "matrixId": "16",
+                "matrixHeight": 13138,
+                "matrixWidth": 1575,
+                "scaleDenominator": 11428.57142857143,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "17": {
+                "matrixId": "17",
+                "matrixHeight": 26276,
+                "matrixWidth": 3150,
+                "scaleDenominator": 5714.285714285715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "18": {
+                "matrixId": "18",
+                "matrixHeight": 52552,
+                "matrixWidth": 6300,
+                "scaleDenominator": 2857.1428571428573,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "19": {
+                "matrixId": "19",
+                "matrixHeight": 105102,
+                "matrixWidth": 12600,
+                "scaleDenominator": 1428.5714285714287,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            }
+        }
+    },
+    "2154_10cm_6_20": {
+        "projection": "EPSG:2154",
+        "nativeResolutions": [
+            "3276.8",
+            "1638.4",
+            "819.2",
+            "409.6",
+            "204.8",
+            "102.4",
+            "51.2",
+            "25.6",
+            "12.8",
+            "6.4",
+            "3.2",
+            "1.6",
+            "0.8",
+            "0.4",
+            "0.2"
+        ],
+        "tileMatrices": {
+            "6": {
+                "matrixId": "6",
+                "matrixHeight": 13,
+                "matrixWidth": 2,
+                "scaleDenominator": 11702857.142857144,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "7": {
+                "matrixId": "7",
+                "matrixHeight": 26,
+                "matrixWidth": 4,
+                "scaleDenominator": 5851428.571428572,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "8": {
+                "matrixId": "8",
+                "matrixHeight": 52,
+                "matrixWidth": 7,
+                "scaleDenominator": 2925714.285714286,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "9": {
+                "matrixId": "9",
+                "matrixHeight": 103,
+                "matrixWidth": 13,
+                "scaleDenominator": 1462857.142857143,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "10": {
+                "matrixId": "10",
+                "matrixHeight": 206,
+                "matrixWidth": 25,
+                "scaleDenominator": 731428.5714285715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "11": {
+                "matrixId": "11",
+                "matrixHeight": 411,
+                "matrixWidth": 50,
+                "scaleDenominator": 365714.28571428574,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "12": {
+                "matrixId": "12",
+                "matrixHeight": 822,
+                "matrixWidth": 99,
+                "scaleDenominator": 182857.14285714287,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "13": {
+                "matrixId": "13",
+                "matrixHeight": 1643,
+                "matrixWidth": 197,
+                "scaleDenominator": 91428.57142857143,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "14": {
+                "matrixId": "14",
+                "matrixHeight": 3285,
+                "matrixWidth": 394,
+                "scaleDenominator": 45714.28571428572,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "15": {
+                "matrixId": "15",
+                "matrixHeight": 6569,
+                "matrixWidth": 788,
+                "scaleDenominator": 22857.14285714286,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "16": {
+                "matrixId": "16",
+                "matrixHeight": 13138,
+                "matrixWidth": 1575,
+                "scaleDenominator": 11428.57142857143,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "17": {
+                "matrixId": "17",
+                "matrixHeight": 26276,
+                "matrixWidth": 3150,
+                "scaleDenominator": 5714.285714285715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "18": {
+                "matrixId": "18",
+                "matrixHeight": 52552,
+                "matrixWidth": 6300,
+                "scaleDenominator": 2857.1428571428573,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "19": {
+                "matrixId": "19",
+                "matrixHeight": 105102,
+                "matrixWidth": 12600,
+                "scaleDenominator": 1428.5714285714287,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "20": {
+                "matrixId": "20",
+                "matrixHeight": 210205,
+                "matrixWidth": 25200,
+                "scaleDenominator": 714.2857142857143,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            }
+        }
+    },
+    "2154_5cm": {
+        "projection": "EPSG:2154",
+        "nativeResolutions": [
+            "209715.2",
+            "104857.6",
+            "52428.8",
+            "26214.4",
+            "13107.2",
+            "6553.6",
+            "3276.8",
+            "1638.4",
+            "819.2",
+            "409.6",
+            "204.8",
+            "102.4",
+            "51.2",
+            "25.6",
+            "12.8",
+            "6.4",
+            "3.2",
+            "1.6",
+            "0.8",
+            "0.4",
+            "0.2",
+            "0.1",
+            "0.05"
+        ],
+        "tileMatrices": {
+            "0": {
+                "matrixId": "0",
+                "matrixHeight": 1,
+                "matrixWidth": 1,
+                "scaleDenominator": 748982857.1428572,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "1": {
+                "matrixId": "1",
+                "matrixHeight": 1,
+                "matrixWidth": 1,
+                "scaleDenominator": 374491428.5714286,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "2": {
+                "matrixId": "2",
+                "matrixHeight": 1,
+                "matrixWidth": 1,
+                "scaleDenominator": 187245714.2857143,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "3": {
+                "matrixId": "3",
+                "matrixHeight": 2,
+                "matrixWidth": 1,
+                "scaleDenominator": 93622857.14285715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "4": {
+                "matrixId": "4",
+                "matrixHeight": 4,
+                "matrixWidth": 1,
+                "scaleDenominator": 46811428.571428575,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "5": {
+                "matrixId": "5",
+                "matrixHeight": 7,
+                "matrixWidth": 1,
+                "scaleDenominator": 23405714.285714287,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "6": {
+                "matrixId": "6",
+                "matrixHeight": 13,
+                "matrixWidth": 2,
+                "scaleDenominator": 11702857.142857144,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "7": {
+                "matrixId": "7",
+                "matrixHeight": 26,
+                "matrixWidth": 4,
+                "scaleDenominator": 5851428.571428572,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "8": {
+                "matrixId": "8",
+                "matrixHeight": 52,
+                "matrixWidth": 7,
+                "scaleDenominator": 2925714.285714286,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "9": {
+                "matrixId": "9",
+                "matrixHeight": 103,
+                "matrixWidth": 13,
+                "scaleDenominator": 1462857.142857143,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "10": {
+                "matrixId": "10",
+                "matrixHeight": 206,
+                "matrixWidth": 25,
+                "scaleDenominator": 731428.5714285715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "11": {
+                "matrixId": "11",
+                "matrixHeight": 411,
+                "matrixWidth": 50,
+                "scaleDenominator": 365714.28571428574,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "12": {
+                "matrixId": "12",
+                "matrixHeight": 822,
+                "matrixWidth": 99,
+                "scaleDenominator": 182857.14285714287,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "13": {
+                "matrixId": "13",
+                "matrixHeight": 1643,
+                "matrixWidth": 197,
+                "scaleDenominator": 91428.57142857143,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "14": {
+                "matrixId": "14",
+                "matrixHeight": 3285,
+                "matrixWidth": 394,
+                "scaleDenominator": 45714.28571428572,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "15": {
+                "matrixId": "15",
+                "matrixHeight": 6569,
+                "matrixWidth": 788,
+                "scaleDenominator": 22857.14285714286,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "16": {
+                "matrixId": "16",
+                "matrixHeight": 13138,
+                "matrixWidth": 1575,
+                "scaleDenominator": 11428.57142857143,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "17": {
+                "matrixId": "17",
+                "matrixHeight": 26276,
+                "matrixWidth": 3150,
+                "scaleDenominator": 5714.285714285715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "18": {
+                "matrixId": "18",
+                "matrixHeight": 52552,
+                "matrixWidth": 6300,
+                "scaleDenominator": 2857.1428571428573,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "19": {
+                "matrixId": "19",
+                "matrixHeight": 105102,
+                "matrixWidth": 12600,
+                "scaleDenominator": 1428.5714285714287,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "20": {
+                "matrixId": "20",
+                "matrixHeight": 210205,
+                "matrixWidth": 25200,
+                "scaleDenominator": 714.2857142857143,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "21": {
+                "matrixId": "21",
+                "matrixHeight": 420409,
+                "matrixWidth": 50400,
+                "scaleDenominator": 357.14285714285717,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "22": {
+                "matrixId": "22",
+                "matrixHeight": 840818,
+                "matrixWidth": 100800,
+                "scaleDenominator": 178.57142857142858,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            }
+        }
+    },
+    "2154_5cm_6_22": {
+        "projection": "EPSG:2154",
+        "nativeResolutions": [
+            "3276.8",
+            "1638.4",
+            "819.2",
+            "409.6",
+            "204.8",
+            "102.4",
+            "51.2",
+            "25.6",
+            "12.8",
+            "6.4",
+            "3.2",
+            "1.6",
+            "0.8",
+            "0.4",
+            "0.2",
+            "0.1",
+            "0.05"
+        ],
+        "tileMatrices": {
+            "6": {
+                "matrixId": "6",
+                "matrixHeight": 13,
+                "matrixWidth": 2,
+                "scaleDenominator": 11702857.142857144,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "7": {
+                "matrixId": "7",
+                "matrixHeight": 26,
+                "matrixWidth": 4,
+                "scaleDenominator": 5851428.571428572,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "8": {
+                "matrixId": "8",
+                "matrixHeight": 52,
+                "matrixWidth": 7,
+                "scaleDenominator": 2925714.285714286,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "9": {
+                "matrixId": "9",
+                "matrixHeight": 103,
+                "matrixWidth": 13,
+                "scaleDenominator": 1462857.142857143,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "10": {
+                "matrixId": "10",
+                "matrixHeight": 206,
+                "matrixWidth": 25,
+                "scaleDenominator": 731428.5714285715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "11": {
+                "matrixId": "11",
+                "matrixHeight": 411,
+                "matrixWidth": 50,
+                "scaleDenominator": 365714.28571428574,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "12": {
+                "matrixId": "12",
+                "matrixHeight": 822,
+                "matrixWidth": 99,
+                "scaleDenominator": 182857.14285714287,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "13": {
+                "matrixId": "13",
+                "matrixHeight": 1643,
+                "matrixWidth": 197,
+                "scaleDenominator": 91428.57142857143,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "14": {
+                "matrixId": "14",
+                "matrixHeight": 3285,
+                "matrixWidth": 394,
+                "scaleDenominator": 45714.28571428572,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "15": {
+                "matrixId": "15",
+                "matrixHeight": 6569,
+                "matrixWidth": 788,
+                "scaleDenominator": 22857.14285714286,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "16": {
+                "matrixId": "16",
+                "matrixHeight": 13138,
+                "matrixWidth": 1575,
+                "scaleDenominator": 11428.57142857143,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "17": {
+                "matrixId": "17",
+                "matrixHeight": 26276,
+                "matrixWidth": 3150,
+                "scaleDenominator": 5714.285714285715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "18": {
+                "matrixId": "18",
+                "matrixHeight": 52552,
+                "matrixWidth": 6300,
+                "scaleDenominator": 2857.1428571428573,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "19": {
+                "matrixId": "19",
+                "matrixHeight": 105102,
+                "matrixWidth": 12600,
+                "scaleDenominator": 1428.5714285714287,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "20": {
+                "matrixId": "20",
+                "matrixHeight": 210205,
+                "matrixWidth": 25200,
+                "scaleDenominator": 714.2857142857143,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "21": {
+                "matrixId": "21",
+                "matrixHeight": 420409,
+                "matrixWidth": 50400,
+                "scaleDenominator": 357.14285714285717,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "22": {
+                "matrixId": "22",
+                "matrixHeight": 840818,
+                "matrixWidth": 100800,
+                "scaleDenominator": 178.57142857142858,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            }
+        }
+    },
+    "LAMB93_2.5m": {
+        "projection": "IGNF:LAMB93",
+        "nativeResolutions": [
+            "163840",
+            "81920",
+            "40960",
+            "20480",
+            "10240",
+            "5120",
+            "2560",
+            "1280",
+            "640",
+            "320",
+            "160",
+            "80",
+            "40",
+            "20",
+            "10",
+            "5",
+            "2.5"
+        ],
+        "tileMatrices": {
+            "0": {
+                "matrixId": "0",
+                "matrixHeight": 1,
+                "matrixWidth": 1,
+                "scaleDenominator": 585142857.1428572,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "1": {
+                "matrixId": "1",
+                "matrixHeight": 1,
+                "matrixWidth": 1,
+                "scaleDenominator": 292571428.5714286,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "2": {
+                "matrixId": "2",
+                "matrixHeight": 2,
+                "matrixWidth": 1,
+                "scaleDenominator": 146285714.2857143,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "3": {
+                "matrixId": "3",
+                "matrixHeight": 3,
+                "matrixWidth": 1,
+                "scaleDenominator": 73142857.14285715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "4": {
+                "matrixId": "4",
+                "matrixHeight": 5,
+                "matrixWidth": 1,
+                "scaleDenominator": 36571428.571428575,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "5": {
+                "matrixId": "5",
+                "matrixHeight": 9,
+                "matrixWidth": 1,
+                "scaleDenominator": 18285714.285714287,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "6": {
+                "matrixId": "6",
+                "matrixHeight": 17,
+                "matrixWidth": 2,
+                "scaleDenominator": 9142857.142857144,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "7": {
+                "matrixId": "7",
+                "matrixHeight": 33,
+                "matrixWidth": 4,
+                "scaleDenominator": 4571428.571428572,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "8": {
+                "matrixId": "8",
+                "matrixHeight": 66,
+                "matrixWidth": 8,
+                "scaleDenominator": 2285714.285714286,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "9": {
+                "matrixId": "9",
+                "matrixHeight": 132,
+                "matrixWidth": 16,
+                "scaleDenominator": 1142857.142857143,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "10": {
+                "matrixId": "10",
+                "matrixHeight": 263,
+                "matrixWidth": 32,
+                "scaleDenominator": 571428.5714285715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "11": {
+                "matrixId": "11",
+                "matrixHeight": 526,
+                "matrixWidth": 63,
+                "scaleDenominator": 285714.28571428574,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "12": {
+                "matrixId": "12",
+                "matrixHeight": 1051,
+                "matrixWidth": 126,
+                "scaleDenominator": 142857.14285714287,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "13": {
+                "matrixId": "13",
+                "matrixHeight": 2102,
+                "matrixWidth": 252,
+                "scaleDenominator": 71428.57142857143,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "14": {
+                "matrixId": "14",
+                "matrixHeight": 4204,
+                "matrixWidth": 504,
+                "scaleDenominator": 35714.28571428572,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "15": {
+                "matrixId": "15",
+                "matrixHeight": 8408,
+                "matrixWidth": 1008,
+                "scaleDenominator": 17857.14285714286,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "16": {
+                "matrixId": "16",
+                "matrixHeight": 16816,
+                "matrixWidth": 2016,
+                "scaleDenominator": 8928.57142857143,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            }
+        }
+    },
+    "LAMB93_2.5m_3_16": {
+        "projection": "IGNF:LAMB93",
+        "nativeResolutions": [
+            "20480",
+            "10240",
+            "5120",
+            "2560",
+            "1280",
+            "640",
+            "320",
+            "160",
+            "80",
+            "40",
+            "20",
+            "10",
+            "5",
+            "2.5"
+        ],
+        "tileMatrices": {
+            "3": {
+                "matrixId": "3",
+                "matrixHeight": 3,
+                "matrixWidth": 1,
+                "scaleDenominator": 73142857.14285715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "4": {
+                "matrixId": "4",
+                "matrixHeight": 5,
+                "matrixWidth": 1,
+                "scaleDenominator": 36571428.571428575,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "5": {
+                "matrixId": "5",
+                "matrixHeight": 9,
+                "matrixWidth": 1,
+                "scaleDenominator": 18285714.285714287,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "6": {
+                "matrixId": "6",
+                "matrixHeight": 17,
+                "matrixWidth": 2,
+                "scaleDenominator": 9142857.142857144,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "7": {
+                "matrixId": "7",
+                "matrixHeight": 33,
+                "matrixWidth": 4,
+                "scaleDenominator": 4571428.571428572,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "8": {
+                "matrixId": "8",
+                "matrixHeight": 66,
+                "matrixWidth": 8,
+                "scaleDenominator": 2285714.285714286,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "9": {
+                "matrixId": "9",
+                "matrixHeight": 132,
+                "matrixWidth": 16,
+                "scaleDenominator": 1142857.142857143,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "10": {
+                "matrixId": "10",
+                "matrixHeight": 263,
+                "matrixWidth": 32,
+                "scaleDenominator": 571428.5714285715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "11": {
+                "matrixId": "11",
+                "matrixHeight": 526,
+                "matrixWidth": 63,
+                "scaleDenominator": 285714.28571428574,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "12": {
+                "matrixId": "12",
+                "matrixHeight": 1051,
+                "matrixWidth": 126,
+                "scaleDenominator": 142857.14285714287,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "13": {
+                "matrixId": "13",
+                "matrixHeight": 2102,
+                "matrixWidth": 252,
+                "scaleDenominator": 71428.57142857143,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "14": {
+                "matrixId": "14",
+                "matrixHeight": 4204,
+                "matrixWidth": 504,
+                "scaleDenominator": 35714.28571428572,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "15": {
+                "matrixId": "15",
+                "matrixHeight": 8408,
+                "matrixWidth": 1008,
+                "scaleDenominator": 17857.14285714286,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            },
+            "16": {
+                "matrixId": "16",
+                "matrixHeight": 16816,
+                "matrixWidth": 2016,
+                "scaleDenominator": 8928.57142857143,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": 0.0,
+                    "y": 12000000.0
+                }
+            }
+        }
+    },
+    "PM": {
+        "projection": "EPSG:3857",
+        "nativeResolutions": [
+            "156543.0339280410",
+            "78271.51696402048",
+            "39135.75848201023",
+            "19567.87924100512",
+            "9783.939620502561",
+            "4891.969810251280",
+            "2445.984905125640",
+            "1222.992452562820",
+            "611.4962262814100",
+            "305.7481131407048",
+            "152.8740565703525",
+            "76.43702828517624",
+            "38.21851414258813",
+            "19.10925707129406",
+            "9.554628535647032",
+            "4.777314267823516",
+            "2.388657133911758",
+            "1.194328566955879",
+            "0.5971642834779395",
+            "0.2985821417389697",
+            "0.1492910708694849",
+            "0.0746455354347424"
+        ],
+        "tileMatrices": {
+            "0": {
+                "matrixId": "0",
+                "matrixHeight": 1,
+                "matrixWidth": 1,
+                "scaleDenominator": 559082264.0287179,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "1": {
+                "matrixId": "1",
+                "matrixHeight": 2,
+                "matrixWidth": 2,
+                "scaleDenominator": 279541132.01435894,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "2": {
+                "matrixId": "2",
+                "matrixHeight": 4,
+                "matrixWidth": 4,
+                "scaleDenominator": 139770566.0071793,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "3": {
+                "matrixId": "3",
+                "matrixHeight": 8,
+                "matrixWidth": 8,
+                "scaleDenominator": 69885283.00358965,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "4": {
+                "matrixId": "4",
+                "matrixHeight": 16,
+                "matrixWidth": 16,
+                "scaleDenominator": 34942641.50179486,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "5": {
+                "matrixId": "5",
+                "matrixHeight": 32,
+                "matrixWidth": 32,
+                "scaleDenominator": 17471320.75089743,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "6": {
+                "matrixId": "6",
+                "matrixHeight": 64,
+                "matrixWidth": 64,
+                "scaleDenominator": 8735660.375448715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "7": {
+                "matrixId": "7",
+                "matrixHeight": 128,
+                "matrixWidth": 128,
+                "scaleDenominator": 4367830.1877243575,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "8": {
+                "matrixId": "8",
+                "matrixHeight": 256,
+                "matrixWidth": 256,
+                "scaleDenominator": 2183915.0938621787,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "9": {
+                "matrixId": "9",
+                "matrixHeight": 512,
+                "matrixWidth": 512,
+                "scaleDenominator": 1091957.5469310894,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "10": {
+                "matrixId": "10",
+                "matrixHeight": 1024,
+                "matrixWidth": 1024,
+                "scaleDenominator": 545978.7734655464,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "11": {
+                "matrixId": "11",
+                "matrixHeight": 2048,
+                "matrixWidth": 2048,
+                "scaleDenominator": 272989.38673277217,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "12": {
+                "matrixId": "12",
+                "matrixHeight": 4096,
+                "matrixWidth": 4096,
+                "scaleDenominator": 136494.69336638608,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "13": {
+                "matrixId": "13",
+                "matrixHeight": 8192,
+                "matrixWidth": 8192,
+                "scaleDenominator": 68247.34668319322,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "14": {
+                "matrixId": "14",
+                "matrixHeight": 16384,
+                "matrixWidth": 16384,
+                "scaleDenominator": 34123.673341596535,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "15": {
+                "matrixId": "15",
+                "matrixHeight": 32768,
+                "matrixWidth": 32768,
+                "scaleDenominator": 17061.83667079829,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "16": {
+                "matrixId": "16",
+                "matrixHeight": 65536,
+                "matrixWidth": 65536,
+                "scaleDenominator": 8530.918335399145,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "17": {
+                "matrixId": "17",
+                "matrixHeight": 131072,
+                "matrixWidth": 131072,
+                "scaleDenominator": 4265.459167699572,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "18": {
+                "matrixId": "18",
+                "matrixHeight": 262144,
+                "matrixWidth": 262144,
+                "scaleDenominator": 2132.7295838497826,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "19": {
+                "matrixId": "19",
+                "matrixHeight": 524288,
+                "matrixWidth": 524288,
+                "scaleDenominator": 1066.364791924893,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "20": {
+                "matrixId": "20",
+                "matrixHeight": 1048576,
+                "matrixWidth": 1048576,
+                "scaleDenominator": 533.1823959624465,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "21": {
+                "matrixId": "21",
+                "matrixHeight": 2097152,
+                "matrixWidth": 2097152,
+                "scaleDenominator": 266.5911979812229,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            }
+        }
+    },
+    "PM_0_14": {
+        "projection": "EPSG:3857",
+        "nativeResolutions": [
+            "156543.0339280410",
+            "78271.51696402048",
+            "39135.75848201023",
+            "19567.87924100512",
+            "9783.939620502561",
+            "4891.969810251280",
+            "2445.984905125640",
+            "1222.992452562820",
+            "611.4962262814100",
+            "305.7481131407048",
+            "152.8740565703525",
+            "76.43702828517624",
+            "38.21851414258813",
+            "19.10925707129406",
+            "9.554628535647032"
+        ],
+        "tileMatrices": {
+            "0": {
+                "matrixId": "0",
+                "matrixHeight": 1,
+                "matrixWidth": 1,
+                "scaleDenominator": 559082264.0287179,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "1": {
+                "matrixId": "1",
+                "matrixHeight": 2,
+                "matrixWidth": 2,
+                "scaleDenominator": 279541132.01435894,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "2": {
+                "matrixId": "2",
+                "matrixHeight": 4,
+                "matrixWidth": 4,
+                "scaleDenominator": 139770566.0071793,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "3": {
+                "matrixId": "3",
+                "matrixHeight": 8,
+                "matrixWidth": 8,
+                "scaleDenominator": 69885283.00358965,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "4": {
+                "matrixId": "4",
+                "matrixHeight": 16,
+                "matrixWidth": 16,
+                "scaleDenominator": 34942641.50179486,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "5": {
+                "matrixId": "5",
+                "matrixHeight": 32,
+                "matrixWidth": 32,
+                "scaleDenominator": 17471320.75089743,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "6": {
+                "matrixId": "6",
+                "matrixHeight": 64,
+                "matrixWidth": 64,
+                "scaleDenominator": 8735660.375448715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "7": {
+                "matrixId": "7",
+                "matrixHeight": 128,
+                "matrixWidth": 128,
+                "scaleDenominator": 4367830.1877243575,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "8": {
+                "matrixId": "8",
+                "matrixHeight": 256,
+                "matrixWidth": 256,
+                "scaleDenominator": 2183915.0938621787,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "9": {
+                "matrixId": "9",
+                "matrixHeight": 512,
+                "matrixWidth": 512,
+                "scaleDenominator": 1091957.5469310894,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "10": {
+                "matrixId": "10",
+                "matrixHeight": 1024,
+                "matrixWidth": 1024,
+                "scaleDenominator": 545978.7734655464,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "11": {
+                "matrixId": "11",
+                "matrixHeight": 2048,
+                "matrixWidth": 2048,
+                "scaleDenominator": 272989.38673277217,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "12": {
+                "matrixId": "12",
+                "matrixHeight": 4096,
+                "matrixWidth": 4096,
+                "scaleDenominator": 136494.69336638608,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "13": {
+                "matrixId": "13",
+                "matrixHeight": 8192,
+                "matrixWidth": 8192,
+                "scaleDenominator": 68247.34668319322,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "14": {
+                "matrixId": "14",
+                "matrixHeight": 16384,
+                "matrixWidth": 16384,
+                "scaleDenominator": 34123.673341596535,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            }
+        }
+    },
+    "PM_0_16": {
+        "projection": "EPSG:3857",
+        "nativeResolutions": [
+            "156543.0339280410",
+            "78271.51696402048",
+            "39135.75848201023",
+            "19567.87924100512",
+            "9783.939620502561",
+            "4891.969810251280",
+            "2445.984905125640",
+            "1222.992452562820",
+            "611.4962262814100",
+            "305.7481131407048",
+            "152.8740565703525",
+            "76.43702828517624",
+            "38.21851414258813",
+            "19.10925707129406",
+            "9.554628535647032",
+            "4.777314267823516",
+            "2.388657133911758"
+        ],
+        "tileMatrices": {
+            "0": {
+                "matrixId": "0",
+                "matrixHeight": 1,
+                "matrixWidth": 1,
+                "scaleDenominator": 559082264.0287179,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "1": {
+                "matrixId": "1",
+                "matrixHeight": 2,
+                "matrixWidth": 2,
+                "scaleDenominator": 279541132.01435894,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "2": {
+                "matrixId": "2",
+                "matrixHeight": 4,
+                "matrixWidth": 4,
+                "scaleDenominator": 139770566.0071793,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "3": {
+                "matrixId": "3",
+                "matrixHeight": 8,
+                "matrixWidth": 8,
+                "scaleDenominator": 69885283.00358965,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "4": {
+                "matrixId": "4",
+                "matrixHeight": 16,
+                "matrixWidth": 16,
+                "scaleDenominator": 34942641.50179486,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "5": {
+                "matrixId": "5",
+                "matrixHeight": 32,
+                "matrixWidth": 32,
+                "scaleDenominator": 17471320.75089743,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "6": {
+                "matrixId": "6",
+                "matrixHeight": 64,
+                "matrixWidth": 64,
+                "scaleDenominator": 8735660.375448715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "7": {
+                "matrixId": "7",
+                "matrixHeight": 128,
+                "matrixWidth": 128,
+                "scaleDenominator": 4367830.1877243575,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "8": {
+                "matrixId": "8",
+                "matrixHeight": 256,
+                "matrixWidth": 256,
+                "scaleDenominator": 2183915.0938621787,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "9": {
+                "matrixId": "9",
+                "matrixHeight": 512,
+                "matrixWidth": 512,
+                "scaleDenominator": 1091957.5469310894,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "10": {
+                "matrixId": "10",
+                "matrixHeight": 1024,
+                "matrixWidth": 1024,
+                "scaleDenominator": 545978.7734655464,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "11": {
+                "matrixId": "11",
+                "matrixHeight": 2048,
+                "matrixWidth": 2048,
+                "scaleDenominator": 272989.38673277217,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "12": {
+                "matrixId": "12",
+                "matrixHeight": 4096,
+                "matrixWidth": 4096,
+                "scaleDenominator": 136494.69336638608,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "13": {
+                "matrixId": "13",
+                "matrixHeight": 8192,
+                "matrixWidth": 8192,
+                "scaleDenominator": 68247.34668319322,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "14": {
+                "matrixId": "14",
+                "matrixHeight": 16384,
+                "matrixWidth": 16384,
+                "scaleDenominator": 34123.673341596535,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "15": {
+                "matrixId": "15",
+                "matrixHeight": 32768,
+                "matrixWidth": 32768,
+                "scaleDenominator": 17061.83667079829,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "16": {
+                "matrixId": "16",
+                "matrixHeight": 65536,
+                "matrixWidth": 65536,
+                "scaleDenominator": 8530.918335399145,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            }
+        }
+    },
+    "PM_0_18": {
+        "projection": "EPSG:3857",
+        "nativeResolutions": [
+            "156543.0339280410",
+            "78271.51696402048",
+            "39135.75848201023",
+            "19567.87924100512",
+            "9783.939620502561",
+            "4891.969810251280",
+            "2445.984905125640",
+            "1222.992452562820",
+            "611.4962262814100",
+            "305.7481131407048",
+            "152.8740565703525",
+            "76.43702828517624",
+            "38.21851414258813",
+            "19.10925707129406",
+            "9.554628535647032",
+            "4.777314267823516",
+            "2.388657133911758",
+            "1.194328566955879",
+            "0.5971642834779395"
+        ],
+        "tileMatrices": {
+            "0": {
+                "matrixId": "0",
+                "matrixHeight": 1,
+                "matrixWidth": 1,
+                "scaleDenominator": 559082264.0287179,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "1": {
+                "matrixId": "1",
+                "matrixHeight": 2,
+                "matrixWidth": 2,
+                "scaleDenominator": 279541132.01435894,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "2": {
+                "matrixId": "2",
+                "matrixHeight": 4,
+                "matrixWidth": 4,
+                "scaleDenominator": 139770566.0071793,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "3": {
+                "matrixId": "3",
+                "matrixHeight": 8,
+                "matrixWidth": 8,
+                "scaleDenominator": 69885283.00358965,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "4": {
+                "matrixId": "4",
+                "matrixHeight": 16,
+                "matrixWidth": 16,
+                "scaleDenominator": 34942641.50179486,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "5": {
+                "matrixId": "5",
+                "matrixHeight": 32,
+                "matrixWidth": 32,
+                "scaleDenominator": 17471320.75089743,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "6": {
+                "matrixId": "6",
+                "matrixHeight": 64,
+                "matrixWidth": 64,
+                "scaleDenominator": 8735660.375448715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "7": {
+                "matrixId": "7",
+                "matrixHeight": 128,
+                "matrixWidth": 128,
+                "scaleDenominator": 4367830.1877243575,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "8": {
+                "matrixId": "8",
+                "matrixHeight": 256,
+                "matrixWidth": 256,
+                "scaleDenominator": 2183915.0938621787,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "9": {
+                "matrixId": "9",
+                "matrixHeight": 512,
+                "matrixWidth": 512,
+                "scaleDenominator": 1091957.5469310894,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "10": {
+                "matrixId": "10",
+                "matrixHeight": 1024,
+                "matrixWidth": 1024,
+                "scaleDenominator": 545978.7734655464,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "11": {
+                "matrixId": "11",
+                "matrixHeight": 2048,
+                "matrixWidth": 2048,
+                "scaleDenominator": 272989.38673277217,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "12": {
+                "matrixId": "12",
+                "matrixHeight": 4096,
+                "matrixWidth": 4096,
+                "scaleDenominator": 136494.69336638608,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "13": {
+                "matrixId": "13",
+                "matrixHeight": 8192,
+                "matrixWidth": 8192,
+                "scaleDenominator": 68247.34668319322,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "14": {
+                "matrixId": "14",
+                "matrixHeight": 16384,
+                "matrixWidth": 16384,
+                "scaleDenominator": 34123.673341596535,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "15": {
+                "matrixId": "15",
+                "matrixHeight": 32768,
+                "matrixWidth": 32768,
+                "scaleDenominator": 17061.83667079829,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "16": {
+                "matrixId": "16",
+                "matrixHeight": 65536,
+                "matrixWidth": 65536,
+                "scaleDenominator": 8530.918335399145,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "17": {
+                "matrixId": "17",
+                "matrixHeight": 131072,
+                "matrixWidth": 131072,
+                "scaleDenominator": 4265.459167699572,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "18": {
+                "matrixId": "18",
+                "matrixHeight": 262144,
+                "matrixWidth": 262144,
+                "scaleDenominator": 2132.7295838497826,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            }
+        }
+    },
+    "PM_0_19": {
+        "projection": "EPSG:3857",
+        "nativeResolutions": [
+            "156543.0339280410",
+            "78271.51696402048",
+            "39135.75848201023",
+            "19567.87924100512",
+            "9783.939620502561",
+            "4891.969810251280",
+            "2445.984905125640",
+            "1222.992452562820",
+            "611.4962262814100",
+            "305.7481131407048",
+            "152.8740565703525",
+            "76.43702828517624",
+            "38.21851414258813",
+            "19.10925707129406",
+            "9.554628535647032",
+            "4.777314267823516",
+            "2.388657133911758",
+            "1.194328566955879",
+            "0.5971642834779395",
+            "0.2985821417389697"
+        ],
+        "tileMatrices": {
+            "0": {
+                "matrixId": "0",
+                "matrixHeight": 1,
+                "matrixWidth": 1,
+                "scaleDenominator": 559082264.0287179,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "1": {
+                "matrixId": "1",
+                "matrixHeight": 2,
+                "matrixWidth": 2,
+                "scaleDenominator": 279541132.01435894,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "2": {
+                "matrixId": "2",
+                "matrixHeight": 4,
+                "matrixWidth": 4,
+                "scaleDenominator": 139770566.0071793,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "3": {
+                "matrixId": "3",
+                "matrixHeight": 8,
+                "matrixWidth": 8,
+                "scaleDenominator": 69885283.00358965,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "4": {
+                "matrixId": "4",
+                "matrixHeight": 16,
+                "matrixWidth": 16,
+                "scaleDenominator": 34942641.50179486,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "5": {
+                "matrixId": "5",
+                "matrixHeight": 32,
+                "matrixWidth": 32,
+                "scaleDenominator": 17471320.75089743,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "6": {
+                "matrixId": "6",
+                "matrixHeight": 64,
+                "matrixWidth": 64,
+                "scaleDenominator": 8735660.375448715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "7": {
+                "matrixId": "7",
+                "matrixHeight": 128,
+                "matrixWidth": 128,
+                "scaleDenominator": 4367830.1877243575,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "8": {
+                "matrixId": "8",
+                "matrixHeight": 256,
+                "matrixWidth": 256,
+                "scaleDenominator": 2183915.0938621787,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "9": {
+                "matrixId": "9",
+                "matrixHeight": 512,
+                "matrixWidth": 512,
+                "scaleDenominator": 1091957.5469310894,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "10": {
+                "matrixId": "10",
+                "matrixHeight": 1024,
+                "matrixWidth": 1024,
+                "scaleDenominator": 545978.7734655464,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "11": {
+                "matrixId": "11",
+                "matrixHeight": 2048,
+                "matrixWidth": 2048,
+                "scaleDenominator": 272989.38673277217,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "12": {
+                "matrixId": "12",
+                "matrixHeight": 4096,
+                "matrixWidth": 4096,
+                "scaleDenominator": 136494.69336638608,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "13": {
+                "matrixId": "13",
+                "matrixHeight": 8192,
+                "matrixWidth": 8192,
+                "scaleDenominator": 68247.34668319322,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "14": {
+                "matrixId": "14",
+                "matrixHeight": 16384,
+                "matrixWidth": 16384,
+                "scaleDenominator": 34123.673341596535,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "15": {
+                "matrixId": "15",
+                "matrixHeight": 32768,
+                "matrixWidth": 32768,
+                "scaleDenominator": 17061.83667079829,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "16": {
+                "matrixId": "16",
+                "matrixHeight": 65536,
+                "matrixWidth": 65536,
+                "scaleDenominator": 8530.918335399145,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "17": {
+                "matrixId": "17",
+                "matrixHeight": 131072,
+                "matrixWidth": 131072,
+                "scaleDenominator": 4265.459167699572,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "18": {
+                "matrixId": "18",
+                "matrixHeight": 262144,
+                "matrixWidth": 262144,
+                "scaleDenominator": 2132.7295838497826,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "19": {
+                "matrixId": "19",
+                "matrixHeight": 524288,
+                "matrixWidth": 524288,
+                "scaleDenominator": 1066.364791924893,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            }
+        }
+    },
+    "PM_0_21": {
+        "projection": "EPSG:3857",
+        "nativeResolutions": [
+            "156543.0339280410",
+            "78271.51696402048",
+            "39135.75848201023",
+            "19567.87924100512",
+            "9783.939620502561",
+            "4891.969810251280",
+            "2445.984905125640",
+            "1222.992452562820",
+            "611.4962262814100",
+            "305.7481131407048",
+            "152.8740565703525",
+            "76.43702828517624",
+            "38.21851414258813",
+            "19.10925707129406",
+            "9.554628535647032",
+            "4.777314267823516",
+            "2.388657133911758",
+            "1.194328566955879",
+            "0.5971642834779395",
+            "0.2985821417389697",
+            "0.1492910708694849",
+            "0.0746455354347424"
+        ],
+        "tileMatrices": {
+            "0": {
+                "matrixId": "0",
+                "matrixHeight": 1,
+                "matrixWidth": 1,
+                "scaleDenominator": 559082264.0287179,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "1": {
+                "matrixId": "1",
+                "matrixHeight": 2,
+                "matrixWidth": 2,
+                "scaleDenominator": 279541132.01435894,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "2": {
+                "matrixId": "2",
+                "matrixHeight": 4,
+                "matrixWidth": 4,
+                "scaleDenominator": 139770566.0071793,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "3": {
+                "matrixId": "3",
+                "matrixHeight": 8,
+                "matrixWidth": 8,
+                "scaleDenominator": 69885283.00358965,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "4": {
+                "matrixId": "4",
+                "matrixHeight": 16,
+                "matrixWidth": 16,
+                "scaleDenominator": 34942641.50179486,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "5": {
+                "matrixId": "5",
+                "matrixHeight": 32,
+                "matrixWidth": 32,
+                "scaleDenominator": 17471320.75089743,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "6": {
+                "matrixId": "6",
+                "matrixHeight": 64,
+                "matrixWidth": 64,
+                "scaleDenominator": 8735660.375448715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "7": {
+                "matrixId": "7",
+                "matrixHeight": 128,
+                "matrixWidth": 128,
+                "scaleDenominator": 4367830.1877243575,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "8": {
+                "matrixId": "8",
+                "matrixHeight": 256,
+                "matrixWidth": 256,
+                "scaleDenominator": 2183915.0938621787,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "9": {
+                "matrixId": "9",
+                "matrixHeight": 512,
+                "matrixWidth": 512,
+                "scaleDenominator": 1091957.5469310894,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "10": {
+                "matrixId": "10",
+                "matrixHeight": 1024,
+                "matrixWidth": 1024,
+                "scaleDenominator": 545978.7734655464,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "11": {
+                "matrixId": "11",
+                "matrixHeight": 2048,
+                "matrixWidth": 2048,
+                "scaleDenominator": 272989.38673277217,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "12": {
+                "matrixId": "12",
+                "matrixHeight": 4096,
+                "matrixWidth": 4096,
+                "scaleDenominator": 136494.69336638608,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "13": {
+                "matrixId": "13",
+                "matrixHeight": 8192,
+                "matrixWidth": 8192,
+                "scaleDenominator": 68247.34668319322,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "14": {
+                "matrixId": "14",
+                "matrixHeight": 16384,
+                "matrixWidth": 16384,
+                "scaleDenominator": 34123.673341596535,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "15": {
+                "matrixId": "15",
+                "matrixHeight": 32768,
+                "matrixWidth": 32768,
+                "scaleDenominator": 17061.83667079829,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "16": {
+                "matrixId": "16",
+                "matrixHeight": 65536,
+                "matrixWidth": 65536,
+                "scaleDenominator": 8530.918335399145,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "17": {
+                "matrixId": "17",
+                "matrixHeight": 131072,
+                "matrixWidth": 131072,
+                "scaleDenominator": 4265.459167699572,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "18": {
+                "matrixId": "18",
+                "matrixHeight": 262144,
+                "matrixWidth": 262144,
+                "scaleDenominator": 2132.7295838497826,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "19": {
+                "matrixId": "19",
+                "matrixHeight": 524288,
+                "matrixWidth": 524288,
+                "scaleDenominator": 1066.364791924893,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "20": {
+                "matrixId": "20",
+                "matrixHeight": 1048576,
+                "matrixWidth": 1048576,
+                "scaleDenominator": 533.1823959624465,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "21": {
+                "matrixId": "21",
+                "matrixHeight": 2097152,
+                "matrixWidth": 2097152,
+                "scaleDenominator": 266.5911979812229,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            }
+        }
+    },
+    "PM_0_6": {
+        "projection": "EPSG:3857",
+        "nativeResolutions": [
+            "156543.0339280410",
+            "78271.51696402048",
+            "39135.75848201023",
+            "19567.87924100512",
+            "9783.939620502561",
+            "4891.969810251280",
+            "2445.984905125640"
+        ],
+        "tileMatrices": {
+            "0": {
+                "matrixId": "0",
+                "matrixHeight": 1,
+                "matrixWidth": 1,
+                "scaleDenominator": 559082264.0287179,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "1": {
+                "matrixId": "1",
+                "matrixHeight": 2,
+                "matrixWidth": 2,
+                "scaleDenominator": 279541132.01435894,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "2": {
+                "matrixId": "2",
+                "matrixHeight": 4,
+                "matrixWidth": 4,
+                "scaleDenominator": 139770566.0071793,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "3": {
+                "matrixId": "3",
+                "matrixHeight": 8,
+                "matrixWidth": 8,
+                "scaleDenominator": 69885283.00358965,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "4": {
+                "matrixId": "4",
+                "matrixHeight": 16,
+                "matrixWidth": 16,
+                "scaleDenominator": 34942641.50179486,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "5": {
+                "matrixId": "5",
+                "matrixHeight": 32,
+                "matrixWidth": 32,
+                "scaleDenominator": 17471320.75089743,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "6": {
+                "matrixId": "6",
+                "matrixHeight": 64,
+                "matrixWidth": 64,
+                "scaleDenominator": 8735660.375448715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            }
+        }
+    },
+    "PM_0_8": {
+        "projection": "EPSG:3857",
+        "nativeResolutions": [
+            "156543.0339280410",
+            "78271.51696402048",
+            "39135.75848201023",
+            "19567.87924100512",
+            "9783.939620502561",
+            "4891.969810251280",
+            "2445.984905125640",
+            "1222.992452562820",
+            "611.4962262814100"
+        ],
+        "tileMatrices": {
+            "0": {
+                "matrixId": "0",
+                "matrixHeight": 1,
+                "matrixWidth": 1,
+                "scaleDenominator": 559082264.0287179,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "1": {
+                "matrixId": "1",
+                "matrixHeight": 2,
+                "matrixWidth": 2,
+                "scaleDenominator": 279541132.01435894,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "2": {
+                "matrixId": "2",
+                "matrixHeight": 4,
+                "matrixWidth": 4,
+                "scaleDenominator": 139770566.0071793,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "3": {
+                "matrixId": "3",
+                "matrixHeight": 8,
+                "matrixWidth": 8,
+                "scaleDenominator": 69885283.00358965,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "4": {
+                "matrixId": "4",
+                "matrixHeight": 16,
+                "matrixWidth": 16,
+                "scaleDenominator": 34942641.50179486,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "5": {
+                "matrixId": "5",
+                "matrixHeight": 32,
+                "matrixWidth": 32,
+                "scaleDenominator": 17471320.75089743,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "6": {
+                "matrixId": "6",
+                "matrixHeight": 64,
+                "matrixWidth": 64,
+                "scaleDenominator": 8735660.375448715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "7": {
+                "matrixId": "7",
+                "matrixHeight": 128,
+                "matrixWidth": 128,
+                "scaleDenominator": 4367830.1877243575,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "8": {
+                "matrixId": "8",
+                "matrixHeight": 256,
+                "matrixWidth": 256,
+                "scaleDenominator": 2183915.0938621787,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            }
+        }
+    },
+    "PM_10_12": {
+        "projection": "EPSG:3857",
+        "nativeResolutions": [
+            "152.8740565703525",
+            "76.43702828517624",
+            "38.21851414258813"
+        ],
+        "tileMatrices": {
+            "10": {
+                "matrixId": "10",
+                "matrixHeight": 1024,
+                "matrixWidth": 1024,
+                "scaleDenominator": 545978.7734655464,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "11": {
+                "matrixId": "11",
+                "matrixHeight": 2048,
+                "matrixWidth": 2048,
+                "scaleDenominator": 272989.38673277217,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "12": {
+                "matrixId": "12",
+                "matrixHeight": 4096,
+                "matrixWidth": 4096,
+                "scaleDenominator": 136494.69336638608,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            }
+        }
+    },
+    "PM_15_18": {
+        "projection": "EPSG:3857",
+        "nativeResolutions": [
+            "4.777314267823516",
+            "2.388657133911758",
+            "1.194328566955879",
+            "0.5971642834779395"
+        ],
+        "tileMatrices": {
+            "15": {
+                "matrixId": "15",
+                "matrixHeight": 32768,
+                "matrixWidth": 32768,
+                "scaleDenominator": 17061.83667079829,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "16": {
+                "matrixId": "16",
+                "matrixHeight": 65536,
+                "matrixWidth": 65536,
+                "scaleDenominator": 8530.918335399145,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "17": {
+                "matrixId": "17",
+                "matrixHeight": 131072,
+                "matrixWidth": 131072,
+                "scaleDenominator": 4265.459167699572,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "18": {
+                "matrixId": "18",
+                "matrixHeight": 262144,
+                "matrixWidth": 262144,
+                "scaleDenominator": 2132.7295838497826,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            }
+        }
+    },
+    "PM_3_15": {
+        "projection": "EPSG:3857",
+        "nativeResolutions": [
+            "19567.87924100512",
+            "9783.939620502561",
+            "4891.969810251280",
+            "2445.984905125640",
+            "1222.992452562820",
+            "611.4962262814100",
+            "305.7481131407048",
+            "152.8740565703525",
+            "76.43702828517624",
+            "38.21851414258813",
+            "19.10925707129406",
+            "9.554628535647032",
+            "4.777314267823516"
+        ],
+        "tileMatrices": {
+            "3": {
+                "matrixId": "3",
+                "matrixHeight": 8,
+                "matrixWidth": 8,
+                "scaleDenominator": 69885283.00358965,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "4": {
+                "matrixId": "4",
+                "matrixHeight": 16,
+                "matrixWidth": 16,
+                "scaleDenominator": 34942641.50179486,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "5": {
+                "matrixId": "5",
+                "matrixHeight": 32,
+                "matrixWidth": 32,
+                "scaleDenominator": 17471320.75089743,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "6": {
+                "matrixId": "6",
+                "matrixHeight": 64,
+                "matrixWidth": 64,
+                "scaleDenominator": 8735660.375448715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "7": {
+                "matrixId": "7",
+                "matrixHeight": 128,
+                "matrixWidth": 128,
+                "scaleDenominator": 4367830.1877243575,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "8": {
+                "matrixId": "8",
+                "matrixHeight": 256,
+                "matrixWidth": 256,
+                "scaleDenominator": 2183915.0938621787,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "9": {
+                "matrixId": "9",
+                "matrixHeight": 512,
+                "matrixWidth": 512,
+                "scaleDenominator": 1091957.5469310894,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "10": {
+                "matrixId": "10",
+                "matrixHeight": 1024,
+                "matrixWidth": 1024,
+                "scaleDenominator": 545978.7734655464,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "11": {
+                "matrixId": "11",
+                "matrixHeight": 2048,
+                "matrixWidth": 2048,
+                "scaleDenominator": 272989.38673277217,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "12": {
+                "matrixId": "12",
+                "matrixHeight": 4096,
+                "matrixWidth": 4096,
+                "scaleDenominator": 136494.69336638608,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "13": {
+                "matrixId": "13",
+                "matrixHeight": 8192,
+                "matrixWidth": 8192,
+                "scaleDenominator": 68247.34668319322,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "14": {
+                "matrixId": "14",
+                "matrixHeight": 16384,
+                "matrixWidth": 16384,
+                "scaleDenominator": 34123.673341596535,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "15": {
+                "matrixId": "15",
+                "matrixHeight": 32768,
+                "matrixWidth": 32768,
+                "scaleDenominator": 17061.83667079829,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            }
+        }
+    },
+    "PM_4_10": {
+        "projection": "EPSG:3857",
+        "nativeResolutions": [
+            "9783.939620502561",
+            "4891.969810251280",
+            "2445.984905125640",
+            "1222.992452562820",
+            "611.4962262814100",
+            "305.7481131407048",
+            "152.8740565703525"
+        ],
+        "tileMatrices": {
+            "4": {
+                "matrixId": "4",
+                "matrixHeight": 16,
+                "matrixWidth": 16,
+                "scaleDenominator": 34942641.50179486,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "5": {
+                "matrixId": "5",
+                "matrixHeight": 32,
+                "matrixWidth": 32,
+                "scaleDenominator": 17471320.75089743,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "6": {
+                "matrixId": "6",
+                "matrixHeight": 64,
+                "matrixWidth": 64,
+                "scaleDenominator": 8735660.375448715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "7": {
+                "matrixId": "7",
+                "matrixHeight": 128,
+                "matrixWidth": 128,
+                "scaleDenominator": 4367830.1877243575,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "8": {
+                "matrixId": "8",
+                "matrixHeight": 256,
+                "matrixWidth": 256,
+                "scaleDenominator": 2183915.0938621787,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "9": {
+                "matrixId": "9",
+                "matrixHeight": 512,
+                "matrixWidth": 512,
+                "scaleDenominator": 1091957.5469310894,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "10": {
+                "matrixId": "10",
+                "matrixHeight": 1024,
+                "matrixWidth": 1024,
+                "scaleDenominator": 545978.7734655464,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            }
+        }
+    },
+    "PM_4_18": {
+        "projection": "EPSG:3857",
+        "nativeResolutions": [
+            "9783.939620502561",
+            "4891.969810251280",
+            "2445.984905125640",
+            "1222.992452562820",
+            "611.4962262814100",
+            "305.7481131407048",
+            "152.8740565703525",
+            "76.43702828517624",
+            "38.21851414258813",
+            "19.10925707129406",
+            "9.554628535647032",
+            "4.777314267823516",
+            "2.388657133911758",
+            "1.194328566955879",
+            "0.5971642834779395"
+        ],
+        "tileMatrices": {
+            "4": {
+                "matrixId": "4",
+                "matrixHeight": 16,
+                "matrixWidth": 16,
+                "scaleDenominator": 34942641.50179486,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "5": {
+                "matrixId": "5",
+                "matrixHeight": 32,
+                "matrixWidth": 32,
+                "scaleDenominator": 17471320.75089743,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "6": {
+                "matrixId": "6",
+                "matrixHeight": 64,
+                "matrixWidth": 64,
+                "scaleDenominator": 8735660.375448715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "7": {
+                "matrixId": "7",
+                "matrixHeight": 128,
+                "matrixWidth": 128,
+                "scaleDenominator": 4367830.1877243575,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "8": {
+                "matrixId": "8",
+                "matrixHeight": 256,
+                "matrixWidth": 256,
+                "scaleDenominator": 2183915.0938621787,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "9": {
+                "matrixId": "9",
+                "matrixHeight": 512,
+                "matrixWidth": 512,
+                "scaleDenominator": 1091957.5469310894,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "10": {
+                "matrixId": "10",
+                "matrixHeight": 1024,
+                "matrixWidth": 1024,
+                "scaleDenominator": 545978.7734655464,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "11": {
+                "matrixId": "11",
+                "matrixHeight": 2048,
+                "matrixWidth": 2048,
+                "scaleDenominator": 272989.38673277217,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "12": {
+                "matrixId": "12",
+                "matrixHeight": 4096,
+                "matrixWidth": 4096,
+                "scaleDenominator": 136494.69336638608,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "13": {
+                "matrixId": "13",
+                "matrixHeight": 8192,
+                "matrixWidth": 8192,
+                "scaleDenominator": 68247.34668319322,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "14": {
+                "matrixId": "14",
+                "matrixHeight": 16384,
+                "matrixWidth": 16384,
+                "scaleDenominator": 34123.673341596535,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "15": {
+                "matrixId": "15",
+                "matrixHeight": 32768,
+                "matrixWidth": 32768,
+                "scaleDenominator": 17061.83667079829,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "16": {
+                "matrixId": "16",
+                "matrixHeight": 65536,
+                "matrixWidth": 65536,
+                "scaleDenominator": 8530.918335399145,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "17": {
+                "matrixId": "17",
+                "matrixHeight": 131072,
+                "matrixWidth": 131072,
+                "scaleDenominator": 4265.459167699572,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "18": {
+                "matrixId": "18",
+                "matrixHeight": 262144,
+                "matrixWidth": 262144,
+                "scaleDenominator": 2132.7295838497826,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            }
+        }
+    },
+    "PM_4_19": {
+        "projection": "EPSG:3857",
+        "nativeResolutions": [
+            "9783.939620502561",
+            "4891.969810251280",
+            "2445.984905125640",
+            "1222.992452562820",
+            "611.4962262814100",
+            "305.7481131407048",
+            "152.8740565703525",
+            "76.43702828517624",
+            "38.21851414258813",
+            "19.10925707129406",
+            "9.554628535647032",
+            "4.777314267823516",
+            "2.388657133911758",
+            "1.194328566955879",
+            "0.5971642834779395",
+            "0.2985821417389697"
+        ],
+        "tileMatrices": {
+            "4": {
+                "matrixId": "4",
+                "matrixHeight": 16,
+                "matrixWidth": 16,
+                "scaleDenominator": 34942641.50179486,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "5": {
+                "matrixId": "5",
+                "matrixHeight": 32,
+                "matrixWidth": 32,
+                "scaleDenominator": 17471320.75089743,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "6": {
+                "matrixId": "6",
+                "matrixHeight": 64,
+                "matrixWidth": 64,
+                "scaleDenominator": 8735660.375448715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "7": {
+                "matrixId": "7",
+                "matrixHeight": 128,
+                "matrixWidth": 128,
+                "scaleDenominator": 4367830.1877243575,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "8": {
+                "matrixId": "8",
+                "matrixHeight": 256,
+                "matrixWidth": 256,
+                "scaleDenominator": 2183915.0938621787,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "9": {
+                "matrixId": "9",
+                "matrixHeight": 512,
+                "matrixWidth": 512,
+                "scaleDenominator": 1091957.5469310894,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "10": {
+                "matrixId": "10",
+                "matrixHeight": 1024,
+                "matrixWidth": 1024,
+                "scaleDenominator": 545978.7734655464,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "11": {
+                "matrixId": "11",
+                "matrixHeight": 2048,
+                "matrixWidth": 2048,
+                "scaleDenominator": 272989.38673277217,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "12": {
+                "matrixId": "12",
+                "matrixHeight": 4096,
+                "matrixWidth": 4096,
+                "scaleDenominator": 136494.69336638608,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "13": {
+                "matrixId": "13",
+                "matrixHeight": 8192,
+                "matrixWidth": 8192,
+                "scaleDenominator": 68247.34668319322,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "14": {
+                "matrixId": "14",
+                "matrixHeight": 16384,
+                "matrixWidth": 16384,
+                "scaleDenominator": 34123.673341596535,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "15": {
+                "matrixId": "15",
+                "matrixHeight": 32768,
+                "matrixWidth": 32768,
+                "scaleDenominator": 17061.83667079829,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "16": {
+                "matrixId": "16",
+                "matrixHeight": 65536,
+                "matrixWidth": 65536,
+                "scaleDenominator": 8530.918335399145,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "17": {
+                "matrixId": "17",
+                "matrixHeight": 131072,
+                "matrixWidth": 131072,
+                "scaleDenominator": 4265.459167699572,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "18": {
+                "matrixId": "18",
+                "matrixHeight": 262144,
+                "matrixWidth": 262144,
+                "scaleDenominator": 2132.7295838497826,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "19": {
+                "matrixId": "19",
+                "matrixHeight": 524288,
+                "matrixWidth": 524288,
+                "scaleDenominator": 1066.364791924893,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            }
+        }
+    },
+    "PM_6_11": {
+        "projection": "EPSG:3857",
+        "nativeResolutions": [
+            "2445.984905125640",
+            "1222.992452562820",
+            "611.4962262814100",
+            "305.7481131407048",
+            "152.8740565703525",
+            "76.43702828517624"
+        ],
+        "tileMatrices": {
+            "6": {
+                "matrixId": "6",
+                "matrixHeight": 64,
+                "matrixWidth": 64,
+                "scaleDenominator": 8735660.375448715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "7": {
+                "matrixId": "7",
+                "matrixHeight": 128,
+                "matrixWidth": 128,
+                "scaleDenominator": 4367830.1877243575,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "8": {
+                "matrixId": "8",
+                "matrixHeight": 256,
+                "matrixWidth": 256,
+                "scaleDenominator": 2183915.0938621787,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "9": {
+                "matrixId": "9",
+                "matrixHeight": 512,
+                "matrixWidth": 512,
+                "scaleDenominator": 1091957.5469310894,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "10": {
+                "matrixId": "10",
+                "matrixHeight": 1024,
+                "matrixWidth": 1024,
+                "scaleDenominator": 545978.7734655464,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "11": {
+                "matrixId": "11",
+                "matrixHeight": 2048,
+                "matrixWidth": 2048,
+                "scaleDenominator": 272989.38673277217,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            }
+        }
+    },
+    "PM_6_14": {
+        "projection": "EPSG:3857",
+        "nativeResolutions": [
+            "2445.984905125640",
+            "1222.992452562820",
+            "611.4962262814100",
+            "305.7481131407048",
+            "152.8740565703525",
+            "76.43702828517624",
+            "38.21851414258813",
+            "19.10925707129406",
+            "9.554628535647032"
+        ],
+        "tileMatrices": {
+            "6": {
+                "matrixId": "6",
+                "matrixHeight": 64,
+                "matrixWidth": 64,
+                "scaleDenominator": 8735660.375448715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "7": {
+                "matrixId": "7",
+                "matrixHeight": 128,
+                "matrixWidth": 128,
+                "scaleDenominator": 4367830.1877243575,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "8": {
+                "matrixId": "8",
+                "matrixHeight": 256,
+                "matrixWidth": 256,
+                "scaleDenominator": 2183915.0938621787,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "9": {
+                "matrixId": "9",
+                "matrixHeight": 512,
+                "matrixWidth": 512,
+                "scaleDenominator": 1091957.5469310894,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "10": {
+                "matrixId": "10",
+                "matrixHeight": 1024,
+                "matrixWidth": 1024,
+                "scaleDenominator": 545978.7734655464,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "11": {
+                "matrixId": "11",
+                "matrixHeight": 2048,
+                "matrixWidth": 2048,
+                "scaleDenominator": 272989.38673277217,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "12": {
+                "matrixId": "12",
+                "matrixHeight": 4096,
+                "matrixWidth": 4096,
+                "scaleDenominator": 136494.69336638608,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "13": {
+                "matrixId": "13",
+                "matrixHeight": 8192,
+                "matrixWidth": 8192,
+                "scaleDenominator": 68247.34668319322,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "14": {
+                "matrixId": "14",
+                "matrixHeight": 16384,
+                "matrixWidth": 16384,
+                "scaleDenominator": 34123.673341596535,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            }
+        }
+    },
+    "PM_6_15": {
+        "projection": "EPSG:3857",
+        "nativeResolutions": [
+            "2445.984905125640",
+            "1222.992452562820",
+            "611.4962262814100",
+            "305.7481131407048",
+            "152.8740565703525",
+            "76.43702828517624",
+            "38.21851414258813",
+            "19.10925707129406",
+            "9.554628535647032",
+            "4.777314267823516"
+        ],
+        "tileMatrices": {
+            "6": {
+                "matrixId": "6",
+                "matrixHeight": 64,
+                "matrixWidth": 64,
+                "scaleDenominator": 8735660.375448715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "7": {
+                "matrixId": "7",
+                "matrixHeight": 128,
+                "matrixWidth": 128,
+                "scaleDenominator": 4367830.1877243575,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "8": {
+                "matrixId": "8",
+                "matrixHeight": 256,
+                "matrixWidth": 256,
+                "scaleDenominator": 2183915.0938621787,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "9": {
+                "matrixId": "9",
+                "matrixHeight": 512,
+                "matrixWidth": 512,
+                "scaleDenominator": 1091957.5469310894,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "10": {
+                "matrixId": "10",
+                "matrixHeight": 1024,
+                "matrixWidth": 1024,
+                "scaleDenominator": 545978.7734655464,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "11": {
+                "matrixId": "11",
+                "matrixHeight": 2048,
+                "matrixWidth": 2048,
+                "scaleDenominator": 272989.38673277217,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "12": {
+                "matrixId": "12",
+                "matrixHeight": 4096,
+                "matrixWidth": 4096,
+                "scaleDenominator": 136494.69336638608,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "13": {
+                "matrixId": "13",
+                "matrixHeight": 8192,
+                "matrixWidth": 8192,
+                "scaleDenominator": 68247.34668319322,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "14": {
+                "matrixId": "14",
+                "matrixHeight": 16384,
+                "matrixWidth": 16384,
+                "scaleDenominator": 34123.673341596535,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "15": {
+                "matrixId": "15",
+                "matrixHeight": 32768,
+                "matrixWidth": 32768,
+                "scaleDenominator": 17061.83667079829,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            }
+        }
+    },
+    "PM_6_16": {
+        "projection": "EPSG:3857",
+        "nativeResolutions": [
+            "2445.984905125640",
+            "1222.992452562820",
+            "611.4962262814100",
+            "305.7481131407048",
+            "152.8740565703525",
+            "76.43702828517624",
+            "38.21851414258813",
+            "19.10925707129406",
+            "9.554628535647032",
+            "4.777314267823516",
+            "2.388657133911758"
+        ],
+        "tileMatrices": {
+            "6": {
+                "matrixId": "6",
+                "matrixHeight": 64,
+                "matrixWidth": 64,
+                "scaleDenominator": 8735660.375448715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "7": {
+                "matrixId": "7",
+                "matrixHeight": 128,
+                "matrixWidth": 128,
+                "scaleDenominator": 4367830.1877243575,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "8": {
+                "matrixId": "8",
+                "matrixHeight": 256,
+                "matrixWidth": 256,
+                "scaleDenominator": 2183915.0938621787,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "9": {
+                "matrixId": "9",
+                "matrixHeight": 512,
+                "matrixWidth": 512,
+                "scaleDenominator": 1091957.5469310894,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "10": {
+                "matrixId": "10",
+                "matrixHeight": 1024,
+                "matrixWidth": 1024,
+                "scaleDenominator": 545978.7734655464,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "11": {
+                "matrixId": "11",
+                "matrixHeight": 2048,
+                "matrixWidth": 2048,
+                "scaleDenominator": 272989.38673277217,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "12": {
+                "matrixId": "12",
+                "matrixHeight": 4096,
+                "matrixWidth": 4096,
+                "scaleDenominator": 136494.69336638608,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "13": {
+                "matrixId": "13",
+                "matrixHeight": 8192,
+                "matrixWidth": 8192,
+                "scaleDenominator": 68247.34668319322,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "14": {
+                "matrixId": "14",
+                "matrixHeight": 16384,
+                "matrixWidth": 16384,
+                "scaleDenominator": 34123.673341596535,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "15": {
+                "matrixId": "15",
+                "matrixHeight": 32768,
+                "matrixWidth": 32768,
+                "scaleDenominator": 17061.83667079829,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "16": {
+                "matrixId": "16",
+                "matrixHeight": 65536,
+                "matrixWidth": 65536,
+                "scaleDenominator": 8530.918335399145,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            }
+        }
+    },
+    "PM_6_17": {
+        "projection": "EPSG:3857",
+        "nativeResolutions": [
+            "2445.984905125640",
+            "1222.992452562820",
+            "611.4962262814100",
+            "305.7481131407048",
+            "152.8740565703525",
+            "76.43702828517624",
+            "38.21851414258813",
+            "19.10925707129406",
+            "9.554628535647032",
+            "4.777314267823516",
+            "2.388657133911758",
+            "1.194328566955879"
+        ],
+        "tileMatrices": {
+            "6": {
+                "matrixId": "6",
+                "matrixHeight": 64,
+                "matrixWidth": 64,
+                "scaleDenominator": 8735660.375448715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "7": {
+                "matrixId": "7",
+                "matrixHeight": 128,
+                "matrixWidth": 128,
+                "scaleDenominator": 4367830.1877243575,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "8": {
+                "matrixId": "8",
+                "matrixHeight": 256,
+                "matrixWidth": 256,
+                "scaleDenominator": 2183915.0938621787,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "9": {
+                "matrixId": "9",
+                "matrixHeight": 512,
+                "matrixWidth": 512,
+                "scaleDenominator": 1091957.5469310894,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "10": {
+                "matrixId": "10",
+                "matrixHeight": 1024,
+                "matrixWidth": 1024,
+                "scaleDenominator": 545978.7734655464,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "11": {
+                "matrixId": "11",
+                "matrixHeight": 2048,
+                "matrixWidth": 2048,
+                "scaleDenominator": 272989.38673277217,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "12": {
+                "matrixId": "12",
+                "matrixHeight": 4096,
+                "matrixWidth": 4096,
+                "scaleDenominator": 136494.69336638608,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "13": {
+                "matrixId": "13",
+                "matrixHeight": 8192,
+                "matrixWidth": 8192,
+                "scaleDenominator": 68247.34668319322,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "14": {
+                "matrixId": "14",
+                "matrixHeight": 16384,
+                "matrixWidth": 16384,
+                "scaleDenominator": 34123.673341596535,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "15": {
+                "matrixId": "15",
+                "matrixHeight": 32768,
+                "matrixWidth": 32768,
+                "scaleDenominator": 17061.83667079829,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "16": {
+                "matrixId": "16",
+                "matrixHeight": 65536,
+                "matrixWidth": 65536,
+                "scaleDenominator": 8530.918335399145,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "17": {
+                "matrixId": "17",
+                "matrixHeight": 131072,
+                "matrixWidth": 131072,
+                "scaleDenominator": 4265.459167699572,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            }
+        }
+    },
+    "PM_6_18": {
+        "projection": "EPSG:3857",
+        "nativeResolutions": [
+            "2445.984905125640",
+            "1222.992452562820",
+            "611.4962262814100",
+            "305.7481131407048",
+            "152.8740565703525",
+            "76.43702828517624",
+            "38.21851414258813",
+            "19.10925707129406",
+            "9.554628535647032",
+            "4.777314267823516",
+            "2.388657133911758",
+            "1.194328566955879",
+            "0.5971642834779395"
+        ],
+        "tileMatrices": {
+            "6": {
+                "matrixId": "6",
+                "matrixHeight": 64,
+                "matrixWidth": 64,
+                "scaleDenominator": 8735660.375448715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "7": {
+                "matrixId": "7",
+                "matrixHeight": 128,
+                "matrixWidth": 128,
+                "scaleDenominator": 4367830.1877243575,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "8": {
+                "matrixId": "8",
+                "matrixHeight": 256,
+                "matrixWidth": 256,
+                "scaleDenominator": 2183915.0938621787,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "9": {
+                "matrixId": "9",
+                "matrixHeight": 512,
+                "matrixWidth": 512,
+                "scaleDenominator": 1091957.5469310894,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "10": {
+                "matrixId": "10",
+                "matrixHeight": 1024,
+                "matrixWidth": 1024,
+                "scaleDenominator": 545978.7734655464,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "11": {
+                "matrixId": "11",
+                "matrixHeight": 2048,
+                "matrixWidth": 2048,
+                "scaleDenominator": 272989.38673277217,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "12": {
+                "matrixId": "12",
+                "matrixHeight": 4096,
+                "matrixWidth": 4096,
+                "scaleDenominator": 136494.69336638608,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "13": {
+                "matrixId": "13",
+                "matrixHeight": 8192,
+                "matrixWidth": 8192,
+                "scaleDenominator": 68247.34668319322,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "14": {
+                "matrixId": "14",
+                "matrixHeight": 16384,
+                "matrixWidth": 16384,
+                "scaleDenominator": 34123.673341596535,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "15": {
+                "matrixId": "15",
+                "matrixHeight": 32768,
+                "matrixWidth": 32768,
+                "scaleDenominator": 17061.83667079829,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "16": {
+                "matrixId": "16",
+                "matrixHeight": 65536,
+                "matrixWidth": 65536,
+                "scaleDenominator": 8530.918335399145,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "17": {
+                "matrixId": "17",
+                "matrixHeight": 131072,
+                "matrixWidth": 131072,
+                "scaleDenominator": 4265.459167699572,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "18": {
+                "matrixId": "18",
+                "matrixHeight": 262144,
+                "matrixWidth": 262144,
+                "scaleDenominator": 2132.7295838497826,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            }
+        }
+    },
+    "PM_6_19": {
+        "projection": "EPSG:3857",
+        "nativeResolutions": [
+            "2445.984905125640",
+            "1222.992452562820",
+            "611.4962262814100",
+            "305.7481131407048",
+            "152.8740565703525",
+            "76.43702828517624",
+            "38.21851414258813",
+            "19.10925707129406",
+            "9.554628535647032",
+            "4.777314267823516",
+            "2.388657133911758",
+            "1.194328566955879",
+            "0.5971642834779395",
+            "0.2985821417389697"
+        ],
+        "tileMatrices": {
+            "6": {
+                "matrixId": "6",
+                "matrixHeight": 64,
+                "matrixWidth": 64,
+                "scaleDenominator": 8735660.375448715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "7": {
+                "matrixId": "7",
+                "matrixHeight": 128,
+                "matrixWidth": 128,
+                "scaleDenominator": 4367830.1877243575,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "8": {
+                "matrixId": "8",
+                "matrixHeight": 256,
+                "matrixWidth": 256,
+                "scaleDenominator": 2183915.0938621787,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "9": {
+                "matrixId": "9",
+                "matrixHeight": 512,
+                "matrixWidth": 512,
+                "scaleDenominator": 1091957.5469310894,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "10": {
+                "matrixId": "10",
+                "matrixHeight": 1024,
+                "matrixWidth": 1024,
+                "scaleDenominator": 545978.7734655464,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "11": {
+                "matrixId": "11",
+                "matrixHeight": 2048,
+                "matrixWidth": 2048,
+                "scaleDenominator": 272989.38673277217,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "12": {
+                "matrixId": "12",
+                "matrixHeight": 4096,
+                "matrixWidth": 4096,
+                "scaleDenominator": 136494.69336638608,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "13": {
+                "matrixId": "13",
+                "matrixHeight": 8192,
+                "matrixWidth": 8192,
+                "scaleDenominator": 68247.34668319322,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "14": {
+                "matrixId": "14",
+                "matrixHeight": 16384,
+                "matrixWidth": 16384,
+                "scaleDenominator": 34123.673341596535,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "15": {
+                "matrixId": "15",
+                "matrixHeight": 32768,
+                "matrixWidth": 32768,
+                "scaleDenominator": 17061.83667079829,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "16": {
+                "matrixId": "16",
+                "matrixHeight": 65536,
+                "matrixWidth": 65536,
+                "scaleDenominator": 8530.918335399145,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "17": {
+                "matrixId": "17",
+                "matrixHeight": 131072,
+                "matrixWidth": 131072,
+                "scaleDenominator": 4265.459167699572,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "18": {
+                "matrixId": "18",
+                "matrixHeight": 262144,
+                "matrixWidth": 262144,
+                "scaleDenominator": 2132.7295838497826,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "19": {
+                "matrixId": "19",
+                "matrixHeight": 524288,
+                "matrixWidth": 524288,
+                "scaleDenominator": 1066.364791924893,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            }
+        }
+    },
+    "PM_6_21": {
+        "projection": "EPSG:3857",
+        "nativeResolutions": [
+            "2445.984905125640",
+            "1222.992452562820",
+            "611.4962262814100",
+            "305.7481131407048",
+            "152.8740565703525",
+            "76.43702828517624",
+            "38.21851414258813",
+            "19.10925707129406",
+            "9.554628535647032",
+            "4.777314267823516",
+            "2.388657133911758",
+            "1.194328566955879",
+            "0.5971642834779395",
+            "0.2985821417389697",
+            "0.1492910708694849",
+            "0.0746455354347424"
+        ],
+        "tileMatrices": {
+            "6": {
+                "matrixId": "6",
+                "matrixHeight": 64,
+                "matrixWidth": 64,
+                "scaleDenominator": 8735660.375448715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "7": {
+                "matrixId": "7",
+                "matrixHeight": 128,
+                "matrixWidth": 128,
+                "scaleDenominator": 4367830.1877243575,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "8": {
+                "matrixId": "8",
+                "matrixHeight": 256,
+                "matrixWidth": 256,
+                "scaleDenominator": 2183915.0938621787,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "9": {
+                "matrixId": "9",
+                "matrixHeight": 512,
+                "matrixWidth": 512,
+                "scaleDenominator": 1091957.5469310894,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "10": {
+                "matrixId": "10",
+                "matrixHeight": 1024,
+                "matrixWidth": 1024,
+                "scaleDenominator": 545978.7734655464,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "11": {
+                "matrixId": "11",
+                "matrixHeight": 2048,
+                "matrixWidth": 2048,
+                "scaleDenominator": 272989.38673277217,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "12": {
+                "matrixId": "12",
+                "matrixHeight": 4096,
+                "matrixWidth": 4096,
+                "scaleDenominator": 136494.69336638608,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "13": {
+                "matrixId": "13",
+                "matrixHeight": 8192,
+                "matrixWidth": 8192,
+                "scaleDenominator": 68247.34668319322,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "14": {
+                "matrixId": "14",
+                "matrixHeight": 16384,
+                "matrixWidth": 16384,
+                "scaleDenominator": 34123.673341596535,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "15": {
+                "matrixId": "15",
+                "matrixHeight": 32768,
+                "matrixWidth": 32768,
+                "scaleDenominator": 17061.83667079829,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "16": {
+                "matrixId": "16",
+                "matrixHeight": 65536,
+                "matrixWidth": 65536,
+                "scaleDenominator": 8530.918335399145,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "17": {
+                "matrixId": "17",
+                "matrixHeight": 131072,
+                "matrixWidth": 131072,
+                "scaleDenominator": 4265.459167699572,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "18": {
+                "matrixId": "18",
+                "matrixHeight": 262144,
+                "matrixWidth": 262144,
+                "scaleDenominator": 2132.7295838497826,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "19": {
+                "matrixId": "19",
+                "matrixHeight": 524288,
+                "matrixWidth": 524288,
+                "scaleDenominator": 1066.364791924893,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "20": {
+                "matrixId": "20",
+                "matrixHeight": 1048576,
+                "matrixWidth": 1048576,
+                "scaleDenominator": 533.1823959624465,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "21": {
+                "matrixId": "21",
+                "matrixHeight": 2097152,
+                "matrixWidth": 2097152,
+                "scaleDenominator": 266.5911979812229,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            }
+        }
+    },
+    "PM_6_9": {
+        "projection": "EPSG:3857",
+        "nativeResolutions": [
+            "2445.984905125640",
+            "1222.992452562820",
+            "611.4962262814100",
+            "305.7481131407048"
+        ],
+        "tileMatrices": {
+            "6": {
+                "matrixId": "6",
+                "matrixHeight": 64,
+                "matrixWidth": 64,
+                "scaleDenominator": 8735660.375448715,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "7": {
+                "matrixId": "7",
+                "matrixHeight": 128,
+                "matrixWidth": 128,
+                "scaleDenominator": 4367830.1877243575,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "8": {
+                "matrixId": "8",
+                "matrixHeight": 256,
+                "matrixWidth": 256,
+                "scaleDenominator": 2183915.0938621787,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "9": {
+                "matrixId": "9",
+                "matrixHeight": 512,
+                "matrixWidth": 512,
+                "scaleDenominator": 1091957.5469310894,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            }
+        }
+    },
+    "PM_7_17": {
+        "projection": "EPSG:3857",
+        "nativeResolutions": [
+            "1222.992452562820",
+            "611.4962262814100",
+            "305.7481131407048",
+            "152.8740565703525",
+            "76.43702828517624",
+            "38.21851414258813",
+            "19.10925707129406",
+            "9.554628535647032",
+            "4.777314267823516",
+            "2.388657133911758",
+            "1.194328566955879"
+        ],
+        "tileMatrices": {
+            "7": {
+                "matrixId": "7",
+                "matrixHeight": 128,
+                "matrixWidth": 128,
+                "scaleDenominator": 4367830.1877243575,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "8": {
+                "matrixId": "8",
+                "matrixHeight": 256,
+                "matrixWidth": 256,
+                "scaleDenominator": 2183915.0938621787,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "9": {
+                "matrixId": "9",
+                "matrixHeight": 512,
+                "matrixWidth": 512,
+                "scaleDenominator": 1091957.5469310894,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "10": {
+                "matrixId": "10",
+                "matrixHeight": 1024,
+                "matrixWidth": 1024,
+                "scaleDenominator": 545978.7734655464,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "11": {
+                "matrixId": "11",
+                "matrixHeight": 2048,
+                "matrixWidth": 2048,
+                "scaleDenominator": 272989.38673277217,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "12": {
+                "matrixId": "12",
+                "matrixHeight": 4096,
+                "matrixWidth": 4096,
+                "scaleDenominator": 136494.69336638608,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "13": {
+                "matrixId": "13",
+                "matrixHeight": 8192,
+                "matrixWidth": 8192,
+                "scaleDenominator": 68247.34668319322,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "14": {
+                "matrixId": "14",
+                "matrixHeight": 16384,
+                "matrixWidth": 16384,
+                "scaleDenominator": 34123.673341596535,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "15": {
+                "matrixId": "15",
+                "matrixHeight": 32768,
+                "matrixWidth": 32768,
+                "scaleDenominator": 17061.83667079829,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "16": {
+                "matrixId": "16",
+                "matrixHeight": 65536,
+                "matrixWidth": 65536,
+                "scaleDenominator": 8530.918335399145,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "17": {
+                "matrixId": "17",
+                "matrixHeight": 131072,
+                "matrixWidth": 131072,
+                "scaleDenominator": 4265.459167699572,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            }
+        }
+    },
+    "PM_7_18": {
+        "projection": "EPSG:3857",
+        "nativeResolutions": [
+            "1222.992452562820",
+            "611.4962262814100",
+            "305.7481131407048",
+            "152.8740565703525",
+            "76.43702828517624",
+            "38.21851414258813",
+            "19.10925707129406",
+            "9.554628535647032",
+            "4.777314267823516",
+            "2.388657133911758",
+            "1.194328566955879",
+            "0.5971642834779395"
+        ],
+        "tileMatrices": {
+            "7": {
+                "matrixId": "7",
+                "matrixHeight": 128,
+                "matrixWidth": 128,
+                "scaleDenominator": 4367830.1877243575,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "8": {
+                "matrixId": "8",
+                "matrixHeight": 256,
+                "matrixWidth": 256,
+                "scaleDenominator": 2183915.0938621787,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "9": {
+                "matrixId": "9",
+                "matrixHeight": 512,
+                "matrixWidth": 512,
+                "scaleDenominator": 1091957.5469310894,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "10": {
+                "matrixId": "10",
+                "matrixHeight": 1024,
+                "matrixWidth": 1024,
+                "scaleDenominator": 545978.7734655464,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "11": {
+                "matrixId": "11",
+                "matrixHeight": 2048,
+                "matrixWidth": 2048,
+                "scaleDenominator": 272989.38673277217,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "12": {
+                "matrixId": "12",
+                "matrixHeight": 4096,
+                "matrixWidth": 4096,
+                "scaleDenominator": 136494.69336638608,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "13": {
+                "matrixId": "13",
+                "matrixHeight": 8192,
+                "matrixWidth": 8192,
+                "scaleDenominator": 68247.34668319322,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "14": {
+                "matrixId": "14",
+                "matrixHeight": 16384,
+                "matrixWidth": 16384,
+                "scaleDenominator": 34123.673341596535,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "15": {
+                "matrixId": "15",
+                "matrixHeight": 32768,
+                "matrixWidth": 32768,
+                "scaleDenominator": 17061.83667079829,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "16": {
+                "matrixId": "16",
+                "matrixHeight": 65536,
+                "matrixWidth": 65536,
+                "scaleDenominator": 8530.918335399145,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "17": {
+                "matrixId": "17",
+                "matrixHeight": 131072,
+                "matrixWidth": 131072,
+                "scaleDenominator": 4265.459167699572,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "18": {
+                "matrixId": "18",
+                "matrixHeight": 262144,
+                "matrixWidth": 262144,
+                "scaleDenominator": 2132.7295838497826,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            }
+        }
+    },
+    "PM_9_16": {
+        "projection": "EPSG:3857",
+        "nativeResolutions": [
+            "305.7481131407048",
+            "152.8740565703525",
+            "76.43702828517624",
+            "38.21851414258813",
+            "19.10925707129406",
+            "9.554628535647032",
+            "4.777314267823516",
+            "2.388657133911758"
+        ],
+        "tileMatrices": {
+            "9": {
+                "matrixId": "9",
+                "matrixHeight": 512,
+                "matrixWidth": 512,
+                "scaleDenominator": 1091957.5469310894,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "10": {
+                "matrixId": "10",
+                "matrixHeight": 1024,
+                "matrixWidth": 1024,
+                "scaleDenominator": 545978.7734655464,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "11": {
+                "matrixId": "11",
+                "matrixHeight": 2048,
+                "matrixWidth": 2048,
+                "scaleDenominator": 272989.38673277217,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "12": {
+                "matrixId": "12",
+                "matrixHeight": 4096,
+                "matrixWidth": 4096,
+                "scaleDenominator": 136494.69336638608,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "13": {
+                "matrixId": "13",
+                "matrixHeight": 8192,
+                "matrixWidth": 8192,
+                "scaleDenominator": 68247.34668319322,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "14": {
+                "matrixId": "14",
+                "matrixHeight": 16384,
+                "matrixWidth": 16384,
+                "scaleDenominator": 34123.673341596535,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "15": {
+                "matrixId": "15",
+                "matrixHeight": 32768,
+                "matrixWidth": 32768,
+                "scaleDenominator": 17061.83667079829,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            },
+            "16": {
+                "matrixId": "16",
+                "matrixHeight": 65536,
+                "matrixWidth": 65536,
+                "scaleDenominator": 8530.918335399145,
+                "tileHeight": 256,
+                "tileWidth": 256,
+                "topLeftCorner": {
+                    "x": -20037508.3427892,
+                    "y": 20037508.3427892
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
3 évolutions 

* Méthode publique pour ajouter à la volée des couches dans le widget.

Ex. ajout de 2 config de couches WFS
```js
catalog.addLayerConfig({
                        "BDTOPO_V3:departement$GEOPORTAIL:OGC:WFS" : {
                            "name": "BDTOPO_V3:departement",
                            "title": "BDTOPO : Départements",
                            "description": "Départements − BDTOPO",
                            "globalConstraint": {
                                "minScaleDenominator": 0,
                                "maxScaleDenominator": 62236752975597,
                                "bbox": {
                                    "left": -63.28125,
                                    "right": 55.8984375,
                                    "top": 51.9734375,
                                    "bottom": -21.77265625
                                }
                            },
                            "serviceParams": {
                                "id": "OGC:WFS",
                                "version": "2.0.0",
                                "serverUrl": {
                                    "full": "https://data.geopf.fr/wfs/wfs"
                                }
                            },
                            "defaultProjection": "EPSG:4326",
                            "queryable": false,
                            "metadata": [],
                            "styles": [],
                            "legends": [],
                            "formats": []
                        },
                        "BDTOPO_V3:commune$GEOPORTAIL:OGC:WFS" : {
                            "name": "BDTOPO_V3:commune",
                            "title": "BDTOPO : Communes",
                            "description": "Communes − BDTOPO",
                            "globalConstraint": {
                                "minScaleDenominator": 0,
                                "maxScaleDenominator": 62236752975597,
                                "bbox": {
                                    "left": -63.28125,
                                    "right": 55.8984375,
                                    "top": 51.9734375,
                                    "bottom": -21.77265625
                                }
                            },
                            "serviceParams": {
                                "id": "OGC:WFS",
                                "version": "2.0.0",
                                "serverUrl": {
                                    "full": "https://data.geopf.fr/wfs/wfs"
                                }
                            },
                            "defaultProjection": "EPSG:4326",
                            "queryable": false,
                            "metadata": [],
                            "styles": [],
                            "legends": [],
                            "formats": []
                        }
});
```
Note :
> Le DOM du composant est entièrement reconstruit (couches et catégories)

* Possibilité de ne pas brancher l'auto-configuration, le widget est indépendant, il peut configurer les couches

Ex. La configuration transmise dans _configuration.data_ ou _configuration.url_ suffit à elle même 
pour ajouter les paramètres aux couches WMTS, WMS ou WFS.

```js
var catalog = new ol.control.Catalog({
    configuration : {
          type : "json",
          data : {...}
    }
});
map.addControl(catalog);
```
* Méthodes publiques pour activer ou desactiver une couche à l'affichage sur la carte avec check de l'entrée

```js
catalog.activeLayerByID("GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2$GEOPORTAIL:OGC:WMTS");
catalog.disableLayerByID("GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2$GEOPORTAIL:OGC:WMTS");
```
ou 
```js
catalog.activeLayer("GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2", "WMTS");
catalog.disableLayer("GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2", "WMTS");
```

---

Pour tester les 3 évolutions : 
```bash
npm run samples:modules
```
Ouvrir l'exemple : `https://localhost:8080/samples/tests/Catalog/pages-ol-catalog-modules-dsfr-type-data-without-config.html`