### PR TITLE
feat(Panoramax/LayerSwitcher): ajout de la gestion de l'affichage des couches dans le gestionnaire de couches

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -22,6 +22,7 @@ __DATE__
 
   - AdvancedSearch : conversion des coordonnées renseignés dans les inputs en changeant de système ou d'unité via les dropdowns (#518) 
   - LayerSwitcher : le tooltip au survol de l'entrée de la couche affiche son titre (#505)
+  - Panoramax : la couche Panoramax n'est pas affiché par défaut dans le gestionnaire de couches (#533)
 
 * 🔥 [Deprecated]
 

--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -16,6 +16,7 @@ __DATE__
 * ✨ [Added]
 
   - Panoramax : 🎉 nouveau widget !
+  - LayerSwitcher : Possibilité de rendre une couche affichable ou non dans le gestionnaire (#533)
 
 * 🔨 [Changed]
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.12-492",
-  "date": "02/06/2026",
+  "version": "1.0.0-beta.12-533",
+  "date": "03/06/2026",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/samples-src/pages/tests/LayerSwitcher/pages-ol-layerswitcher-modules-addlayers.html
+++ b/samples-src/pages/tests/LayerSwitcher/pages-ol-layerswitcher-modules-addlayers.html
@@ -37,10 +37,13 @@
                     <button type="button" id="addMapsLayer">Ajouter une couche Map</button>
                     <button type="button" id="addOSMLayer">Ajouter une couche OSM</button>
                     <br>
+                    <button type="button" id="modifyTitleOSMLayer">Modifier le titre de la couche OSM</button>
                     <button type="button" id="modifyVisibilityOSMLayer">Visibilité sur la couche OSM</button>
                     <button type="button" id="modifyOpacityOSMLayer">Opacité sur la couche OSM</button>
                     <button type="button" id="modifyIndexOSMLayerMin">Position (-) de la couche OSM</button>
                     <button type="button" id="modifyIndexOSMLayerMax">Position (+) de la couche OSM</button>
+                    <button type="button" id="hiddenOSMLayer">Masquer la couche OSM</button>
+                    <button type="button" id="showOSMLayer">Afficher la couche OSM</button>
                 </div>
             </div>
 
@@ -187,12 +190,24 @@
                     var cidx = osm.getZIndex();
                     osm.setZIndex(++cidx);
                 };
+                hiddenOSMLayer = function () {
+                    osm.set("display", false);
+                };
+                showOSMLayer = function () {
+                    osm.set("display", true);
+                };
+                modifyTitleOSMLayer = function () {
+                    osm.set("title", "OpenStreetMap");
+                };
+                document.getElementById("modifyTitleOSMLayer").onclick = modifyTitleOSMLayer;
                 document.getElementById("addMapsLayer").onclick = addMapsLayer;
                 document.getElementById("addOSMLayer").onclick = addOSMLayer;
                 document.getElementById("modifyVisibilityOSMLayer").onclick = modifyVisibilityOSMLayer;
                 document.getElementById("modifyOpacityOSMLayer").onclick = modifyOpacityOSMLayer;
                 document.getElementById("modifyIndexOSMLayerMin").onclick = modifyIndexOSMLayerMin;
                 document.getElementById("modifyIndexOSMLayerMax").onclick = modifyIndexOSMLayerMax;
+                document.getElementById("hiddenOSMLayer").onclick = hiddenOSMLayer;
+                document.getElementById("showOSMLayer").onclick = showOSMLayer;
            </script>
 {{/content}}
 

--- a/samples-src/pages/tests/LayerSwitcher/pages-ol-layerswitcher-modules-dsfr-addlayers.html
+++ b/samples-src/pages/tests/LayerSwitcher/pages-ol-layerswitcher-modules-dsfr-addlayers.html
@@ -36,6 +36,8 @@
                 <button type="button" class="fr-btn" id="modifyOpacityOSMLayer">Opacité sur la couche OSM</button>
                 <button type="button" class="fr-btn" id="modifyIndexOSMLayerMin">Position (-) de la couche OSM</button>
                 <button type="button" class="fr-btn" id="modifyIndexOSMLayerMax">Position (+) de la couche OSM</button>
