### PR TITLE
fix(drawing): Prise en compte de l'option layerDescription

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -25,6 +25,8 @@ __DATE__
 * 🔥 [Removed]
 
 * 🐛 [Fixed]
+
+  - Drawing: Prise en compte de l'option layerDescription (#380)
   
 * 🔒 [Security]
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.4-378",
-  "date": "16/05/2025",
+  "version": "1.0.0-beta.4-380",
+  "date": "22/05/2025",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/samples-src/pages/tests/Drawing/pages-ol-drawing-modules-dsfr-edition.html
+++ b/samples-src/pages/tests/Drawing/pages-ol-drawing-modules-dsfr-edition.html
@@ -65,7 +65,11 @@
                     });
 
                     var drawing = new ol.control.Drawing({
-                        position: "top-left"
+                        position: "top-left",
+                        layerDescription : {
+                            title: "Croquis par défaut",
+                            description : "C'est mon croquis"
+                        }
                     });
                     map.addControl(drawing);
                     drawing.on("change:collapsed", (e) => {

--- a/src/packages/Controls/Drawing/Drawing.js
+++ b/src/packages/Controls/Drawing/Drawing.js
@@ -545,7 +545,11 @@ var Drawing = class Drawing extends Control {
                     if (control instanceof LayerSwitcher) {
                         // un layer switcher est présent dans la carte
                         var layerId = this.layer.gpLayerId;
-                        // on n'ajoute des informations que s'il n'y en a pas déjà (si le titre est le numéro par défaut)
+                        // INFO
+                        // dans des cas "très" particuliers, le titre peut être un identifiant
+                        // car le titre n'a pas été renseigné.
+                        // donc, on force le croquis à être renommé avec une description
+                        // dans le gestionnaire de couche.
                         if (control._layers[layerId].title === layerId) {
                             control.addLayer(
                                 this.layer, {
@@ -786,7 +790,8 @@ var Drawing = class Drawing extends Control {
             source : new VectorSource({
                 features : features
             }),
-            title : "Mon Croquis"
+            title : this.options.layerDescription.title,
+            description : this.options.layerDescription.description
         });
         // on rajoute le champ gpResultLayerId permettant d'identifier une couche crée par le composant.
         layer.gpResultLayerId = "drawing";

--- a/src/packages/Controls/Drawing/Drawing.js
+++ b/src/packages/Controls/Drawing/Drawing.js
@@ -669,12 +669,9 @@ var Drawing = class Drawing extends Control {
         // Set default options
         this.options = options;
 
-        if (!this.options.layerDescription) {
-            this.options.layerDescription = {
-                title : "Croquis",
-                description : "Mon croquis"
-            };
-        }
+        this.options.layerDescription = Object.assign({
+            title : "Croquis",
+            description : "Mon croquis"}, options.layerDescription);
 
         // applying default tools
         if (!this.options.tools) {


### PR DESCRIPTION
cf. issue #379 

```js
var drawing = new ol.control.Drawing({
      position: "top-left",
      layerDescription : {
           title: "Croquis par défaut", // par défaut, Croquis
           description : "C'est mon croquis" // par défaut, Mon croquis
      }
});
```

