### PR TITLE
La tooltip de Territories ne s'affiche pas

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -25,6 +25,7 @@ __DATE__
 
   - SearchEngine : recherche guidée parcellaire sur les DROM-COM (#491)
   - Reporting: suppression de la classe gpf-button-no-gutter par défaut
+  - Territories: suppression d'une classe qui empeche la tooltip de s'afficher
 
 * 🔒 [Security]
 

--- a/src/packages/Controls/Territories/TerritoriesDOM.js
+++ b/src/packages/Controls/Territories/TerritoriesDOM.js
@@ -90,7 +90,6 @@ var TerritoriesDOM = {
         button.id = this._addUID("GPshowTerritoriesPicto");
         button.classList.add("GPshowOpen", "GPshowAdvancedToolPicto", "GPshowTerritoriesPicto");
         button.classList.add("gpf-btn", "gpf-btn--tertiary", "gpf-btn-icon", "gpf-btn-icon-territories");
-        button.classList.add("fr-icon-france-line");
         button.classList.add("fr-btn", "fr-btn--tertiary");
         button.setAttribute("aria-label", "Sélectionner un territoire");
         button.setAttribute("tabindex", "0");


### PR DESCRIPTION
Suppression d'une classe qui empêche l'ouverture de la tooltip.
A priori, cette classe n'était pas utile (ni pour le JS, ni le CSS)