### PR TITLE
refacto(LayerSwitcher): titre affiché au survol de l'entrée de la couche

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.10-503",
-  "date": "22/04/2026",
+  "version": "1.0.0-beta.10-505",
+  "date": "29/04/2026",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/src/packages/Controls/LayerSwitcher/LayerSwitcherDOM.js
+++ b/src/packages/Controls/LayerSwitcher/LayerSwitcherDOM.js
@@ -610,9 +610,9 @@ var LayerSwitcherDOM = {
         var label = document.createElement("div");
         label.id = this._addUID("GPname_ID_" + obj.id);
         label.className = "GPlayerName";
-        label.title = obj.description || obj.title;
+        label.title = obj.title || obj.description;
         if (tooltips) {
-            label.dataset.tooltip = obj.description || obj.title;
+            label.dataset.tooltip = obj.title || obj.description;
             ToolTips.active(label);
             label.title = obj.name;
         }


### PR DESCRIPTION
Au survol de l'entrée des couches dans le LS, on affiche le titre en priorité devant la description
<img width="704" height="459" alt="image" src="https://github.com/user-attachments/assets/a2507d69-696b-43b9-a348-f89fe1c731bc" />

(https://github.com/IGNF/cartes.gouv.fr-entree-carto/issues/1022)