### PR TITLE
fix(contextMenu): interfacage resource alti contextmenu

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -29,7 +29,7 @@ Homogénéisation du paramètre serverUrl pour brancher un service différent au
 
   - Interface(widgets) : interfaçage du paramètre serverUrl pour les widgets iti/iso/reversegeocode/mouseposition/search (#503)
   - Interface(AdvancedSearch) : interfaçage du paramètre serverUrl et geocodeGetCapabilitiesUrl pour le widget de recherche avancée (#504, #508)
-  - Interface(ContextMenu): interfaçage du paramétre serverUrl pour le menuContextuel (#506)
+  - Interface(ContextMenu): interfaçage du paramétre serverUrl et resource pour l'alti du menuContextuel (#506)
   - Search: filtrage plus fin des résultats liés aux codes postaux en cas d'option "pretiffyResults" (#507) 
   
 * 🔒 [Security]

--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -29,7 +29,7 @@ Homogénéisation du paramètre serverUrl pour brancher un service différent au
 
   - Interface(widgets) : interfaçage du paramètre serverUrl pour les widgets iti/iso/reversegeocode/mouseposition/search (#503)
   - Interface(AdvancedSearch) : interfaçage du paramètre serverUrl et geocodeGetCapabilitiesUrl pour le widget de recherche avancée (#504, #508)
-  - Interface(ContextMenu): interfaçage du paramétre serverUrl et resource pour l'alti du menuContextuel (#506)
+  - Interface(ContextMenu): interfaçage du paramétre serverUrl et resource pour l'alti du menuContextuel (#506, #510)
   - Search: filtrage plus fin des résultats liés aux codes postaux en cas d'option "pretiffyResults" (#507) 
   
 * 🔒 [Security]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.11-510",
   "date": "19/05/2026",
   "module": "src/index.js",
   "directories": {},

--- a/src/packages/Controls/ContextMenu/ContextMenu.js
+++ b/src/packages/Controls/ContextMenu/ContextMenu.js
@@ -518,7 +518,8 @@ class ContextMenu extends Control {
             // spécifique au service
             positions : [{lon : clickedCoordinate[0], lat : clickedCoordinate[1]}],
             outputFormat : "json", // json|xml
-            serverUrl : this.options.altiServerUrl
+            serverUrl : this.options.altiServerUrl,
+            resource : this.options.altiResource
         };
         Gp.Services.getAltitude(altiOptions);
 


### PR DESCRIPTION
Possibilité de changer le nom de la ressource alti attaquée par le widget ContextMenu via son entrée adresse/coordonnées du lieu : 

option à passer : "altiResource"

```
            var contextMenu = new ol.control.ContextMenu({
                contextMenuItemsOptions : itemsOpt,
                altiResource : "popo"
            });
            map.addControl(contextMenu);
```