### PR TITLE
Supprime l'ajout d'une balise <body>

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -26,6 +26,7 @@ __DATE__
   - SearchEngine : recherche guidée parcellaire sur les DROM-COM (#491)
   - Reporting: suppression de la classe gpf-button-no-gutter par défaut
   - Territories: suppression d'une classe qui empeche la tooltip de s'afficher
+  - MousePosition: supprime l'ajout d'une balise <body> dans le panel
 
 * 🔒 [Security]
 

--- a/src/packages/Controls/MousePosition/MousePositionDOM.js
+++ b/src/packages/Controls/MousePosition/MousePositionDOM.js
@@ -600,6 +600,8 @@ var MousePositionDOM = {
                     </section>
            `
         );
+        // get first element
+        div = div.firstChild;
         htmlContent.map(content => div.getElementsByClassName("fr-collapse")[0].append(content));
         div.getElementsByTagName("button")[0].addEventListener("click", function (e) {
             var status = (e.target.ariaExpanded === "true");


### PR DESCRIPTION
La fonction `stringToHtml` (et donc `DOMParser`) renvoie l'élément `<body>` (`return doc.body`).
Dans tous les autres widgets, ça ne pose pas soucis car c'est utilisé soit en shadow dom (sans le `DOMParser`), soit avec `firstChild`.
Sauf pour le MousePosition, où ça crée donc un `<body>` dans le panel.

Avant/Après
<img width="290" height="276" alt="image" src="https://github.com/user-attachments/assets/890e9881-b4fc-4f8b-a954-6bceacd743ca" />
<img width="290" height="276" alt="image" src="https://github.com/user-attachments/assets/d6e0b772-c418-45ee-b901-5d16693f717c" />

