### PR TITLE
feat(Panoramax): afficher l'orientation dans la minimap du PhotoViewer

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -16,6 +16,7 @@ __DATE__
 * ✨ [Added]
 
   - Panoramax : 🎉 nouveau widget !
+  - Panoramax : Ajout de l'orientation du deplacement dans la minimap du PhotoViewer (#532)
 
 * 🔨 [Changed]
 

--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -16,7 +16,7 @@ __DATE__
 * ✨ [Added]
 
   - Panoramax : 🎉 nouveau widget !
-  - Panoramax : Ajout de l'orientation du deplacement dans la minimap du PhotoViewer (#532)
+  - Panoramax : Ajout de l'orientation du déplacement dans la minimap du PhotoViewer (#532)
 
 * 🔨 [Changed]
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.12-492",
-  "date": "02/06/2026",
+  "version": "1.0.0-beta.12-532",
+  "date": "03/06/2026",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/src/packages/Controls/Panoramax/Panoramax.js
+++ b/src/packages/Controls/Panoramax/Panoramax.js
@@ -751,7 +751,7 @@ class Panoramax extends Control {
          * @private
          */
         this.photoViewerPictureLoadedListener = null;
-        this.photoViewerPictureRotatedListener =null;
+        this.photoViewerPictureRotatedListener = null;
 
         /**
          * instance PSV liée au listener de synchro photo -> minimap

--- a/src/packages/Controls/Panoramax/Panoramax.js
+++ b/src/packages/Controls/Panoramax/Panoramax.js
@@ -751,6 +751,7 @@ class Panoramax extends Control {
          * @private
          */
         this.photoViewerPictureLoadedListener = null;
+        this.photoViewerPictureRotatedListener =null;
 
         /**
          * instance PSV liée au listener de synchro photo -> minimap
@@ -1195,6 +1196,7 @@ class Panoramax extends Control {
             // Nullifier les références et listeners
             this.photoViewerPanoramax = null;
             this.photoViewerPictureLoadedListener = null;
+            this.photoViewerPictureRotatedListener = null;
             this.photoViewerPictureLoadedTarget = null;
         }
     }
@@ -1686,12 +1688,16 @@ class Panoramax extends Control {
         if (this.photoViewerPictureLoadedTarget
             && this.photoViewerPictureLoadedTarget !== psv
             && this.photoViewerPictureLoadedListener
+            && this.photoViewerPictureRotatedListener
             && typeof this.photoViewerPictureLoadedTarget.removeEventListener === "function") {
+            this.photoViewerPictureLoadedTarget.removeEventListener("view-rotated", this.photoViewerPictureRotatedListener);   
             this.photoViewerPictureLoadedTarget.removeEventListener("picture-loaded", this.photoViewerPictureLoadedListener);
             this.photoViewerPictureLoadedTarget = null;
         }
 
-        if (this.photoViewerPictureLoadedTarget === psv && this.photoViewerPictureLoadedListener) {
+        if (this.photoViewerPictureLoadedTarget === psv && 
+            this.photoViewerPictureLoadedListener && 
+            this.photoViewerPictureRotatedListener) {
             return;
         }
 
@@ -1718,6 +1724,31 @@ class Panoramax extends Control {
         }
 
         psv.addEventListener("picture-loaded", this.photoViewerPictureLoadedListener);
+
+        if (!this.photoViewerPictureRotatedListener) {
+            this.photoViewerPictureRotatedListener = () => {
+                if (!this.photoViewerMiniMap) {
+                    return;
+                }
+
+                var currentPsv = this.photoViewerPanoramax && this.photoViewerPanoramax.psv
+                    ? this.photoViewerPanoramax.psv
+                    : null;
+                if (!currentPsv) {
+                    return;
+                }
+                let heading = currentPsv.getPosition().yaw * (180 / Math.PI);
+		        heading += currentPsv.getPictureOriginalHeading();
+		        if (typeof this.photoViewerMiniMap.setPhotoHeading === "function") {
+                    this.photoViewerMiniMap.setPhotoHeading(heading);
+                } else {
+                    this.photoViewerMiniMap.pictureHeading = heading;
+                }
+            };
+        }
+
+        psv.addEventListener("view-rotated", this.photoViewerPictureRotatedListener);
+
         this.photoViewerPictureLoadedTarget = psv;
     }
 

--- a/src/packages/Controls/Panoramax/Panoramax.js
+++ b/src/packages/Controls/Panoramax/Panoramax.js
@@ -1689,7 +1689,7 @@ class Panoramax extends Control {
             && this.photoViewerPictureLoadedTarget !== psv
             && this.photoViewerPictureLoadedListener
             && this.photoViewerPictureRotatedListener
-            && typeof this.photoViewerPictureLoadedTarget.removeEventListener === "function") {
+        ) {
             this.photoViewerPictureLoadedTarget.removeEventListener("view-rotated", this.photoViewerPictureRotatedListener);   
             this.photoViewerPictureLoadedTarget.removeEventListener("picture-loaded", this.photoViewerPictureLoadedListener);
             this.photoViewerPictureLoadedTarget = null;

--- a/src/packages/Controls/Panoramax/PnxMiniMapWidget.js
+++ b/src/packages/Controls/Panoramax/PnxMiniMapWidget.js
@@ -223,7 +223,7 @@ class MiniMap extends LitElement {
     }
 
     _syncToPictureCoordinates () {
-        if (!this._pictureCoordinates || !this._pictureHeading || !this._overviewControl) {
+        if (!this._pictureCoordinates || !this._overviewControl) {
             return;
         }
 

--- a/src/packages/Controls/Panoramax/PnxMiniMapWidget.js
+++ b/src/packages/Controls/Panoramax/PnxMiniMapWidget.js
@@ -34,6 +34,7 @@ class MiniMap extends LitElement {
         this._map = map || null;
         this._options = options && typeof options === "object" ? options : {};
         this._pictureCoordinates = null;
+        this._pictureHeading = null;
         this._overviewControl = null;
 
         this._isSyncingView = false;
@@ -119,6 +120,15 @@ class MiniMap extends LitElement {
         this._renderOverviewMap();
     }
 
+    get pictureHeading () {
+        return this._pictureHeading;
+    }
+
+    set pictureHeading (heading) {
+        this._pictureHeading =  heading;
+        this._syncToPictureCoordinates();
+    }
+
     get pictureCoordinates () {
         return this._pictureCoordinates;
     }
@@ -150,6 +160,14 @@ class MiniMap extends LitElement {
         this.pictureCoordinates = coordinates;
     }
 
+    /**
+     * Met à jour la direction de la photo pour orienter le marker
+     * @param {Number} heading - orientation en degres
+     */
+    setPhotoHeading (heading) {
+        this.pictureHeading = heading;
+    }
+
     // ################################################################### //
     // ######################## marker overlay ########################### //
     // ################################################################### //
@@ -173,6 +191,7 @@ class MiniMap extends LitElement {
         markerElement.className = "pnx-mini-map__center-marker";
         markerElement.setAttribute("aria-hidden", "true");
 
+        // TODO heading par defaut
         this._centerMarkerOverlay = new Overlay({
             element : markerElement,
             positioning : "center-center",
@@ -189,6 +208,7 @@ class MiniMap extends LitElement {
 
         var overviewMap = this._overviewControl.getOverviewMap && this._overviewControl.getOverviewMap();
         var miniView = overviewMap && overviewMap.getView && overviewMap.getView();
+        var heading = this._pictureHeading;
 
         if (miniView) {
             this._isSyncingView = true;
@@ -198,11 +218,12 @@ class MiniMap extends LitElement {
 
         if (this._centerMarkerOverlay) {
             this._centerMarkerOverlay.setPosition(position);
+            this._centerMarkerOverlay.getElement().style.transform = `rotate(${heading || 0}deg)`;
         }
     }
 
     _syncToPictureCoordinates () {
-        if (!this._pictureCoordinates || !this._overviewControl) {
+        if (!this._pictureCoordinates || !this._pictureHeading || !this._overviewControl) {
             return;
         }
 
@@ -443,10 +464,9 @@ class MiniMap extends LitElement {
                 .pnx-mini-map__center-marker {
                     width: 14px;
                     height: 14px;
-                    border: 2px solid #fff;
-                    border-radius: 50%;
                     background-color: var(--background-action-high-blue-france);
-                    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.2);
+                    clip-path: polygon(50% 0%, 5% 100%, 95% 100%);
+                    filter: drop-shadow(0 0 0 2px #fff) drop-shadow(0 0 1px rgba(0,0,0,0.2));
                     pointer-events: none;
                     z-index: 2;
                 }


### PR DESCRIPTION
cf. issue #531 

Pour recetter :

- ouvrir l'exemple Panoramax : `samples-src/pages/tests/Panoramax/pages-ol-panoramax-modules-dsfr-v4.4.0.html`
- cliquer sur un point de la couche Panoramax pour ouvrir le PhotoViewer
- se déplacer dans la photo (rotation, avancer)

@iamvdo Mettre en place un marker conforme à la maquette