### PR TITLE
fix(contextual-menu): le bouton gfi conserve son état si un gfi est lancé via le menu contextuel

### DIFF
--- a/src/packages/Controls/ContextMenu/ContextMenu.js
+++ b/src/packages/Controls/ContextMenu/ContextMenu.js
@@ -429,8 +429,9 @@ class ContextMenu extends Control {
     getFeatureInfo (evt) {
         var gfi = this.getMap().getControls().getArray().filter(control => control.CLASSNAME == "GetFeatureInfo")[0];
         // Enregistrement de l'état actif ou non du GFI
+        var activatedGFI;
         if (gfi.buttonGetFeatureInfoShow.getAttribute("aria-pressed") === "false") {
-            var activatedGFI = false;
+            activatedGFI = false;
         }
         gfi.buttonGetFeatureInfoShow.click();
         gfi.buttonGetFeatureInfoShow.setAttribute("aria-pressed", true);


### PR DESCRIPTION
Il est possible de lancer une requête GetFeatureInfo via le menu contextuel.


Le problème est que cette requête va activer le widget getFeatureInfo même s'il était désactivé. Dans l'entrée carto par exemple, le seul moyen de faire un gfi est de passer par le menu contextuel. On veut donc conserver le status désactivé du bouton.


**AVANT**

[Capture vidéo du 26-09-2025 18:32:55.webm](https://github.com/user-attachments/assets/f7f37ef7-b0e2-427e-99e3-0aa8769470fe)


**APRES**

[Capture vidéo du 26-09-2025 18:31:29.webm](https://github.com/user-attachments/assets/72143c51-7007-42b4-b26d-26a7b605b397)
