### PR TITLE
fix(layerswitcher): label editer au lieu de style pour les couches non TMS

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -9,8 +9,6 @@ __DATE__
 
 ### 🎉 Summary
 
-Homogénéisation du paramètre serverUrl pour brancher un service différent aux widgets.
-
 ### 💥 Breaking changes
 
 ### 📖 Changelog
@@ -28,7 +26,7 @@ Homogénéisation du paramètre serverUrl pour brancher un service différent au
 * 🐛 [Fixed]
 
   - DSFR: ne surcharge plus le style fr-tabs global (#512)
-  - LayerSwitcher : le label "éditer" s'affiche au lieu de "style" pour les couches non TMS
+  - LayerSwitcher : le label "éditer" s'affiche au lieu de "style" pour les couches non TMS (#516)
   
 * 🔒 [Security]
 

--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -19,7 +19,7 @@ Homogénéisation du paramètre serverUrl pour brancher un service différent au
 
 * 🔨 [Changed]
 
-  - UI(Search): ajout d'un séparateur entre la recherche simple et la recherche avancée (#509)
+  - LayerSwitcher : le tooltip au survol de l'entrée de la couche affiche son titre (#505)
 
 * 🔥 [Deprecated]
 
@@ -27,11 +27,8 @@ Homogénéisation du paramètre serverUrl pour brancher un service différent au
 
 * 🐛 [Fixed]
 
-  - Interface(widgets) : interfaçage du paramètre serverUrl pour les widgets iti/iso/reversegeocode/mouseposition/search (#503)
-  - Interface(AdvancedSearch) : interfaçage du paramètre serverUrl et geocodeGetCapabilitiesUrl pour le widget de recherche avancée (#504, #508)
-  - Interface(ContextMenu): interfaçage du paramétre serverUrl et resource pour l'alti du menuContextuel (#506, #510)
-  - Search: filtrage plus fin des résultats liés aux codes postaux en cas d'option "pretiffyResults" (#507)
   - DSFR: ne surcharge plus le style fr-tabs global (#512)
+  - LayerSwitcher : le label "éditer" s'affiche au lieu de "style" pour les couches non TMS
   
 * 🔒 [Security]
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.11-505",
-  "date": "22/05/2026",
-  "module": "src/index.js",
+  "version": "1.0.0-beta.12-516",
+  "date": "27/05/2026",
+  "module":"src/index.js",
   "directories": {},
   "engines": {
     "node": ">=20"

--- a/src/packages/Controls/LayerSwitcher/LayerSwitcherDOM.js
+++ b/src/packages/Controls/LayerSwitcher/LayerSwitcherDOM.js
@@ -1049,7 +1049,11 @@ var LayerSwitcherDOM = {
         let label;
         if (checkDsfr()) {
             icon = "fr-icon-pencil-line";
-            label = "Style";
+            if (tms) {
+                label = "Style";
+            } else {
+                label = "Éditer";
+            }
         }
         let className = `GPlayerEdit gpf-btn gpf-btn--tertiary fr-btn fr-btn--tertiary-no-outline`;
 


### PR DESCRIPTION
Fix du https://github.com/IGNF/cartes.gouv.fr-entree-carto/issues/1065


**Actuellement** : le label "style" est toujours affiché par défaut, qu'importe le type de couche
<img width="711" height="402" alt="image" src="https://github.com/user-attachments/assets/f6fd4ad7-d901-41f1-932f-c9e2da793051" />

Or, si pour les couches TMS, ce label est pertinent 

<img width="625" height="691" alt="image" src="https://github.com/user-attachments/assets/0caeba77-17f8-49d4-a4b3-7de40b5da73e" />

Ca l'est beaucoup moins mour les couches de calcul ou de dessin qui ouvre le widget associé à la couche pour éditer le tracé : 
<img width="625" height="691" alt="image" src="https://github.com/user-attachments/assets/612a118c-44e9-4540-bc02-fe885c2fa5de" />



**Désormais**, le label "style" ne s'affiche que pour les couches TMS. Sinon, on affiche le label "éditer"

TMS : 
<img width="677" height="505" alt="image" src="https://github.com/user-attachments/assets/a800f936-f2e7-452a-b1b9-bf1b920d2614" />

Calcul / Croquis :
<img width="1161" height="673" alt="image" src="https://github.com/user-attachments/assets/9f4c58dc-e685-4e67-958e-d1c0dd46c8fa" />
