### PR TITLE
feat(layerswitcher) : Ajout méthodes forget & listen sur l'écouteur d'ajout de couche

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -16,6 +16,7 @@ __DATE__
 * ✨ [Added]
 
   - Catalog: Ajout de méthodes publiques pour ajouter une config partielle, activer ou desactiver l'affichage d'une couche (#378)
+  - LayerSwitcher : Ajout des méthodes publiques forget et listen pour (des)activer l'écouteur d'ajout de couche sur la carte (#389)
 
 * 🔨 [Changed]
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.4-386",
-  "date": "12/06/2025",
+  "version": "1.0.0-beta.4-389",
+  "date": "13/06/2025",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/samples-src/pages/tests/Drawing/pages-ol-drawing-modules-dsfr-forget-listen.html
+++ b/samples-src/pages/tests/Drawing/pages-ol-drawing-modules-dsfr-forget-listen.html
@@ -1,0 +1,133 @@
+{{#extend "ol-sample-modules-dsfr-layout"}}
+
+{{#content "vendor"}}
+
+        <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlCatalog.css" />
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlCatalog.js"></script>
+        <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlLayerSwitcher.css" />
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlLayerSwitcher.js"></script>
+        <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlDrawing.css" />
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlDrawing.js"></script>
+{{/content}}
+
+{{#content "head"}}
+        <title>Sample OpenLayers Drawing</title>
+{{/content}}
+
+{{#content "style"}}
+        <style>
+            div#map {
+                width: 100%;
+                height: 500px;
+                background-image:url("{{ resources }}/geoportail-waiting.gif");
+                background-position:center center;
+                background-repeat:no-repeat;
+            }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+            <h2>Ajout des outils de dessin</h2>
+            <!-- map -->
+            <div id="map">
+            </div>
+{{/content}}
+
+{{#content "js"}}
+            <script type="text/javascript">
+                var map;
+                var layerSwitcher;
+                var createMap = function() {
+                    // on cache l'image de chargement du Géoportail.
+                    document.getElementById('map').style.backgroundImage = 'none';
+
+                    //Création de la map
+                    map = new ol.Map({
+                        target : "map",
+                        layers : [
+                            new ol.layer.Tile({
+                                source: new ol.source.OSM(),
+                                opacity: 0.5
+                            })
+                        ],
+                        view : new ol.View({
+                            center : [288074.8449901076, 6247982.515792289],
+                            zoom : 8
+                        })
+                    });
+
+                    var catalog = new ol.control.Catalog({
+                        position: "top-left",
+                        collapsed : false
+                    });
+                    map.addControl(catalog);
+
+                    layerSwitcher = new ol.control.LayerSwitcher({
+                        options :{
+                            panel: true,
+                        }
+                    });
+                    map.addControl(layerSwitcher);
+                    layerSwitcher.on("layerswticher:add", (e) => {
+                        console.log(e);
+                    })
+                    layerSwitcher.on("layerswitcher:remove", (e) => {
+                        console.log(e);
+                    });
+
+                    var drawing = new ol.control.Drawing({
+                        collapsed : false,
+                        /*markersList : [{
+                            src : "http://api.ign.fr/api/images/api/markers/marker_01.png",
+                            anchor : [0.5, 1]
+                        } , {
+                            src : "http://api.ign.fr/api/images/api/markers/marker_02.png",
+                            anchor : [12.5, 25],
+                            anchorYUnits : "pixels",
+                            anchorXUnits : "pixels"
+                        } , {
+                            src : "http://api.ign.fr/api/images/api/markers/marker_03.png",
+                            anchor : [0.5, 0],
+                            anchorOrigin : "bottom-right"
+                        }
+                        ],*/
+                        defaultStyles : {
+                            textFillColor : "#0000FF",
+                            textStrokeColor : "#FFFFFF",
+                            strokeColor : "#000000",
+                            polyFillColor : "#FF00FF",
+                            polyFillOpacity : 0.8,
+                            strokeWidth : 2
+                        },
+                        cursorStyle : {
+                            pointRadius : 3,
+                            fillColor : "rgba(255,153,0,1)",
+                            strokeColor : "#FF0",
+                            strokeWidth : 1
+                        }
+                    });
+                    map.addControl(drawing);
+                    drawing.on("drawing:add:before", function(e) {
+                        console.log("before drawing add", e);
+                        layerSwitcher.forget();
+                        e.layer.setZIndex(1000);
+                    });
+                    drawing.on("drawing:add:after", function(e) {
+                        console.log("after drawing add", e);
+                        layerSwitcher.listen();
+                    });
+                };
+                Gp.Services.getConfig({
+                    customConfigFile : "{{ configurl }}",
+                    callbackSuffix : "",
+                    // apiKey: "{{ apikey }}",
+                    timeOut : 20000,
+                    onSuccess : createMap,
+                    onFailure : (e) => {
+                        console.error(e);
+                    }
+                });
+           </script>
+{{/content}}
+
+{{/extend}}

--- a/src/packages/Controls/Drawing/Drawing.js
+++ b/src/packages/Controls/Drawing/Drawing.js
@@ -126,6 +126,8 @@ var logger = Logger.getLogger("Drawing");
  * @param {String} [options.cursorStyle.strokeColor = "#ffffff"] - Cursor stroke color.
  * @param {String} [options.cursorStyle.strokeWidth = 1] - Cursor surrounding stroke width.
  * @param {String} [options.cursorStyle.radius = 6] - Cursor radius.
+ * @fires drawing:add:before - event triggered before an layer is added
+ * @fires drawing:add:after - event triggered after an layer is added
  * @example
  * var drawing = new ol.control.Drawing({
  *   collapsed : false,
@@ -521,6 +523,22 @@ var Drawing = class Drawing extends Control {
             // si le layer n'est pas sur la carte, on l'ajoute.
             if (!found) {
                 this.getMap().addLayer(vlayer);
+                /**
+                 * event triggered after an layer is added
+                 *
+                 * @event drawing:add:after
+                 * @property {Object} type - event
+                 * @property {Object} layer - layer
+                 * @property {Object} target - instance Drawing
+                 * @example
+                 * Drawing.on("drawing:add:after", function (e) {
+                 *   console.log(e.layer);
+                 * })
+                 */
+                this.dispatchEvent({
+                    type : "drawing:add:after",
+                    layer : vlayer
+                });
             }
             // style par defaut !
             // application des styles ainsi que ceux par defaut de ol sur le layer
@@ -550,7 +568,7 @@ var Drawing = class Drawing extends Control {
                         // car le titre n'a pas été renseigné.
                         // donc, on force le croquis à être renommé avec une description
                         // dans le gestionnaire de couche.
-                        if (control._layers[layerId].title === layerId) {
+                        if (layerId && control._layers[layerId].title === layerId) {
                             control.addLayer(
                                 this.layer, {
                                     title : this.options.layerDescription.title,
@@ -792,6 +810,24 @@ var Drawing = class Drawing extends Control {
         });
         // on rajoute le champ gpResultLayerId permettant d'identifier une couche crée par le composant.
         layer.gpResultLayerId = "drawing";
+
+        /**
+         * event triggered before an layer is added
+         *
+         * @event drawing:add:before
+         * @property {Object} type - event
+         * @property {Object} layer - layer
+         * @property {Object} target - instance Drawing
+         * @example
+         * Drawing.on("drawing:add:before", function (e) {
+         *   console.log(e.layer);
+         * })
+         */
+        this.dispatchEvent({
+            type : "drawing:add:before",
+            layer : layer
+        });
+
         // on le rajoute au controle (et à la carte)
         this.setLayer(layer);
     }

--- a/src/packages/Controls/LayerSwitcher/LayerSwitcher.js
+++ b/src/packages/Controls/LayerSwitcher/LayerSwitcher.js
@@ -192,6 +192,7 @@ var LayerSwitcher = class LayerSwitcher extends Control {
             this._listeners.onAddListener = map.getLayers().on(
                 "add",
                 (evt) => {
+                    logger.debug("LayerSwitcher:onAddListener", evt);
                     var layer = evt.element;
                     var id;
                     // on attribue un nouvel identifiant à cette couche,
@@ -213,6 +214,7 @@ var LayerSwitcher = class LayerSwitcher extends Control {
             this._listeners.onRemoveListener = map.getLayers().on(
                 "remove",
                 (evt) => {
+                    logger.debug("LayerSwitcher:onRemoveListener", evt);
                     var layer = evt.element;
                     var id = layer.gpLayerId;
                     if (this._layers[id]) {
@@ -572,6 +574,44 @@ var LayerSwitcher = class LayerSwitcher extends Control {
      */
     getContainer () {
         return this.container;
+    }
+
+    /**
+     * Forget add listener added to the control
+     */
+    forget () {
+        // on supprime les listeners d'ajout de couches
+        olObservableUnByKey(this._listeners.onAddListener);
+    }
+
+    /**
+     * Add listeners to catch map layers addition
+     */
+    listen () {
+        // on ajoute les listeners d'ajout de couches
+        var map = this.getMap();
+        if (map) {
+            this._listeners.onAddListener = map.getLayers().on(
+                "add",
+                (evt) => {
+                    logger.debug("LayerSwitcher:onAddListener", evt);
+                    var layer = evt.element;
+                    var id;
+                    // on attribue un nouvel identifiant à cette couche,
+                    // sauf si c'est une couche qui a déjà été ajoutée dans le LayerSwitcher au préalable (si gpLayerId existe)
+                    if (!layer.hasOwnProperty("gpLayerId")) {
+                        id = this._layerId;
+                        layer.gpLayerId = id;
+                        this._layerId++;
+                    } else {
+                        id = layer.gpLayerId;
+                    }
+                    if (!this._layers[id]) {
+                        this.addLayer(layer);
+                    }
+                }
+            );
+        }
     }
 
     // ################################################################### //


### PR DESCRIPTION
Ajout des méthodes publiques **forget** et **listen** pour (des)activer l'écouteur d'ajout de couches.
Ceci permet de cacher l'affichage d'une couche sur le gestionnaire de couches.

Ex.
```js
// on desactive l'écouteur du layerswitcher avant que le croquis soit ajouté à la carte
drawing.on("drawing:add:before", function(e) {
      console.log("before drawing add", e);
      layerSwitcher.forget();
      e.layer.setZIndex(1000); // Hack pour avoir les croquis toujours au dessus
});
 
// on reactive l'écouteur du layerswitcher aprés que la couche croquis soit ajoutée à la carte 
drawing.on("drawing:add:after", function(e) {
     console.log("after drawing add", e);
     layerSwitcher.listen();
});
```

Recetter avec l'exemple : `samples-src/pages/tests/Drawing/pages-ol-drawing-modules-dsfr-forget-listen.html`