+                <button type="button" class="fr-btn" id="hiddenOSMLayer">Masquer la couche OSM</button>
+                <button type="button" class="fr-btn" id="showOSMLayer">Afficher la couche OSM</button>
             </div>
 {{/content}}
 
@@ -206,6 +208,12 @@
                 modifyDescriptionOSMLayer = function () {
                     osm.set('description', "Couche Osm");
                 }
+                hiddenOSMLayer = function () {
+                    osm.set("display", false);
+                };
+                showOSMLayer = function () {
+                    osm.set("display", true);
+                };
                 document.getElementById("addMapsLayer").onclick = addMapsLayer;
                 document.getElementById("addOSMLayer").onclick = addOSMLayer;
                 document.getElementById("addVTLayer").onclick = addVTLayer;
@@ -215,6 +223,8 @@
                 document.getElementById("modifyOpacityOSMLayer").onclick = modifyOpacityOSMLayer;
                 document.getElementById("modifyIndexOSMLayerMin").onclick = modifyIndexOSMLayerMin;
                 document.getElementById("modifyIndexOSMLayerMax").onclick = modifyIndexOSMLayerMax;
+                document.getElementById("hiddenOSMLayer").onclick = hiddenOSMLayer;
+                document.getElementById("showOSMLayer").onclick = showOSMLayer;
            </script>
 {{/content}}
 

--- a/src/packages/Controls/LayerSwitcher/LayerSwitcher.js
+++ b/src/packages/Controls/LayerSwitcher/LayerSwitcher.js
@@ -108,6 +108,14 @@ var logger = Logger.getLogger("layerswitcher");
  * @property {Array<Object>} [config.legends] - Légendes associées à la couche.
  * @property {Array<Object>} [config.metadata] - Métadonnées associées à la couche.
  * @property {boolean} [config.locked] - Indique si la couche est verrouillée.
