### PR TITLE
feat(contextMenu): interfacage serverUrl pour reverse et alti

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -24,6 +24,7 @@ __DATE__
 * 🐛 [Fixed]
 
   - Interface(widgets) : interfaçage du paramètre serverUrl pour les widgets iti/iso/reversegeocode/mouseposition
+  - Interface(ContextMenu): interfacçage du paramétre serverUrl pour le menuContextuel (#506)
   
 * 🔒 [Security]
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.10-503",
-  "date": "22/04/2026",
+  "version": "1.0.0-beta.10-506",
+  "date": "05/05/2026",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/src/packages/Controls/ContextMenu/ContextMenu.js
+++ b/src/packages/Controls/ContextMenu/ContextMenu.js
@@ -43,6 +43,8 @@ var logger = Logger.getLogger("contextMenu");
  * @property {string} [position] - Position CSS du widget sur la carte.
  * @property {boolean} [gutter] - Ajoute ou retire l’espace autour du panneau.
  * @property {string|number} [id] - Identifiant unique du widget.
+ * @property {string} [altiServerUrl] - URL vers le service d'altimétrie utilisé (data.geopf.fr par défaut)
+ * @property {string} [reverseGeocodeServerUrl] - URL vers le service de géocodage inverse utilisé (data.geopf.fr par défaut)
  */
 /**
  * @classdesc
@@ -515,7 +517,8 @@ class ContextMenu extends Control {
             onFailure : function (error) {},
             // spécifique au service
             positions : [{lon : clickedCoordinate[0], lat : clickedCoordinate[1]}],
-            outputFormat : "json" // json|xml
+            outputFormat : "json", // json|xml
+            serverUrl : this.options.altiServerUrl
         };
         Gp.Services.getAltitude(altiOptions);
 
@@ -530,7 +533,8 @@ class ContextMenu extends Control {
             position : {lon : clickedCoordinate[1], lat : clickedCoordinate[0]},
             searchGeometry : { type : "Circle", coordinates : [clickedCoordinate[1], clickedCoordinate[0]], radius : 100 },
             index : "CadastralParcel",
-            maximumResponses : 1
+            maximumResponses : 1,
+            serverUrl : this.options.reverseGeocodeServerUrl
         };
         Gp.Services.reverseGeocode(geocodageParcelOptions);
 
@@ -572,7 +576,8 @@ class ContextMenu extends Control {
             position : {lon : clickedCoordinate[0], lat : clickedCoordinate[1]},
             searchGeometry : { type : "Circle", coordinates : [clickedCoordinate[0], clickedCoordinate[1]], radius : 100 },
             index : "StreetAddress",
-            maximumResponses : 1
+            maximumResponses : 1,
+            serverUrl : this.options.reverseGeocodeServerUrl
         };
         Gp.Services.reverseGeocode(geocodageAdressOptions);
     }


### PR DESCRIPTION
Interfacage de paramètres altiServerUrl et reverseGeocodeServrUrl pour que le menu contextuel puisse appeler des services différents lorsqu'on clique sur 'adresse/coordonnées du lieu'

Pour tester, dans l'exemple context-menu, changer le paramétrage du widget :
```
            var contextMenu = new ol.control.ContextMenu({
                contextMenuItemsOptions : itemsOpt,
                reverseGeocodeServerUrl : "https://data-pprd.priv.geopf.fr/geocodage/reverse", 
                altiServerUrl : "https://data-pprd.priv.geopf.fr/altimetrie/1.0/calcul/alti/rest/elevation.json?"
            });
            map.addControl(contextMenu);
```
En console, les appels vers les services se font bien avec l'url de pprd
