### PR TITLE
fix(Search): interfacage via une option de l'url du getCapabilities du geocodage

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -24,7 +24,7 @@ __DATE__
 * 🐛 [Fixed]
 
   - Interface(widgets) : interfaçage du paramètre serverUrl pour les widgets iti/iso/reversegeocode/mouseposition/search (#503)
-  - Interface(AdvancedSearch) : interfaçage du paramètre serverUrl pour le widget de recherche avancée (#504)
+  - Interface(AdvancedSearch) : interfaçage du paramètre serverUrl et geocodeGetCapabilitiesUrl pour le widget de recherche avancée (#504, #508)
   - Interface(ContextMenu): interfacçage du paramétre serverUrl pour le menuContextuel (#506)
   
 * 🔒 [Security]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.10-504",
+  "version": "1.0.0-beta.10-508",
   "date": "05/05/2026",
   "module": "src/index.js",
   "directories": {},

--- a/src/packages/Controls/SearchEngine/LocationAdvancedSearch.js
+++ b/src/packages/Controls/SearchEngine/LocationAdvancedSearch.js
@@ -142,9 +142,9 @@ class LocationAdvancedSearch extends AbstractAdvancedSearch {
          * @private
          */
         this.CLASSNAME = "LocationAdvancedSearch";
-
+        const getCapabilitiesUrl = options.searchOptions?.geocodeGetCapabilitiesUrl || "https://data.geopf.fr/geocodage/getCapabilities";
         // Get type list from capabilities if not provided
-        fetch("https://data.geopf.fr/geocodage/getCapabilities").then(response => {
+        fetch(getCapabilitiesUrl).then(response => {
             return response.json();
         }).then (json => {
             // Get list from capabilities

--- a/src/packages/Controls/SearchEngine/LocationAdvancedSearch.js
+++ b/src/packages/Controls/SearchEngine/LocationAdvancedSearch.js
@@ -158,7 +158,7 @@ class LocationAdvancedSearch extends AbstractAdvancedSearch {
                 this.setCategories(values);
             }
         }).catch(() => {
-            console.log("error");
+            console.log("Geocode getCapabilites parsing error (see https://data.geopf.fr/geocodage/getCapabilities) ");
         });
         this._typeList = {};
         // Default values

--- a/src/packages/Controls/SearchEngine/LocationAdvancedSearch.js
+++ b/src/packages/Controls/SearchEngine/LocationAdvancedSearch.js
@@ -16,6 +16,9 @@ class LocationAdvancedSearch extends AbstractAdvancedSearch {
      * @constructor
      * @param {AbstractAdvancedSearchOptions} options Options du constructeur
      * @param {String} [options.name="Lieux et toponymes"] Nom du contrôle
+     * @param {Object} [options.searchOptions] Options pour le service de geocodage sous-jacent
+     * @param {String} [options.searchOptions.serverUrl] Route vers le serveur de geocodage
+     * @param {String} [options.searchOptions.geocodeGetCapabilitiesUrl] Route vers le getCapabilities du serveur de geocodage
      * @param {Array<String>|Object} [options.typeList] Liste des types de lieux (catégories) ou objet clé/valeur avec tableau de sous-catégories
      * @extends {ol.control.AbstractAdvancedSearch}
      */


### PR DESCRIPTION
Le composant LocationAdvancedSearch fait un appel au getcapabilities du service de geocodage.

Cet appel est en dur, et par défaut vers https://data.geopf.fr/geocodage/getCapabilities

L'objectif de cette PR est de pouvoir paramétrer si besoin la route du getCapabilities en passant l'option "geocodeGetCapabilitiesUrl" au widget : 

```javascript
                     var location = new ol.control.LocationAdvancedSearch({
                        searchOptions : {
                            serverUrl : `https://serverUrl/geocodage/search?`,
                            geocodeGetCapabilitiesUrl : "https://serverGetCapURL/geocodage/getCapabilities"
                        }    
                     })
```
 
