### PR TITLE
fix: Ne surcharge plus le style global DSFR fr-tabs

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -30,7 +30,8 @@ Homogénéisation du paramètre serverUrl pour brancher un service différent au
   - Interface(widgets) : interfaçage du paramètre serverUrl pour les widgets iti/iso/reversegeocode/mouseposition/search (#503)
   - Interface(AdvancedSearch) : interfaçage du paramètre serverUrl et geocodeGetCapabilitiesUrl pour le widget de recherche avancée (#504, #508)
   - Interface(ContextMenu): interfaçage du paramétre serverUrl et resource pour l'alti du menuContextuel (#506, #510)
-  - Search: filtrage plus fin des résultats liés aux codes postaux en cas d'option "pretiffyResults" (#507) 
+  - Search: filtrage plus fin des résultats liés aux codes postaux en cas d'option "pretiffyResults" (#507)
+  - DSFR: ne surcharge plus le style fr-tabs global (#512)
   
 * 🔒 [Security]
 

--- a/src/packages/CSS/Controls/Catalog/DSFRcatalogStyle.css
+++ b/src/packages/CSS/Controls/Catalog/DSFRcatalogStyle.css
@@ -124,23 +124,23 @@
   display: block;
 }
 
-.fr-tabs {
+.catalog-container-tabs .fr-tabs {
   box-shadow : unset;
 }
 
-.fr-tabs::before {
+.catalog-container-tabs .fr-tabs::before {
   box-shadow : unset;
 }
 
-.fr-tabs__tab[aria-selected=true] {
+.catalog-container-tabs .fr-tabs__tab[aria-selected=true] {
     background-size: 100% 0px, 0px calc(100% - 1px), 0px calc(100% - 1px), 100% 3px;
 }
 
-.fr-tabs__tab[aria-selected=true]:not(:disabled) {
+.catalog-container-tabs .fr-tabs__tab[aria-selected=true]:not(:disabled) {
     background-image: linear-gradient(0deg, var(--border-active-blue-france), var(--border-active-blue-france)), linear-gradient(0deg, var(--border-default-grey), var(--border-default-grey)), linear-gradient(0deg, var(--border-default-grey), var(--border-default-grey)), linear-gradient(0deg, var(--border-active-blue-france), var(--border-active-blue-france));
 }
 
-.fr-tabs__tab:not([aria-selected=true]) {
+.catalog-container-tabs .fr-tabs__tab:not([aria-selected=true]) {
     background-color: unset;
     --hover: unset;
     --active: unset;


### PR DESCRIPTION
Fixe l'issue #512 
Solution retenue pour l'instant: surcharge encore `.fr-tabs`, mais uniquement pour les enfants de `.catalog-container-tabs`