### PR TITLE
Fix(Reporting): l'option `gutter` n'avait aucun impact

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -24,7 +24,8 @@ __DATE__
 * 🐛 [Fixed]
 
   - SearchEngine : recherche guidée parcellaire sur les DROM-COM (#491)
-  
+  - Reporting: suppression de la classe gpf-button-no-gutter par défaut
+
 * 🔒 [Security]
 
 

--- a/src/packages/Controls/Reporting/ReportingDOM.js
+++ b/src/packages/Controls/Reporting/ReportingDOM.js
@@ -47,7 +47,7 @@ var ReportingDOM = {
     _createMainContainerElement : function () {
         var container = document.createElement("div");
         container.id = this._addUID("GPreporting");
-        container.className = "gpf-widget gpf-widget-button gpf-mobile-fullscreen gpf-button-no-gutter";
+        container.className = "gpf-widget gpf-widget-button gpf-mobile-fullscreen";
         return container;
     },
 


### PR DESCRIPTION
Pour le widget Reporting, l'option `gutter` ne fonctionnait pas car la classe était en dur dans le code.