+ * @property {boolean} [config.display] - Indique si la couche est affichée dans le gestionnaire de couche. Par défaut, une couche est affichée sauf si `layer.get("display") === false`.
+ *
+ * Les propriétés OpenLayers suivantes sont réactives par défaut dans le LayerSwitcher.
+ * Lorsqu'elles sont modifiées via `layer.set(...)`, le gestionnaire met à jour son interface automatiquement.
+ * @property {string} [layer.title] - Libellé affiché dans le gestionnaire.
+ * @property {string} [layer.description] - Description utilisée dans les info-bulles et le panneau d'information.
+ * @property {string} [layer.producer] - Producteur affiché sous le titre de la couche.
+ * @property {boolean} [layer.display=true] - Visibilité de l'entrée dans le gestionnaire uniquement, sans impact sur le rendu cartographique.
  */
 
 /**
@@ -385,15 +393,35 @@ class LayerSwitcher extends Control {
     }
 
     /**
+     * Indique si la couche doit être affichée dans le gestionnaire de couches.
+     * La couche est toujours rendue sur la carte ; seule sa visibilité dans le
+     * gestionnaire est contrôlée par cette propriété.
+     * Par défaut, une couche est affichée sauf si `layer.get("display") === false`.
+     * Cette propriété n'a aucun effet sur le rendu de la couche sur la carte,
+     * elle ne contrôle que la visibilité de son entrée dans le LayerSwitcher.
+     *
+     * @param {Layer} layer - Couche OpenLayers.
+     * @returns {Boolean} `true` si la couche doit apparaître dans le gestionnaire.
+     */
+    shouldDisplayLayerInSwitcher (layer) {
+        if (!layer || typeof layer.get !== "function") {
+            return true;
+        }
+        return layer.get("display") !== false;
+    }
+    
+    /**
      * Add a new layer to control (when added to map) or add new layer configuration
      *
      * @param {Layer} layer - layer to add to layer switcher
      * @param {Object} [config] - additional options for layer configuration
      * @param {Object} [config.title] - layer title (default is layer identifier)
      * @param {Object} [config.description] - layer description (default is null)
+    * @param {Object} [config.producer] - layer producer (default is null)
      * @param {Object} [config.legends] - layer legends (default is an empty array)
      * @param {Object} [config.metadata] - layer metadata (default is an empty array)
      * @param {Object} [config.quicklookUrl] - layer quicklookUrl (default is null)
+    * @param {Boolean} [config.display=true] - controls the visibility of the layer entry in the LayerSwitcher only.
      * @fires layerswitcher:add {@link LayerSwitcher#ADD_LAYER_EVENT}
      * @example
      *   layerSwitcher.addLayer(
@@ -420,7 +448,6 @@ class LayerSwitcher extends Control {
             return;
         }
 
-        // make sure layer is in map layers
         var isLayerInMap = false;
         map.getLayers().forEach(
             (lyr) => {
@@ -948,12 +975,21 @@ class LayerSwitcher extends Control {
          * @group Events
          * @param {Object} type - event
          * @param {Object} layer - layer
+         * @param {string} key - Nom de la propriété modifiée.
+         * Valeurs documentées et gérées nativement : `title`, `description`, `producer`, `display`.
+         * @param {string|boolean|null} value - Nouvelle valeur de la propriété.
          * @param {Object} target - instance LayerSwitcher
          * @public
          * @example
          * LayerSwitcher.on("layerswitcher:propertychange", function (e) {
          *   console.log(e.layer);
          * })
+         *
+         * @example
+         * layer.set("title", "Orthophoto");
+         * layer.set("description", "Photographies aériennes");
+         * layer.set("producer", "IGN");
+         * layer.set("display", false); // masque uniquement l'entrée du gestionnaire
          */
         this.PROPERTY_CHANGE_EVENT = "layerswitcher:propertychange";
         /**
@@ -1447,6 +1483,11 @@ class LayerSwitcher extends Control {
         // ajout d'une div pour cette layer dans le control
         var layerDiv = this._createContainerLayerElement(layerOptions, this.options.allowTooltips);
 
+        // La propriété "display" ne pilote que la visibilité dans le gestionnaire.
+        if (!this.shouldDisplayLayerInSwitcher(layerOptions.layer)) {
+            layerDiv.classList.add("gpf-hidden");
+        }
+
         if (!layerOptions.inRange) {
             layerDiv.classList.add("outOfRange");
         }
@@ -1485,7 +1526,11 @@ class LayerSwitcher extends Control {
      */
     _updateLayerCounter () {
         if (this._layerSwitcherCounter) {
-            this._layerSwitcherCounter.innerHTML = Object.keys(this._layers).length;
+            // on exclut les couches masquées (display === false) du compteur
+            const count = Object.values(this._layers).filter(
+                (opts) => opts.layer && this.shouldDisplayLayerInSwitcher(opts.layer)
+            ).length;
+            this._layerSwitcherCounter.innerHTML = count;
         }
     }
 
