### PR TITLE
fix(Search): affine le filtre "prettifyResults" pour ne pas exclure codes postaux

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -26,6 +26,7 @@ __DATE__
   - Interface(widgets) : interfaçage du paramètre serverUrl pour les widgets iti/iso/reversegeocode/mouseposition/search (#503)
   - Interface(AdvancedSearch) : interfaçage du paramètre serverUrl pour le widget de recherche avancée (#504)
   - Interface(ContextMenu): interfacçage du paramétre serverUrl pour le menuContextuel (#506)
+  - Search: filtrage plus fin des résultats liés aux codes postaux en cas d'option "pretiffyResults" (#507) 
   
 * 🔒 [Security]
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.10-504",
-  "date": "05/05/2026",
+  "version": "1.0.0-beta.10-507",
+  "date": "06/05/2026",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/src/packages/Controls/SearchEngine/ParcelAdvancedSearch.js
+++ b/src/packages/Controls/SearchEngine/ParcelAdvancedSearch.js
@@ -774,7 +774,7 @@ class ParcelAdvancedSearch extends AbstractAdvancedSearch {
         prefixInput.title = "Choisir le préfixe de la parcelle";
         prefixInput.id = Helper.getUid("ParcelAdvancedSearch-prefix-");
         prefixInput.setAttribute("disabled", "disabled");
-        this._getLabelContainer("Préfix", "fr-select-group", prefixInput, "");
+        this._getLabelContainer("Préfixe", "fr-select-group", prefixInput, "");
 
         // Section
         const sectionInput = this.sectionInput = document.createElement("select");

--- a/src/packages/Controls/SearchEngine/SearchEngine.js
+++ b/src/packages/Controls/SearchEngine/SearchEngine.js
@@ -2718,9 +2718,9 @@ class SearchEngine extends Control {
     _prettifyAutocompleteResults (autocompleteResults) {
         for (var i = autocompleteResults.length - 1; i >= 0; i--) {
             var autocompleteResult = autocompleteResults[i];
-            if ((autocompleteResult.type === "StreetAddress" && autocompleteResult.kind === "municipality") ||
+            if ((autocompleteResult.type === "StreetAddress" && autocompleteResult.kind === "municipality" && ["Lyon", "Marseille", "Paris"].includes(autocompleteResult.commune)) ||
             autocompleteResult.type === "PositionOfInterest" && autocompleteResult.poiType[0] === "lieu-dit habité" && autocompleteResult.poiType[1] === "zone d'habitation") {
-                // on retire les éléments streetAdress - municipality car déjà pris en compte par POI
+                // on retire les éléments streetAdress - municipality pour Lyon Marseille et Paris car ca sort le 1er arrondissement, et que la commune est déjà prise en compte par POI
                 autocompleteResults.splice(i, 1);
             }
             // on précise le type dans le fulltext au POI des types département et région

--- a/src/packages/Services/IGNSearchService.js
+++ b/src/packages/Services/IGNSearchService.js
@@ -332,7 +332,7 @@ class IGNSearchService extends AbstractSearchService {
     _prettifyAutocompleteResults (autocompleteResults) {
         for (let i = autocompleteResults.length - 1; i >= 0; i--) {
             const autocompleteResult = autocompleteResults[i];
-            if ((autocompleteResult.type === "StreetAddress" && autocompleteResult.kind === "municipality") ||
+            if ((autocompleteResult.type === "StreetAddress" && autocompleteResult.kind === "municipality" && ["Lyon", "Marseille", "Paris"].includes(autocompleteResult.commune)) ||
             autocompleteResult.type === "PositionOfInterest" && autocompleteResult.poiType[0] === "lieu-dit habité" && autocompleteResult.poiType[1] === "zone d'habitation") {
                 // on retire les éléments streetAdress - municipality car déjà pris en compte par POI
                 autocompleteResults.splice(i, 1);


### PR DESCRIPTION
L'option "prettifyResults" de la barre de recherche excluait tous les résultats de type "streeAdress" et de kind "municipality", pour ne pas récuperer le 1er arrondissement de Paris/Marseille/Lyon en tapant "Paris"/"Marseille"/"Lyon" :

>  if ((autocompleteResult.type === "StreetAddress" && autocompleteResult.kind === "municipality")

Filtre trop violent, car excluait au final tous les résultats liés à des codes postaux. Si on affine en testant en plus la string "commune" pour tester les 3 villes françaises à arrondissements, on exclue bien ce qu'on veut et on conserve les résultats liés au codes postaux.

>             if ((autocompleteResult.type === "StreetAddress" && autocompleteResult.kind === "municipality" && ["Lyon", "Marseille", "Paris"].includes(autocompleteResult.commune))

<img width="429" height="498" alt="image" src="https://github.com/user-attachments/assets/a7c8c548-ec3f-47f8-92db-20a0b4415a1d" />
<img width="451" height="482" alt="image" src="https://github.com/user-attachments/assets/0a545122-dd77-47a8-af10-b7387549af43" />
<img width="462" height="468" alt="image" src="https://github.com/user-attachments/assets/f042b362-f787-4a79-91f8-3a3acfe9fd78" />
