### PR TITLE
Ajout séparateur à la suite du place holder de la barre de recherche

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -17,6 +17,8 @@ __DATE__
 
 * 🔨 [Changed]
 
+  - UI(Search): ajout d'un séparateur entre la recherche simple et la recherche avancée (#509)
+
 * 🔥 [Deprecated]
 
 * 🔥 [Removed]

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.10-508",
-  "date": "05/05/2026",
+  "version": "1.0.0-beta.10-509",
+  "date": "13/05/2026",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/samples-src/pages/tests/SearchEngine/pages-ol-searchenginebase-modules-dsfr-geocodeAdvanced.html
+++ b/samples-src/pages/tests/SearchEngine/pages-ol-searchenginebase-modules-dsfr-geocodeAdvanced.html
@@ -97,6 +97,7 @@
                             prettifyResults : true,
                             maximumEntries : 5
                         },
+                        placeholder: "Rechercher",
                         popupButtons : [{
                             label : "Ajouter l'objet à la couche",
                             className : "custom-button",

--- a/src/packages/CSS/Controls/SearchEngine/DSFRsearchEngineStyle.css
+++ b/src/packages/CSS/Controls/SearchEngine/DSFRsearchEngineStyle.css
@@ -417,6 +417,22 @@ form.GPSearchBar > .GPInputGroup > input[data-erase] ~ .GPOptionsContainer > but
   display:block;
 }
 
+form.GPSearchBar > .GPInputGroup > input ~ .GPOptionsContainer::before {
+  content:"";
+  width:1px;
+  height:2rem;
+  margin:8px 0;
+  background-color: var(--border-default-grey);
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+}
+
+form.GPSearchBar > .GPInputGroup > input[data-erase] ~ .GPOptionsContainer::before {
+  display: none;
+}
+
+
 form.GPSearchBar > .GPInputGroup > input[data-erase] ~ .GPOptionsContainer > button[id^="GPSearchEngine-advanced-btn"] {
   display:none;
 }

--- a/src/packages/CSS/Controls/SearchEngine/GPFsearchEngine.css
+++ b/src/packages/CSS/Controls/SearchEngine/GPFsearchEngine.css
@@ -213,6 +213,7 @@ form[id^=GPadvancedSearchForm]:has(option[value="Coordinates"]:checked) > input[
     display: flex;
     flex-direction: row;
     padding: 0;
+    border-radius: 0.25rem 0 0 0;
 }
 
 [id^="GPsearchEngine"] form[id^=GPsearchInput-Base-] .GPOptionsContainer {


### PR DESCRIPTION
Pour résolution de https://github.com/IGNF/cartes.gouv.fr-entree-carto/issues/1010 (ajout séparateur barre de recherche)

Cherry picks des commits de la branche refonte drawing : 
- https://github.com/IGNF/geopf-extensions-openlayers/pull/490/changes/0367c2870ae0d04f624d2b4a24b01f6601477e95
- https://github.com/IGNF/geopf-extensions-openlayers/pull/490/changes/ff140d548965f67a4e11e93aa78adf96afa976d9