@@ -1660,6 +1705,11 @@ class LayerSwitcher extends Control {
         map.getLayers().forEach(
             (layer) => {
                 id = layer.gpLayerId;
+
+                // on ignore les couches non suivies (ex. display=false dès l'origine)
+                if (!this._layers[id]) {
+                    return;
+                }
 
                 // on commence par désactiver temporairement l'écouteur d'événements sur le changement de zindex.
                 olObservableUnByKey(this._layers[id].onZIndexChangeEvent);
@@ -2220,6 +2270,9 @@ class LayerSwitcher extends Control {
      */
     _updateGenericProperty (e) {
         var id = e.target.gpLayerId;
+        if (!this._layers[id]) {
+            return;
+        }
         var layer = this._layers[id].layer;
         var value = layer.get(e.key);
 
@@ -2245,6 +2298,19 @@ class LayerSwitcher extends Control {
                 if (producerDiv) {
                     producerDiv.innerHTML = value;
                 }
+                break;
+            case "display":
+                // masquer ou afficher uniquement dans le gestionnaire de couches ;
+                // la couche reste rendue sur la carte dans tous les cas.
+                var layerDiv = this._layers[id].div;
+                if (layerDiv) {
+                    if (value === false) {
+                        layerDiv.classList.add("gpf-hidden", "GPelementHidden");
+                    } else {
+                        layerDiv.classList.remove("gpf-hidden", "GPelementHidden");
+                    }
+                }
+                this._updateLayerCounter();
                 break;
             default:
                 break;

--- a/src/packages/Controls/LayerSwitcher/LayerSwitcher.js
+++ b/src/packages/Controls/LayerSwitcher/LayerSwitcher.js
@@ -1706,7 +1706,7 @@ class LayerSwitcher extends Control {
             (layer) => {
                 id = layer.gpLayerId;
 
-                // on ignore les couches non suivies (ex. display=false dès l'origine)
+                // on ignore les couches non suivies (par ex. ajoutées à la carte sans passer par le LayerSwitcher)
                 if (!this._layers[id]) {
                     return;
                 }

--- a/src/packages/Controls/LayerSwitcher/LayerSwitcher.js
+++ b/src/packages/Controls/LayerSwitcher/LayerSwitcher.js
@@ -1485,7 +1485,7 @@ class LayerSwitcher extends Control {
 
         // La propriété "display" ne pilote que la visibilité dans le gestionnaire.
         if (!this.shouldDisplayLayerInSwitcher(layerOptions.layer)) {
-            layerDiv.classList.add("gpf-hidden");
+            layerDiv.classList.add("gpf-hidden", "GPelementHidden");
         }
 
         if (!layerOptions.inRange) {

--- a/src/packages/Controls/LayerSwitcher/LayerSwitcher.js
+++ b/src/packages/Controls/LayerSwitcher/LayerSwitcher.js
@@ -435,11 +435,14 @@ class LayerSwitcher extends Control {
      */
     addLayer (layer, config) {
         var map = this.getMap();
-        config = config || layer.config || {};
 
         if (!layer) {
             logger.log("[ERROR] LayerSwitcher:addLayer - missing layer parameter");
             return;
+        }
+        config = config || layer.config || {};
+        if (Object.prototype.hasOwnProperty.call(config, "display")) {
+            layer.set("display", config.display);
         }
 
         var id = layer.gpLayerId;

--- a/src/packages/Controls/Panoramax/Panoramax.js
+++ b/src/packages/Controls/Panoramax/Panoramax.js
@@ -37,6 +37,7 @@ var logger = Logger.getLogger("panoramax");
  * @property {Boolean} [draggable=false] - Permet de déplacer le panneau du catalogue.
  * @property {Boolean} [auto=true] - Active l’ajout automatique des événements sur la carte.
  * @property {Boolean} [hover=true] - Active l’interaction au survol (pointermove) sur la couche Panoramax.
+ * @property {Boolean} [displayable=false] - Indique si les couches sont affichables dans le gestionnaire de couches.
  * @property {Boolean} [panel=false] - Affiche un en-tête (header) dans le panneau.
  * @property {String} [id] - Identifiant unique du widget.
  * @property {String} [position] - Position CSS du widget sur la carte.
@@ -65,6 +66,10 @@ var logger = Logger.getLogger("panoramax");
  * @property {Boolean} [buttonsWindow.hover.display] - Affiche ou masque le bouton de survol.
  * @property {String} [buttonsWindow.hover.label] - Libellé du bouton de survol.
  * @property {String} [buttonsWindow.hover.description] - Description du bouton de survol.
+ * @property {Object} [buttonsWindow.layerswitcher] - Options de configuration du bouton de gestion des couches.
+ * @property {Boolean} [buttonsWindow.layerswitcher.display] - Affiche ou masque le bouton de gestion des couches.
+ * @property {String} [buttonsWindow.layerswitcher.label] - Libellé du bouton de gestion des couches.
+ * @property {String} [buttonsWindow.layerswitcher.description] - Description du bouton de gestion des couches.
  * @property {Object} [buttonsWindow.contributions] - Options de configuration des contributions.
  * @property {Boolean} [buttonsWindow.contributions.display] - Affiche ou masque les contributions.
  * @property {String} [buttonsWindow.contributions.label] - Libellé du bouton de contribution.
@@ -413,6 +418,7 @@ class Panoramax extends Control {
             panel : false,
             auto : true,
             hover : true,
+            displayable : false,
             gutter : false,
             position : "bottom-left",
             group : true, // option interne !
@@ -434,7 +440,7 @@ class Panoramax extends Control {
                 display : true,
                 target : null, // experimental !
                 position : "bottom-left", // TODO position ?
-                order : ["filters", "contributions", "hover", "background", "styles"],
+                order : ["filters", "contributions", "hover", "background", "layerswitcher", "styles"],
                 filters : {
                     display : true,
                     label : "Effacer les filtres",
@@ -466,6 +472,11 @@ class Panoramax extends Control {
                     display : true,
                     label : "Fond de carte",
                     description : "Afficher ou masquer un fond de carte de référence"
+                },
+                layerswitcher : {
+                    display : true,
+                    label : "Couches Panoramax",
+                    description : "Afficher ou masquer les différentes couches Panoramax",
                 }
             },
             visualizationWindow : {
@@ -551,6 +562,12 @@ class Panoramax extends Control {
          * Indique si l'interaction au survol est activée.
          */
         this.hover = this.options.hover;
+
+        /**
+         * @type {Boolean}
+         * Indique si les couches sont affichables dans le gestionnaire de couches.
+         */
+        this.displayable = this.options.displayable;
 
         /** @private */
         this.buttonPanoramaxShow = null;
@@ -851,6 +868,15 @@ class Panoramax extends Control {
                         if (this.options.buttonsWindow.hover.display) {
                             this.btnPanoramaxHover = this._createButtonChoiceHoverElement(this.options.hover, this.options.buttonsWindow.hover);
                             this.panelPanoramaxOptions.appendChild(this.btnPanoramaxHover);
+                        }
+                        break;
+                    case "layerswitcher":
+                        if (this.options.buttonsWindow.layerswitcher.display) {
+                            this.btnPanoramaxLayerswitcher = this._createButtonChoiceDisplayLayerElement(
+                                this.displayable, 
+                                this.options.buttonsWindow.layerswitcher
+                            );
+                            this.panelPanoramaxOptions.appendChild(this.btnPanoramaxLayerswitcher);
                         }
                         break;
                     case "styles":
@@ -1345,6 +1371,8 @@ class Panoramax extends Control {
         if (!this.groupPanoramax) {
             this.groupPanoramax = new LayerGroup();
             this.groupPanoramax.gpResultLayerId = "panoramax:group";
+            // on masque le nom du groupe dans le gestionnaire de couche
+            this.groupPanoramax.set("display", this.displayable);
             this.groupPanoramax.setProperties({
                 "title" : "Panoramax",
                 "description" : "Couche de données Panoramax"
@@ -1391,6 +1419,7 @@ class Panoramax extends Control {
             // mise à jour du nom de la couche du gestionnaire de couche
             layer.set("title", opts.name);
             layer.set("description", "Couche de données Panoramax");
+            layer.set("display", this.displayable);
             // sauvegarde de la référence de la couche
             this.layerPanoramax = layer;
             return layer;
@@ -1436,6 +1465,7 @@ class Panoramax extends Control {
             await this.waitForMapboxVectorLayerReady(layer);
             this.backgroundPanoramax = layer;
             this.backgroundPanoramax.set("title", opts.name);
+            this.backgroundPanoramax.set("display", this.displayable);
             if (this.layerPanoramax) {
                 const baseZIndex = this.layerPanoramax.getZIndex() ?? 0;
                 this.backgroundPanoramax.setZIndex(baseZIndex + 1);  
@@ -3413,7 +3443,19 @@ class Panoramax extends Control {
             this.resetBackground();
         }
     }
-
+ 
+    /**
+     * Gère le clic d'activation/désactivation de l'affichage des couches dans le gestionnaire de couches.
+     *
+     * @param {Event} e - Événement DOM du bouton de gestion des couches.
+     * @private
+     */
+    onToggleChoiceDisplayLayerPanoramaxClick (e) {
+        logger.debug(e);
+        this.displayable = !this.displayable;
+        this.groupPanoramax.set("display", this.displayable);
+    }
+            
     /**
      * Gère le changement de mode de rendu dans Panoramax.
      *

--- a/src/packages/Controls/Panoramax/Panoramax.js
+++ b/src/packages/Controls/Panoramax/Panoramax.js
@@ -3453,7 +3453,16 @@ class Panoramax extends Control {
     onToggleChoiceDisplayLayerPanoramaxClick (e) {
         logger.debug(e);
         this.displayable = !this.displayable;
-        this.groupPanoramax.set("display", this.displayable);
+
+        if (this.groupPanoramax) {
+            this.groupPanoramax.set("display", this.displayable);
+        }
+        if (this.layerPanoramax) {
+            this.layerPanoramax.set("display", this.displayable);
+        }
+        if (this.backgroundPanoramax) {
+            this.backgroundPanoramax.set("display", this.displayable);
+        }
     }
             
     /**

--- a/src/packages/Controls/Panoramax/Panoramax.js
+++ b/src/packages/Controls/Panoramax/Panoramax.js
@@ -661,6 +661,17 @@ class Panoramax extends Control {
         this.HOVERED_DATA_PANORAMAX_CB = "pnx:data:hovered";
 
         /**
+         * Nom du callback déclenché lors de la suppression de la couche Panoramax active.
+         * @event pnx:layer:removed
+         * @defaultValue "pnx:layer:removed"
+         * @group Callbacks
+         * @description
+         * Ce callback est utilisé pour indiquer que la couche Panoramax a été supprimée de la carte.
+         * Il peut être utilisé pour déclencher des actions complémentaires de nettoyage.
+         */
+        this.LAYER_PANORAMAX_REMOVE_CB = "pnx:layer:removed";
+
+        /**
          * Nom de l'événement déclenché quand une plage de dates est saisie.
          * @event pnx:filter:dates
          * @defaultValue "pnx:filter:dates"
@@ -1073,6 +1084,17 @@ class Panoramax extends Control {
         };
         this.eventsListeners[this.HOVERED_DATA_PANORAMAX_CB] = this.onPointerMoveDebounced(hoverHandler);
         map.on("pointermove", this.eventsListeners[this.HOVERED_DATA_PANORAMAX_CB]);
+
+        // on met en place un ecouteur sur la suppression de la couche Panoramax
+        // ce qui permet de réinitialiser le panneau Panoramax si la couche 
+        // est supprimée par un autre contrôle de gestion des couches
+        this.eventsListeners[this.LAYER_PANORAMAX_REMOVE_CB] = (e) => {
+            var layer = e.element;
+            if (layer === self.groupPanoramax || layer === self.layerPanoramax) {
+                self.setCollapsed(true);
+            }
+        };
+        map.getLayers().on("remove", this.eventsListeners[this.LAYER_PANORAMAX_REMOVE_CB]);
     }
 
     /**
@@ -1098,6 +1120,10 @@ class Panoramax extends Control {
         var mapTarget = map.getTargetElement();
         if (mapTarget) {
             mapTarget.style.cursor = "";
+        }
+        if (this.eventsListeners[this.LAYER_PANORAMAX_REMOVE_CB]) {
+            map.getLayers().un("remove", this.eventsListeners[this.LAYER_PANORAMAX_REMOVE_CB]);
+            delete this.eventsListeners[this.LAYER_PANORAMAX_REMOVE_CB];
         }
     }
 
@@ -1188,6 +1214,13 @@ class Panoramax extends Control {
     /** @private */
     resetButtons () {
         this.unbindFiltersPanelPositioning();
+        if (this.panelPanoramaxOptions) {
+            this.panelPanoramaxOptions.classList.replace("gpf-visible", "gpf-hidden");
+        }
+        if (this.btnPanoramaxOptions) {
+            this.btnPanoramaxOptions.setAttribute("aria-pressed", "false");
+        }
+        this.hideButtonsPanel();
     }
     /** @private */
     resetPhotoViewer () {

--- a/src/packages/Controls/Panoramax/PanoramaxDOM.js
+++ b/src/packages/Controls/Panoramax/PanoramaxDOM.js
@@ -349,6 +349,43 @@ var PanoramaxDOM = {
         return div;
     },
 
+    _createButtonChoiceDisplayLayerElement : function (active, opts) {
+        var self = this;
+
+        var div = document.createElement("div");
+        div.id = this._addUID("GPpanoramaxToggleDisplay");
+        div.className = "pnx-toggle fr-toggle fr-m-2v";
+
+        var messages = document.createElement("div");
+        messages.id = this._addUID("GPpanoramaxToggleDisplayMessages");
+        messages.className = "fr-messages-group";
+        messages.setAttribute("aria-live", "polite");
+        
+        var input = document.createElement("input");
+        input.id = this._addUID("GPpanoramaxToggleDisplayInput");
+        input.className = "pnx-toggle__input fr-toggle__input";
+        input.type = "checkbox";
+        input.checked = active;
+        input.setAttribute("aria-describedby", messages.id);
+
+        input.addEventListener("click", function (e) {
+            self.onToggleChoiceDisplayLayerPanoramaxClick(e);
+        });
+
+        var label = document.createElement("label");
+        label.id = this._addUID("GPpanoramaxToggleDisplayLabel");
+        label.className = "pnx-toggle__label fr-toggle__label";
+        label.setAttribute("title", opts.description);
+        label.setAttribute("for", input.id);
+        label.innerText = opts.label;
+
+        div.appendChild(input);
+        div.appendChild(label);
+        div.appendChild(messages);
+
+        return div;
+    },
+
     // ################################################################### //
     // ####################### Methods for filters ####################### //
     // ################################################################### //


### PR DESCRIPTION
cf. issue #521 

Dans **Panoramax**, l'option `displayable` indique si les couches sont affichables dans le gestionnaire de couches.
Par défaut, `displayable=false`

Le menu des options permet de modifier la valeur à la volée.

Pour recetter :
- ouvrir l'exemple Panoramax : `samples-src/pages/tests/Panoramax/pages-ol-panoramax-modules-dsfr-v4.4.0.html`
- par défaut, la couche Panoramax n'est pas dans le LayerSwitcher
- aller dans le menu des options, et changer l'affichage de la couche dans le gestionnaire

---

# Pour rendre une couche affichable ou pas dans le gestionnaire de couches 

Dans la classe **LayerSwitcher**

## Property de la couche

_Property_ reactive !

```js
layer.set("display", false);
```
avec _true_ pour affichable
et _false_ pour non affichable

## Abonnement aux événements 

```js
// Evenement du contrôle
layerSwitcher.on("layerswitcher:propertychange", function (e) {});

// Evenement de la couche
layer.on("change:display", (e) => {});
```

## Mécanisme

La _property_ va déclencher un événement qui va rendre l'entrée du gestionnaire de couche visible ou invisible
en ajoutant / supprimant la classe CSS `gpf-hidden`

## Recette

Pour recetter
- ouvrir l'exemple : `samples-src/pages/tests/LayerSwitcher/pages-ol-layerswitcher-modules-dsfr-addlayers.html`
- cliquer sur le bouton 'Ajouter une couche OSM"
- cliquer sur les boutons : 
   - Changer le titre
   - Masquer la couche
   - Afficher la couche
   - ...

Chaque opération fait appel au même mecanisme des properties réactives.
