### PR TITLE
fix(ui): css pour corriger plein de boutons en mode classique

### DIFF
--- a/samples-src/pages/tests/Default/pages-ol-modules-dsfr-default.html
+++ b/samples-src/pages/tests/Default/pages-ol-modules-dsfr-default.html
@@ -20,7 +20,12 @@
         <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlReverseGeocode.css" />
         <script src="{{ baseurl }}/dist/modules/GpfExtOlReverseGeocode.js"></script>
         <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlSearchEngine.css" />
-        <script src="{{ baseurl }}/dist/modules/GpfExtOlSearchEngine.js"></script>
+        <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlAbstractAdvancedSearch.css" />
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlSearchEngineAdvanced.js"></script>
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlInseeAdvancedSearch.js"></script>
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlLocationAdvancedSearch.js"></script>
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlParcelAdvancedSearch.js"></script>
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlCoordinateAdvancedSearch.js"></script>
         <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlGetFeatureInfo.css" />
         <script src="{{ baseurl }}/dist/modules/GpfExtOlGetFeatureInfo.js"></script>
         <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlMeasureLength.css" />
@@ -186,11 +191,19 @@
                   gutter: false,
                 });
                 map.addControl(reverse);
+                
+                var insee = new ol.control.InseeAdvancedSearch({});
 
