### PR TITLE
fix(ContextMenu) : correction de la requete WFS pour récupérer la commune et de l'altimétrie

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -37,6 +37,7 @@ __DATE__
   - Layerswitcher : Menu contextuel en mode mobile snas items vides (#417)
   - ControlList et ZoomOut : Tooltips cassées (#419)
   - Coordinates : homogénéisation de l'affichage des coordonnées dans l'ordre lat,lon (#421)
+  - ContextMenu : correction recherche commune par wfs et interrogation service alti (#438)
 
 * 🔒 [Security]
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.5-415",
-  "date": "12/09/2025",
+  "version": "1.0.0-beta.5-438",
+  "date": "15/09/2025",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/src/packages/Controls/ContextMenu/ContextMenu.js
+++ b/src/packages/Controls/ContextMenu/ContextMenu.js
@@ -493,13 +493,13 @@ class ContextMenu extends Control {
             let config = {
                 id : "LIMITES_ADMINISTRATIVES_EXPRESS.LATEST:commune",
                 layer : "LIMITES_ADMINISTRATIVES_EXPRESS.LATEST:commune",
-                attributes : ["nom"]
+                attributes : ["code_postal","nom_officiel"]
             };
             const result = await OGCRequest.computeGenericGPFWFS(
                 config.layer,
                 config.attributes,
                 config.around || 0,
-                config.geom_name || "geom",
+                config.geom_name || "geometrie",
                 config.additional_cql || "",
                 config.epsg || 4326,
                 config.get_geom || false,
@@ -507,7 +507,7 @@ class ContextMenu extends Control {
                 clickedCoordinate[1]
             );
             if (result.length) {
-                address.innerHTML = result[0];
+                address.innerHTML = result[0].join(", ");
             }
         };
 

--- a/src/packages/Controls/ContextMenu/ContextMenu.js
+++ b/src/packages/Controls/ContextMenu/ContextMenu.js
@@ -469,7 +469,7 @@ class ContextMenu extends Control {
             },
             onFailure : function (error) {},
             // spécifique au service
-            positions : [{lon : clickedCoordinate[1], lat : clickedCoordinate[0]}],
+            positions : [{lon : clickedCoordinate[0], lat : clickedCoordinate[1]}],
             outputFormat : "json" // json|xml
         };
         Gp.Services.getAltitude(altiOptions);


### PR DESCRIPTION
Voir #350 pour la correction de la requête WFS Limites administratives sur la table commune.

Pour l'elevation, lon et lat étaient inversés : -99999 toujours renvoyé. 

Etrange : en prod entrée carto pas de problème ?!