### PR TITLE
[OLD] feat(Export): amélioration de l'interface utilisateur du menu

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -22,6 +22,7 @@ __DATE__
   - UI : changement contenu labels affichés au survol (#474)
   - Territories : ajout des territoires d'outre-mer
   - Layerswitcher : affichage des titres des couches sur deux lignes en mode DSFR (#476)
+  - Export : Amélioration de l'interface utilisateur du menu d'exportation (#481)
 
 * 🔥 [Deprecated]
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.7-480",
-  "date": "27/01/2026",
+  "version": "1.0.0-beta.7-481",
+  "date": "02/02/2026",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/samples-src/pages/tests/Export/pages-ol-export-modules-dsfr-buttons.html
+++ b/samples-src/pages/tests/Export/pages-ol-export-modules-dsfr-buttons.html
@@ -95,7 +95,8 @@
                   menu : true,
                   menuOptions : {
                     outside : true,
-                    above : true,
+                    position : "top",
+                    name : "options",
                     labelDesc : false,
                     selectFormat : false
                   },

--- a/samples-src/pages/tests/Export/pages-ol-export-modules-dsfr-menu.html
+++ b/samples-src/pages/tests/Export/pages-ol-export-modules-dsfr-menu.html
@@ -92,6 +92,7 @@
                 // * appel instance externe
                 var drawing = new ol.control.Drawing({
                   position: "bottom-left",
+                  collapsed: false,
                   tools : {
                     export : false
                   }
@@ -105,9 +106,12 @@
                   direction : "column",
                   menu : true,
                   menuOptions : {
-                    above : true,
-                    outside : true,
-                    labelFormat : false
+                    name : "option",
+                    position : "top",
+                    outside : false,
+                    labelName : true,
+                    labelDesc : true,
+                    selectFormat : true
                   },
                   icons : {
                     menu : "",
@@ -165,7 +169,7 @@
                   direction: "column",
                   menu : true,
                   menuOptions : {
-                    above : true,
+                    position : "top",
                     outside : true,
                     selectFormat : false
                   },
@@ -182,7 +186,7 @@
                 exportRoute.setTitle("Exporter Itineraire");
                 exportRoute.setMenu(true);
                 exportRoute.setMenuOptions({
-                  above : true,
+                  position : "top",
                   outside : true,
                   selectFormat : false
                 });

--- a/samples-src/pages/tests/Export/pages-ol-export-modules-dsfr-menu.html
+++ b/samples-src/pages/tests/Export/pages-ol-export-modules-dsfr-menu.html
@@ -106,11 +106,11 @@
                   direction : "column",
                   menu : true,
                   menuOptions : {
-                    name : "option",
-                    position : "top",
-                    outside : false,
+                    name : "Options",
+                    position : "bottom",
+                    outside : true,
                     labelName : true,
-                    labelDesc : true,
+                    labelDesc : false,
                     selectFormat : true
                   },
                   icons : {
@@ -137,12 +137,17 @@
                     format: "kml",
                     kind: "primary",
                     name: "export-iso",
-                    direction: "column",
                     description : "Graphe isochrone",
                     title : "Exporter Isochrone",
-                    menu: true,
+                    direction : "column",
+                    menu : true,
                     menuOptions : {
-                      outside : true
+                      name : "Options",
+                      position : "bottom",
+                      outside : true,
+                      labelName : true,
+                      labelDesc : false,
+                      selectFormat : true
                     },
                     icons : {
                       menu : "",
@@ -166,12 +171,15 @@
                 });
                 map.addControl(route);
                 exportRoute = new ol.control.Export({
-                  direction: "column",
+                  direction : "column",
                   menu : true,
                   menuOptions : {
-                    position : "top",
+                    name : "Options",
+                    position : "bottom",
                     outside : true,
-                    selectFormat : false
+                    labelName : true,
+                    labelDesc : false,
+                    selectFormat : true
                   },
                   icons: {
                     menu : "",
@@ -186,9 +194,12 @@
                 exportRoute.setTitle("Exporter Itineraire");
                 exportRoute.setMenu(true);
                 exportRoute.setMenuOptions({
-                  position : "top",
-                  outside : true,
-                  selectFormat : false
+                    name : "Options",
+                    position : "bottom",
+                    outside : true,
+                    labelName : true,
+                    labelDesc : false,
+                    selectFormat : true
                 });
                 exportRoute.on("button:clicked", (e) => {
                   console.log("Export Route", e);
@@ -209,13 +220,16 @@
                   control: measureProfil,
                   name: "export-profil", 
                   format : "geojson",
-                  direction: "column",
+                  direction : "column",
                   menu : true,
                   menuOptions : {
+                    name : "Options",
+                    position : "bottom",
                     outside : true,
-                    selectFormat : false,
-                    labelDesc : false
-                  }
+                    labelName : true,
+                    labelDesc : false,
+                    selectFormat : true
+                  },
                 });
                 map.addControl(exportProfil);
                 exportProfil.on("button:clicked", (e) => {

--- a/src/packages/CSS/Controls/Export/DSFRexportStyle.css
+++ b/src/packages/CSS/Controls/Export/DSFRexportStyle.css
@@ -42,22 +42,41 @@ dialog div .gpf-export-menu-container {
     justify-content: flex-end;
 }
 
+.gpf-export-menu-format,
+.gpf-export-menu-desc,
+.gpf-export-menu-name {
+    display: flex;
+    justify-content: space-evenly;
+    flex-direction: column;
+}
+
+/* position du menu */
+
+/* right */
 .gpf-export-menu-container-row-reverse {
     flex-direction: row-reverse;
 }
-
+/* bottom (par défaut) */
 .gpf-export-menu-container-column-reverse {
     flex-direction: column-reverse;
 }
-
+/* left */
 .gpf-export-menu-container-row {
     flex-direction: row;
 }
-
+/* top */
 .gpf-export-menu-container-column {
     flex-direction: column;
 }
 
+/* position des options dans le menu */
+.gpf-export-menu-options-row {
+    flex-direction: row;
+    align-items: center;
+}
+.gpf-export-menu-options-column {
+    flex-direction: column;
+}
 .gpf-accordion {
     width: 110px;
 }

--- a/src/packages/CSS/Controls/Export/GPFexport.css
+++ b/src/packages/CSS/Controls/Export/GPFexport.css
@@ -11,3 +11,13 @@
 [id^=GPexportMenuName]{}
 [id^=GPexportMenuDesc]{}
 [id^=GPexportMenuFormat]{}
+
+[id^=GPexportMenuFormat].gpf-export-menu-options-row label,
+[id^=GPexportMenuDesc].gpf-export-menu-options-row label,
+[id^=GPexportMenuName].gpf-export-menu-options-row label {
+    width: 30%;
+}
+[id^=GPexportMenuDesc].gpf-export-menu-options-row input,
+[id^=GPexportMenuName].gpf-export-menu-options-row input {
+    width: 70%;
+}

--- a/src/packages/CSS/Controls/Export/GPFexport.css
+++ b/src/packages/CSS/Controls/Export/GPFexport.css
@@ -1,0 +1,13 @@
+/* le menu des options */
+[id^=GPexportBtnMenuContent] {}
+[id^=GPexportMenuContent]{}
+[id^=GPexportMenuButtons] {
+    display: flex;
+    align-items: center;
+    justify-content: space-evenly;
+    flex-direction: row;
+    align-content: center;
+}
+[id^=GPexportMenuName]{}
+[id^=GPexportMenuDesc]{}
+[id^=GPexportMenuFormat]{}

--- a/src/packages/Controls/Export/Export.js
+++ b/src/packages/Controls/Export/Export.js
@@ -445,6 +445,7 @@ class ButtonExport extends Control {
                         id="GPexportBtnMenuContent-${this.uid}"
                         class="gpf-accordion__btn fr-accordion__btn" 
                         aria-expanded="false" aria-controls="GPexportMenuContent-${this.uid}">${menuName}</button>
+                    <span id="GPexportTxtMenuContent-${this.uid}" class="gpf-hidden">${menuName}</span>
                 </h3>
                 <div id="GPexportMenuContent-${this.uid}"
                     class="GPexportMenuContent fr-collapse">
@@ -554,6 +555,8 @@ class ButtonExport extends Control {
                     this.menu.classList.remove("gpf-accordion", "fr-accordion");
                     var divButton = this.menu.querySelector("#GPexportBtnMenuContent-" + this.uid);
                     divButton.classList.add("gpf-hidden");
+                    var txtButton = this.menu.querySelector("#GPexportTxtMenuContent-" + this.uid);
+                    txtButton.classList.remove("gpf-hidden");
                     var divContent = this.menu.querySelector("#GPexportMenuContent-" + this.uid);
                     divContent.classList.remove("fr-collapse");
                     var divButtons = this.menu.querySelector("#GPexportMenuButtons-" + this.uid);

--- a/src/packages/Controls/Export/Export.js
+++ b/src/packages/Controls/Export/Export.js
@@ -44,12 +44,13 @@ class ButtonExport extends Control {
     * @param {String} [options.kind = "secondary"] - button type : primary | secondary | tertiary
     * @param {Boolean} [options.menu = false] - displays the menu
     * @param {Object} [options.menuOptions] - options of the menu.
+    * @param {Boolean} [options.menuOptions.name = "options"] - displays the menu name. Null if you don't want it
     * @param {Boolean} [options.menuOptions.outside = false] - displays all element outside of menu
-    * @param {Boolean} [options.menuOptions.above = false] - displays menu above or not of the button
+    * @param {String} [options.menuOptions.position = "bottom"] - displays menu position relative to the button
     * @param {Boolean} [options.menuOptions.labelName = true] - displays the label name
     * @param {Boolean} [options.menuOptions.labelDesc = true] - displays the label description
     * @param {Boolean} [options.menuOptions.selectFormat = true] - displays the select format
-    * @param {String} [options.direction = "row"] - buttons and menus layout
+    * @param {String} [options.direction = "column"] - buttons and menus layout
     * @param {Object} [options.icons] - icons
     * @param {String} [options.icons.menu = "\u2630 "] - displays the menu icon, or otherwise left blank if you don't want it
     * @param {String} [options.icons.button = "export"] - displays the button icon : save or export icon, or otherwise left blank if you don't want it
@@ -354,10 +355,11 @@ class ButtonExport extends Control {
             description : "export",
             title : "Exporter",
             kind : "secondary",
-            direction : "row",
+            direction : "column",
             menu : false,
             menuOptions : {
-                above : false, // au dessus ou en dessous du bouton !
+                name : "options",
+                position : "bottom", // en dessous du bouton
                 outside : false,
                 labelName : true,
                 labelDesc : true,
@@ -431,12 +433,9 @@ class ButtonExport extends Control {
 
         var div = document.createElement("div");
         div.id = this._addUID("GPexportContainer");
-        div.className = "GPexportMenuContainer gpf-export-menu-container gpf-export-menu-container-row-reverse";
+        div.className = "GPexportMenuContainer gpf-export-menu-container gpf-export-menu-container-column-reverse";
 
-        if (this.options.direction === "column") {
-            div.classList.replace("gpf-export-menu-container-row-reverse", "gpf-export-menu-container-column-reverse");
-        }
-        
+        var menuName = this.options.menuOptions.name || "";
         // menu des options
         // > GPexportMenuHidden : pas de menu pour le mode classic !
         var menu = this.stringToHTML(`
@@ -445,22 +444,23 @@ class ButtonExport extends Control {
                     <button type="button" 
                         id="GPexportBtnMenuContent-${this.uid}"
                         class="gpf-accordion__btn fr-accordion__btn" 
-                        aria-expanded="false" aria-controls="GPexportMenuContent-${this.uid}">options</button>
+                        aria-expanded="false" aria-controls="GPexportMenuContent-${this.uid}">${menuName}</button>
                 </h3>
                 <div id="GPexportMenuContent-${this.uid}"
                     class="GPexportMenuContent fr-collapse fr-mx-2w">
                     <div id="GPexportMenuName-${this.uid}" 
-                        class="GPexportMenuName">
+                        class="gpf-export-menu-name">
                         <label class="GPlabel gpf-label fr-label" for="GPexportMenuInputName-${this.uid}" title="Nom">Nom</label>
                         <input type="text" id="GPexportMenuInputName-${this.uid}" class="GPinput gpf-input fr-input">
                     </div>
                     <div id="GPexportMenuDesc-${this.uid}"
-                        class="GPexportMenuDesc">
+                        class="gpf-export-menu-desc">
                         <label class="GPlabel gpf-label fr-label" for="GPexportMenuInputDesc-${this.uid}" title="Description">Description</label>
                         <input type="text" id="GPexportMenuInputDesc-${this.uid}" class="GPinput gpf-input fr-input">
                     </div>
-                    <div id="GPexportMenuFormat-${this.uid}">
-                        <label class="GPlabel gpf-label fr-label" title="Formats">Formats</label>
+                    <div id="GPexportMenuFormat-${this.uid}"
+                        class="gpf-export-menu-format">
+                        <label class="GPlabel gpf-label fr-label" title="Formats">Format</label>
                         <div class="GPexportMenuFormat fr-radio-group fr-m-1w">
                             <input type="radio" 
                                 id="GPmenuFormatGeojson-${this.uid}"
@@ -543,6 +543,11 @@ class ButtonExport extends Control {
             var btnCancel = this.menu.querySelector("#GPexportMenuButtonCancel-" + this.uid);
             btnCancel.addEventListener("click", (e) => this.onClickButtonCancel(e));
         
+            if (this.options.direction === "row") {
+                this.menu.querySelector("#GPexportMenuName-" + this.uid).classList.add("gpf-export-menu-options-row");
+                this.menu.querySelector("#GPexportMenuDesc-" + this.uid).classList.add("gpf-export-menu-options-row");
+                this.menu.querySelector("#GPexportMenuFormat-" + this.uid).classList.add("gpf-export-menu-options-row");                
+            }
             // les options du menu
             if (this.options.menuOptions) {
                 if (this.options.menuOptions.outside) {
@@ -553,22 +558,35 @@ class ButtonExport extends Control {
                     divContent.classList.remove("fr-collapse");
                     var divButtons = this.menu.querySelector("#GPexportMenuButtons-" + this.uid);
                     divButtons.classList.add("gpf-hidden");
+                    divButtons.style.display = "none";
                 }
-                if (this.options.menuOptions.above) {
-                    div.classList.replace("gpf-export-menu-container-row-reverse", "gpf-export-menu-container-row");
+                if (this.options.menuOptions.position === "top") {
                     div.classList.replace("gpf-export-menu-container-column-reverse", "gpf-export-menu-container-column");
+                }
+                // bottom par defaut
+                if (this.options.menuOptions.position === "bottom") {
+                    div.classList.replace("gpf-export-menu-container-column", "gpf-export-menu-container-column-reverse");
+                }
+                if (this.options.menuOptions.position === "left") {
+                    div.classList.replace("gpf-export-menu-container-column-reverse", "gpf-export-menu-container-row");
+                }
+                if (this.options.menuOptions.position === "right") {
+                    div.classList.replace("gpf-export-menu-container-column-reverse", "gpf-export-menu-container-row-reverse");
                 }
                 if (!this.options.menuOptions.labelName) {
                     var divName = this.menu.querySelector("#GPexportMenuName-" + this.uid);
                     divName.classList.add("gpf-hidden");
+                    divName.style.display = "none";
                 }
                 if (!this.options.menuOptions.labelDesc) {
                     var divDesc = this.menu.querySelector("#GPexportMenuDesc-" + this.uid);
                     divDesc.classList.add("gpf-hidden");
+                    divDesc.style.display = "none";
                 }
                 if (!this.options.menuOptions.selectFormat) {
                     var divFormat = this.menu.querySelector("#GPexportMenuFormat-" + this.uid);
                     divFormat.classList.add("gpf-hidden");
+                    divFormat.style.display = "none";
                 }
             }
         }

--- a/src/packages/Controls/Export/Export.js
+++ b/src/packages/Controls/Export/Export.js
@@ -440,27 +440,27 @@ class ButtonExport extends Control {
         // > GPexportMenuHidden : pas de menu pour le mode classic !
         var menu = this.stringToHTML(`
             <div class="GPexportMenuHidden gpf-accordion fr-accordion ${this.menuClassHidden}">
-                <h3 class="gpf-accordion__title fr-accordion__title">
+                <h3 class="gpf-accordion__title fr-accordion__title fr-my-1w">
                     <button type="button" 
                         id="GPexportBtnMenuContent-${this.uid}"
                         class="gpf-accordion__btn fr-accordion__btn" 
                         aria-expanded="false" aria-controls="GPexportMenuContent-${this.uid}">${menuName}</button>
                 </h3>
                 <div id="GPexportMenuContent-${this.uid}"
-                    class="GPexportMenuContent fr-collapse fr-mx-2w">
+                    class="GPexportMenuContent fr-collapse">
                     <div id="GPexportMenuName-${this.uid}" 
                         class="gpf-export-menu-name">
-                        <label class="GPlabel gpf-label fr-label" for="GPexportMenuInputName-${this.uid}" title="Nom">Nom</label>
+                        <label class="GPlabel gpf-label fr-label fr-mr-1w" for="GPexportMenuInputName-${this.uid}" title="Nom">Nom</label>
                         <input type="text" id="GPexportMenuInputName-${this.uid}" class="GPinput gpf-input fr-input">
                     </div>
                     <div id="GPexportMenuDesc-${this.uid}"
-                        class="gpf-export-menu-desc">
-                        <label class="GPlabel gpf-label fr-label" for="GPexportMenuInputDesc-${this.uid}" title="Description">Description</label>
+                        class="gpf-export-menu-desc fr-mt-2w">
+                        <label class="GPlabel gpf-label fr-label fr-mr-1w" for="GPexportMenuInputDesc-${this.uid}" title="Description">Description</label>
                         <input type="text" id="GPexportMenuInputDesc-${this.uid}" class="GPinput gpf-input fr-input">
                     </div>
                     <div id="GPexportMenuFormat-${this.uid}"
-                        class="gpf-export-menu-format">
-                        <label class="GPlabel gpf-label fr-label" title="Formats">Format</label>
+                        class="gpf-export-menu-format fr-mt-2w">
+                        <label class="GPlabel gpf-label fr-label fr-mr-1w" title="Formats">Format</label>
                         <div class="GPexportMenuFormat fr-radio-group fr-m-1w">
                             <input type="radio" 
                                 id="GPmenuFormatGeojson-${this.uid}"

--- a/src/packages/Controls/Export/Export.js
+++ b/src/packages/Controls/Export/Export.js
@@ -439,7 +439,7 @@ class ButtonExport extends Control {
         // menu des options
         // > GPexportMenuHidden : pas de menu pour le mode classic !
         var menu = this.stringToHTML(`
-            <div class="GPexportMenuHidden gpf-accordion fr-accordion ${this.menuClassHidden}">
+            <div class="GPexportMenuHidden fr-accordion ${this.menuClassHidden}">
                 <h3 class="gpf-accordion__title fr-accordion__title fr-my-1w">
                     <button type="button" 
                         id="GPexportBtnMenuContent-${this.uid}"

--- a/src/packages/Controls/Export/Export.js
+++ b/src/packages/Controls/Export/Export.js
@@ -279,6 +279,8 @@ class ButtonExport extends Control {
         /** @private */
         this.inputDesc = null;
         /** @private */
+        this.inputFormats = {};
+        /** @private */
         this.menu = null;
         /** @private */
         this.menuClassHidden = "GPelementHidden gpf-hidden";
@@ -439,7 +441,7 @@ class ButtonExport extends Control {
         // menu des options
         // > GPexportMenuHidden : pas de menu pour le mode classic !
         var menu = this.stringToHTML(`
-            <div class="GPexportMenuHidden fr-accordion ${this.menuClassHidden}">
+            <div id="GPexportMenu-${this.uid}" class="GPexportMenuHidden fr-accordion ${this.menuClassHidden}">
                 <h3 class="gpf-accordion__title fr-accordion__title fr-my-1w">
                     <button type="button" 
                         id="GPexportBtnMenuContent-${this.uid}"
@@ -465,7 +467,7 @@ class ButtonExport extends Control {
                         <div class="GPexportMenuFormat fr-radio-group fr-m-1w">
                             <input type="radio" 
                                 id="GPmenuFormatGeojson-${this.uid}"
-                                name="format" 
+                                name="format-${this.uid}" 
                                 value="geojson">
                             <label class="fr-label container" for="GPmenuFormatGeojson-${this.uid}">GeoJSON
                                 <span class="checkmark"></span>
@@ -474,7 +476,7 @@ class ButtonExport extends Control {
                         <div class="GPexportMenuFormat fr-radio-group fr-m-1w">
                             <input type="radio" 
                                 id="GPmenuFormatKml-${this.uid}"
-                                name="format" 
+                                name="format-${this.uid}" 
                                 value="kml">
                             <label class="fr-label container" for="GPmenuFormatKml-${this.uid}">KML
                                 <span class="checkmark"></span>
@@ -483,7 +485,7 @@ class ButtonExport extends Control {
                         <div class="GPexportMenuFormat fr-radio-group fr-m-1w">
                             <input type="radio" 
                                 id="GPmenuFormatGpx-${this.uid}"
-                                name="format" 
+                                name="format-${this.uid}" 
                                 value="gpx">
                             <label class="fr-label container" for="GPmenuFormatGpx-${this.uid}">GPX
                                 <span class="checkmark"></span>
@@ -509,16 +511,17 @@ class ButtonExport extends Control {
             </div>
         `);
 
-        this.menu = menu.firstChild;
+        this.menu = menu.querySelector("#GPexportMenu-" + this.uid);
         if (this.menu) {
             if (this.options.menu) {
                 var className = this.menu.className;
                 this.menu.className = className.replace(this.menuClassHidden, "");
             }
             var format = this.options.format.toUpperCase();
-            var radios = this.menu.querySelectorAll(`input[type=radio][name="format"]`);
+            var radios = this.menu.querySelectorAll(`input[type=radio][name="format-${this.uid}"]`);
             for (let i = 0; i < radios.length; i++) {
                 var radio = radios[i];
+                this.inputFormats[radio.value] = radio;
                 // radio checked par defaut
                 if (radio.id.toUpperCase().includes(format)) {
                     radio.checked = true;
@@ -988,20 +991,32 @@ class ButtonExport extends Control {
             case "KML":
                 this.extension = ".kml";
                 this.mimeType = "application/vnd.google-earth.kml+xml";
+                if (this.inputFormats["kml"]) {
+                    this.inputFormats["kml"].checked = true;
+                }
                 break;
             case "GPX":
                 this.extension = ".gpx";
                 this.mimeType = "application/gpx+xml";
+                if (this.inputFormats["gpx"]) {
+                    this.inputFormats["gpx"].checked = true;
+                }
                 break;
             case "GEOJSON":
                 this.extension = ".geojson";
                 this.mimeType = "application/geo+json";
+                if (this.inputFormats["geojson"]) {
+                    this.inputFormats["geojson"].checked = true;
+                }
                 break;
             default:
                 // redefine format by default !
                 this.options.format = "GEOJSON";
                 this.extension = ".geojson";
                 this.mimeType = "application/geo+json";
+                if (this.inputFormats["geojson"]) {
+                    this.inputFormats["geojson"].checked = true;
+                }
                 break;
         }
     }
@@ -1013,6 +1028,9 @@ class ButtonExport extends Control {
      */
     setName (name) {
         this.options.name = name;
+        if (this.inputName) {
+            this.inputName.value = name;
+        }
     }
 
     /**
@@ -1022,6 +1040,9 @@ class ButtonExport extends Control {
      */
     setDescription (desc) {
         this.options.description = desc;
+        if (this.inputDesc) {
+            this.inputDesc.value = desc;
+        }
     }
 
     /**


### PR DESCRIPTION
# Améliorer l'UX/UI du menu des options

## Pour tester

> on utilise l'exemple suivant :
> `samples-src/pages/tests/Export/pages-ol-export-modules-dsfr-menu.html`

:information_source: Le bouton export et ses options sont disponible pour les widgets suivants : 
- drawing
- elevationPath
- Isochron
- Route

## Les options à modifier

Options du menu du bouton Export
```js
var exportDrawing = new ol.control.Export({
                  title : "Exporter",
                  download : true,
                  control: drawing,accordeon
                  format : "geojson",
                  direction : "column", // row
                  menu : true,
                  menuOptions : {
                    name : "option", // nom du menu, null affiche uniquement le curseur
                    position : "top", // bottom, right, left
                    outside : false, // menu accordéon ou non
                    labelName : true, // afficher le nom de l'export
                    labelDesc : true, // afficher la description
                    selectFormat : true // afficher la liste des types d'export
                  },
                  icons : {
                    menu : "",
                    button : "export"
                  },
                  kind : "primary"
});left
```

## Exemples

Ex. de configuration avec _position_, _outside_ et _direction_ avec **Drawing**

<img width="395" height="431" alt="image" src="https://github.com/user-attachments/assets/21c31b09-789c-49af-b10d-e936a853309d" />
<img width="404" height="444" alt="image" src="https://github.com/user-attachments/assets/0b6adffd-aceb-4b88-8452-8b960222e2da" />
<img width="513" height="376" alt="image" src="https://github.com/user-attachments/assets/7b62d534-faa6-4ae6-8909-8fb79157e752" />
<img width="426" height="400" alt="image" src="https://github.com/user-attachments/assets/887d66e7-dec0-4b92-b10e-a84c6fba7952" />
---
<img width="426" height="667" alt="image" src="https://github.com/user-attachments/assets/32e0cd9a-3a52-4876-a600-ed915e040ae4" />
<img width="423" height="676" alt="image" src="https://github.com/user-attachments/assets/0076e6f4-ec0d-41f3-84bf-4655a370be08" />
<img width="526" height="514" alt="image" src="https://github.com/user-attachments/assets/62a09d98-c1cf-4ddc-9ed8-26263155fff9" />