-                var search = new ol.control.SearchEngine({
-                  position : "top-left",
-                  splitResults : false,
-                });
+                var location = new ol.control.LocationAdvancedSearch({});
+
+                var parcel = new ol.control.ParcelAdvancedSearch({});
+
+                var coordinates = new ol.control.CoordinateAdvancedSearch({});
+                
+                var search = new ol.control.SearchEngineAdvanced({
+                        advancedSearch : [insee, location, coordinates, parcel],
+                        returnTrueGeometry : true
+                    });
                 map.addControl(search);
 
                 var measureLength = new ol.control.MeasureLength({

--- a/src/packages/CSS/Controls/ControlList/GPFcontrolListStyle.css
+++ b/src/packages/CSS/Controls/ControlList/GPFcontrolListStyle.css
@@ -1,3 +1,9 @@
+.GPshowControlListPicto {
+  background-image: url("img/GPcontrolList.svg");
+  background-repeat: no-repeat;
+  background-position: center center;
+}
+
 div[id^="GPcontrolList-"] .GPshowOpen > span {
   font-size: 24px;
   color: white;

--- a/src/packages/CSS/Controls/ControlList/img/GPcontrolList.svg
+++ b/src/packages/CSS/Controls/ControlList/img/GPcontrolList.svg
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="4.3232098mm"
+   height="0.96131092mm"
+   viewBox="0 0 4.3232098 0.96131092"
+   version="1.1"
+   id="svg1"
+   xml:space="preserve"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+     id="defs1" /><g
+     id="layer1"
+     transform="translate(-112.29948,-168.46085)"><circle
+       style="fill:#ffffff;stroke:#ff0000;stroke-width:0;stroke-dasharray:none;paint-order:markers fill stroke"
+       id="path2"
+       cx="112.78014"
+       cy="168.9415"
+       r="0.48065579" /><circle
+       style="fill:#ffffff;stroke:#ff0000;stroke-width:0;stroke-dasharray:none;paint-order:markers fill stroke"
+       id="path2-3"
+       cx="114.4611"
+       cy="168.9415"
+       r="0.48065579" /><circle
+       style="fill:#ffffff;stroke:#ff0000;stroke-width:0;stroke-dasharray:none;paint-order:markers fill stroke"
+       id="path2-6"
+       cx="116.14204"
+       cy="168.9415"
+       r="0.48065579" /></g></svg>

--- a/src/packages/CSS/Controls/Drawing/GPFdrawingStyle.css
+++ b/src/packages/CSS/Controls/Drawing/GPFdrawingStyle.css
@@ -156,6 +156,7 @@ div.drawing-tools-flex-display {
 
 button[id^=drawing-export-] {
     background-position: 2px 0;
+    cursor: pointer;
 }
 
 .drawing-button {

--- a/src/packages/CSS/Controls/Export/GPFexportStyle.css
+++ b/src/packages/CSS/Controls/Export/GPFexportStyle.css
@@ -21,6 +21,7 @@ button[id^=GPexportButton-].GPexportButtonExportIcon {
     background-size: 25px 25px;
     background-repeat: no-repeat;
     background-position: left;
+    cursor: pointer;
 }
 
 button[id^=GPexportButton-].GPexportButtonSaveIcon {
@@ -29,6 +30,7 @@ button[id^=GPexportButton-].GPexportButtonSaveIcon {
     background-size: 25px 25px;
     background-repeat: no-repeat;
     background-position: left;
+    cursor: pointer;
 }
 
 /* menu */

--- a/src/packages/CSS/Controls/Measures/GPFmeasureAreaStyle.css
+++ b/src/packages/CSS/Controls/Measures/GPFmeasureAreaStyle.css
@@ -9,10 +9,6 @@ button[id^="GPshowMeasureAreaPicto-"] {
   background-position: -78px center;
 }
   
-button[id^="GPshowMeasureAreaPicto-"][aria-pressed="false"] {
-  background-color: rgba(0,60,136,0.5);
-}
-  
 button[id^="GPshowMeasureAreaPicto-"][aria-pressed="true"] {
   background-color: rgba(0,60,136,0.7);
 }

--- a/src/packages/CSS/Controls/Measures/GPFmeasureAzimuthStyle.css
+++ b/src/packages/CSS/Controls/Measures/GPFmeasureAzimuthStyle.css
@@ -8,10 +8,6 @@ button[id^="GPshowMeasureAzimuthPicto-"] {
   background-position: 2px center;
 }
   
-button[id^="GPshowMeasureAzimuthPicto-"][aria-pressed="false"] {
-  background-color: rgba(0,60,136,0.5);
-}
-  
 button[id^="GPshowMeasureAzimuthPicto-"][aria-pressed="true"] {
   background-color: rgba(0,60,136,0.7);
 }

--- a/src/packages/CSS/Controls/Measures/GPFmeasureLengthStyle.css
+++ b/src/packages/CSS/Controls/Measures/GPFmeasureLengthStyle.css
@@ -8,10 +8,6 @@ button[id^="GPshowMeasureLengthPicto-"] {
   background-position: -24px center;
 }
   
-button[id^="GPshowMeasureLengthPicto-"][aria-pressed="false"] {
-  background-color: rgba(0,60,136,0.5);
-}
-  
 button[id^="GPshowMeasureLengthPicto-"][aria-pressed="true"] {
     background-color: rgba(0,60,136,0.7);
 }

--- a/src/packages/CSS/Controls/OverviewMap/GPFoverviewMapStyle.css
+++ b/src/packages/CSS/Controls/OverviewMap/GPFoverviewMapStyle.css
@@ -1,6 +1,6 @@
-.GPshowOverviewMap {
-    background-image: url("img/overviewmap.svg");
+.GPshowOverviewMapPicto {
+    background-image: url("img/GPoverviewMap.svg");
     background-repeat: no-repeat;
     background-size: auto auto;
-    background-position: 2px center;
+    background-position: 3px center;
 }

--- a/src/packages/CSS/Controls/OverviewMap/img/GPoverviewMap.svg
+++ b/src/packages/CSS/Controls/OverviewMap/img/GPoverviewMap.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="6.1169472mm"
+   height="5.7458382mm"
+   viewBox="0 0 6.1169472 5.7458382"
+   version="1.1"
+   id="svg1"
+   xml:space="preserve"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+     id="defs1" /><g
+     id="layer1"
+     transform="translate(-111.38076,-165.92516)"><g
+       id="g3"><g
+         id="g2"><path
+           style="fill:none;stroke:#ffffff;stroke-width:0.2;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+           d="m 113.31974,166.54388 v 4.99229 l -1.90997,-0.57901"
+           id="path1-3" /><path
+           style="fill:none;stroke:#ffffff;stroke-width:0.2;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+           d="m 111.48076,171.05224 v -4.99229 l 1.90997,0.57901"
+           id="path1" /></g><g
+         id="g2-2"
+         transform="matrix(-1,0,0,1,226.83948,0)"><path
+           style="fill:none;stroke:#ffffff;stroke-width:0.2;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+           d="m 113.31974,166.54388 v 4.99229 l -1.90997,-0.57901"
+           id="path1-3-8" /><path
+           style="fill:none;stroke:#ffffff;stroke-width:0.2;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+           d="m 111.48076,171.05224 v -4.99229 l 1.90997,0.57901"
+           id="path1-9" /></g><g
+         id="g2-29"
+         transform="translate(4.0779614)"><path
+           style="fill:none;stroke:#ffffff;stroke-width:0.2;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+           d="m 113.31974,166.54388 v 4.99229 l -1.90997,-0.57901"
+           id="path1-3-3" /><path
+           style="fill:none;stroke:#ffffff;stroke-width:0.2;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+           d="m 111.48076,171.05224 v -4.99229 l 1.90997,0.57901"
+           id="path1-1" /></g></g></g></svg>

--- a/src/packages/CSS/Controls/SearchEngine/DSFRsearchEngineStyle.css
+++ b/src/packages/CSS/Controls/SearchEngine/DSFRsearchEngineStyle.css
@@ -66,6 +66,7 @@ input[name^="inputSex"].gpf-input {
 button[id^=GPsearchInputReset] {
   width: 40px;
   height: 40px;
+  right: 0px;
 }
 
 [id^="GPshowSearchDiv"] {

--- a/src/packages/CSS/Controls/SearchEngine/GPFsearchEngine.css
+++ b/src/packages/CSS/Controls/SearchEngine/GPFsearchEngine.css
@@ -64,7 +64,6 @@ form[id^=GPsearchInput-] {
 button[id^=GPsearchInputReset] {
   position: absolute;
   top: 0px;
-  right: 0px;
   border: unset;
 }
 

--- a/src/packages/CSS/Controls/SearchEngine/GPFsearchEngineStyle.css
+++ b/src/packages/CSS/Controls/SearchEngine/GPFsearchEngineStyle.css
@@ -63,6 +63,10 @@
   background-position: 0 center;
 }
 
+button[id^=GPsearchInputReset] {
+  right: 3px;
+}
+
 .gpf-select {
   background-color: #FFF;
 }
@@ -117,8 +121,6 @@ form[id^=GPsearchInput-] {
 
 form[id^=GPsearchInput-] input {
   display: block;
-  width: 100%;
-  /* height: 100%; */
   border: 1px solid #999;
   border-top-right-radius: 5px;
   border-bottom-right-radius: 5px;

--- a/src/packages/CSS/GPFgeneralWidget.css
+++ b/src/packages/CSS/GPFgeneralWidget.css
@@ -45,7 +45,6 @@
 #position-container-top-right,
 #position-container-bottom-left,
 #position-container-bottom-right {
-  border-style: solid;
   position: absolute;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
En mode classique, plein de boutons ne s'affichaient plus correctement.
Chirurgie de guerre pour corriger rapidement.

Avant : 
<img width="892" height="561" alt="image" src="https://github.com/user-attachments/assets/74f83e7b-2e55-4d67-942d-103f4b9676ef" />
<img width="83" height="50" alt="image" src="https://github.com/user-attachments/assets/c05609c6-7c14-422b-9639-3e6b7bd3103e" />

Après : 
<img width="893" height="556" alt="image" src="https://github.com/user-attachments/assets/03bff018-371d-4a69-a9f1-f2958abc27d2" />
<img width="242" height="68" alt="image" src="https://github.com/user-attachments/assets/b257514f-b5d2-4b2a-957b-af9ad4f9a392" />


**Attention, en mode classique, le clic sur bouton GFI n'a aucun effet ! à corriger**
