### PR TITLE
Interfacage du paramètre "serverUrl" pour les widgets MousePositon, ReverseGeocode, Route, Iso

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -22,6 +22,8 @@ __DATE__
 * 🔥 [Removed]
 
 * 🐛 [Fixed]
+
+  - Interface(widgets) : interfaçage du paramètre serverUrl pour les widgets iti/iso/reversegeocode/mouseposition
   
 * 🔒 [Security]
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
   "version": "1.0.0-beta.10-503",
-  "date": "20/04/2026",
+  "date": "22/04/2026",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.10",
-  "date": "15/04/2026",
+  "version": "1.0.0-beta.10-503",
+  "date": "20/04/2026",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/samples-src/pages/tests/SearchEngine/pages-ol-searchenginebase-modules-dsfr-geocodeAdvanced.html
+++ b/samples-src/pages/tests/SearchEngine/pages-ol-searchenginebase-modules-dsfr-geocodeAdvanced.html
@@ -90,6 +90,19 @@
                     var search = new ol.control.SearchEngineAdvanced({
                         advancedSearch : [insee, location, coordinates, parcel],
                         returnTrueGeometry : true,
+                        autocompleteOptions : {
+                            serviceOptions : {
+                                maximumResponses : 10,
+                                serverUrl : `https://data-pprd.priv.geopf.fr/geocodage/completion?`
+                            },
+                            prettifyResults : true,
+                            maximumEntries : 5
+                        },
+                        geocodeOptions : {
+                            serviceOptions : {
+                                serverUrl : `https://data-pprd.priv.geopf.fr/geocodage/search`
+                            }
+                        },
                         popupButtons : [{
                             label : "Ajouter l'objet à la couche",
                             className : "custom-button",

--- a/src/packages/Controls/ElevationPath/ElevationPath.js
+++ b/src/packages/Controls/ElevationPath/ElevationPath.js
@@ -60,7 +60,7 @@ class ElevationPath extends Control {
     * @param {Boolean} [options.active = false] - specify if control should be actived at startup. Default is false.
     * @param {Boolean} [options.ssl = true] - use of ssl or not (default true, service requested using https protocol)
     * @param {Boolean|Object} [options.export = false] - Specify if button "Export" is displayed. For the use of the options of the "Export" control, see {@link packages/Controls/Export/Export.default}
-    * @param {Object} [options.elevationOptions = {}] - elevation path service options. See {@link http://ignf.github.io/geoportal-access-lib/latest/jsdoc/module-Services.html#~getAltitude Gp.Services.getAltitude()} for available options
+    * @param {Object} [options.elevationPathOptions = {}] - elevation path service options. See {@link http://ignf.github.io/geoportal-access-lib/latest/jsdoc/module-Services.html#~getAltitude Gp.Services.getAltitude()} for available options
     * @param {Object} [options.layerDescription = {}] - Layer informations to be displayed in LayerSwitcher widget (only if a LayerSwitcher is also added to the map)
     * @param {String} [options.layerDescription.title = "Profil altimétrique"] - Layer title to be displayed in LayerSwitcher
     * @param {String} [options.layerDescription.description = "Mon profil altimétrique"] - Layer description to be displayed in LayerSwitcher
@@ -752,7 +752,7 @@ class ElevationPath extends Control {
             active : false,
             apiKey : null,
             export : false,
-            elevationOptions : {
+            elevationPathOptions : {
                 outputFormat : "json"
             },
             layerDescription : {
@@ -1133,7 +1133,7 @@ class ElevationPath extends Control {
 
             // Si il n'y a pas de surcharge utilisateur de la fonction de recuperation des
             // resultats, on realise l'affichage du panneau
-            if (typeof this.options.elevationOptions.onSuccess === "undefined" && this.options.displayProfileOptions.target === null) {
+            if (typeof this.options.elevationPathOptions.onSuccess === "undefined" && this.options.displayProfileOptions.target === null) {
                 this._panelContainer.style.display = "block";
                 // self._panelContainer.style.visibility = "visible";
             }
@@ -1300,7 +1300,7 @@ class ElevationPath extends Control {
         var options = {};
 
         // on surcharge avec les options de l'utilisateur
-        Utils.mergeParams(options, this.options.elevationOptions);
+        Utils.mergeParams(options, this.options.elevationPathOptions);
 
         // au cas où ...
         Utils.mergeParams(options, {
@@ -1325,8 +1325,8 @@ class ElevationPath extends Control {
         var self = this;
 
         // gestion des callback
-        var bOnFailure = !!(this.options.elevationOptions.onFailure !== null && typeof this.options.elevationOptions.onFailure === "function"); // cast variable to boolean
-        var bOnSuccess = !!(this.options.elevationOptions.onSuccess !== null && typeof this.options.elevationOptions.onSuccess === "function");
+        var bOnFailure = !!(this.options.elevationPathOptions.onFailure !== null && typeof this.options.elevationPathOptions.onFailure === "function"); // cast variable to boolean
+        var bOnSuccess = !!(this.options.elevationPathOptions.onSuccess !== null && typeof this.options.elevationPathOptions.onSuccess === "function");
 
         // callback _requestServiceOnSuccess
         var _requestServiceOnSuccess = function (result) {
@@ -1344,7 +1344,7 @@ class ElevationPath extends Control {
                 self._measureDraw.setActive(true);
             }
             if (bOnSuccess) {
-                self.options.elevationOptions.onSuccess.call(self, self.getData());
+                self.options.elevationPathOptions.onSuccess.call(self, self.getData());
             }
         };
 
@@ -1358,7 +1358,7 @@ class ElevationPath extends Control {
             self._waiting = false;
             self._measureDraw.setActive(true);
             if (bOnFailure) {
-                self.options.elevationOptions.onFailure.call(self, error);
+                self.options.elevationPathOptions.onFailure.call(self, error);
             }
         };
 

--- a/src/packages/Controls/Isocurve/Isocurve.js
+++ b/src/packages/Controls/Isocurve/Isocurve.js
@@ -1155,6 +1155,7 @@ class Isocurve extends Control {
         // on met en place l'affichage des resultats dans la fenetre de resultats.
         var context = this;
         var isoRequestOptions = {
+            serverUrl : options.serverUrl,
             position : position,
             graph : options.graph || this._currentTransport,
             exclusions : options.exclusions || this._currentExclusions,

--- a/src/packages/Controls/MousePosition/MousePosition.js
+++ b/src/packages/Controls/MousePosition/MousePosition.js
@@ -1152,6 +1152,9 @@ class MousePosition extends Control {
         // on recupere les options du service
         var options = this.options.altitude.serviceOptions || {};
 
+        // éventuelle surcharge de l'adresse du service d'altimétrie
+        var _serverUrl = options.serverUrl;
+
         // gestion du protocole et du timeout
         // le timeout est indispensable sur le protocole JSONP.
         var _protocol = options.protocol || "XHR";
@@ -1235,6 +1238,7 @@ class MousePosition extends Control {
 
         Gp.Services.getAltitude({
             apiKey : _apiKey,
+            serverUrl : _serverUrl,
             protocol : _protocol,
             ssl : _ssl,
             timeOut : _timeout,

--- a/src/packages/Controls/ReverseGeocode/ReverseGeocode.js
+++ b/src/packages/Controls/ReverseGeocode/ReverseGeocode.js
@@ -1072,6 +1072,7 @@ class ReverseGeocode extends Control {
         var bOnSuccess = !!(reverseGeocodeOptions.onSuccess !== null && typeof reverseGeocodeOptions.onSuccess === "function");
 
         var requestOptions = {
+            serverUrl : reverseGeocodeOptions.serverUrl,
             apiKey : reverseGeocodeOptions.apiKey || this.options.apiKey,
             ssl : this.options.ssl,
             position : this._requestPosition,

--- a/src/packages/Controls/Route/Route.js
+++ b/src/packages/Controls/Route/Route.js
@@ -1154,6 +1154,7 @@ class Route extends Control {
         // on met en place l'affichage des resultats dans la fenetre de resultats.
         var context = this;
         this._requestRouting({
+            serverUrl : routeOptions.serverUrl,
             startPoint : start,
             endPoint : end,
             viaPoints : step,


### PR DESCRIPTION
Le paramètre "serverUrl" déjà implémenté par la bibliothèque d'accès permet de surcharger l'url du service sous-jacent utilisé par le widget.


Cela permet notamment de paramétrer un widget pour taper sur un service de qualif ou de preprod que sur le service de prod (par défaut).

A noter : si l'option serverUrl est présente mais undefined, la bibliothèque d'accès va prendre l'url par défaut (prod GPF)

Cette PR est réalisée en vue de la mise en place d'une branche côté entrée carto qui ne pointerait que sur des services de preprod de la GPF : https://github.com/IGNF/cartes.gouv.fr-entree-carto/pull/1034