### PR TITLE
fix(Panoramax): meilleur gestion de recherche des features pour afficher la preview

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -31,6 +31,7 @@ __DATE__
   - DSFR: ne surcharge plus le style fr-tabs global (#512)
   - LayerSwitcher : le label "éditer" s'affiche au lieu de "style" pour les couches non TMS (#516)
   - Catalog: correction du nom des icones (#519)
+  - Panoramax : correction sur l'affichage de la previsualisation des images (#534)
   
 * 🔒 [Security]
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.12-492",
-  "date": "02/06/2026",
+  "version": "1.0.0-beta.12-534",
+  "date": "04/06/2026",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/src/packages/Controls/Panoramax/Panoramax.js
+++ b/src/packages/Controls/Panoramax/Panoramax.js
@@ -1092,7 +1092,6 @@ class Panoramax extends Control {
                     feature = pictureFeature;
                 }
             }
-            }
             feature.pointerCoordinate = e.coordinate;
             self.displayPreview(feature);
         };

--- a/src/packages/Controls/Panoramax/Panoramax.js
+++ b/src/packages/Controls/Panoramax/Panoramax.js
@@ -1004,7 +1004,7 @@ class Panoramax extends Control {
                         self.options.interactions.sequences.actions.includes("zoom")) {
                         e.map.getView().animate({
                             center : feature.pointerCoordinate || feature.coordinates,
-                            zoom : 17,
+                            zoom : 18, // FIXME zoom niveau fixe !?
                             duration : 500
                         });
                     }

--- a/src/packages/Controls/Panoramax/Panoramax.js
+++ b/src/packages/Controls/Panoramax/Panoramax.js
@@ -1058,19 +1058,34 @@ class Panoramax extends Control {
             if (!self.eventActived || e.dragging) {
                 return;
             }
-            console.warn(e.map.getView().getZoom());
+
             var options = {
                 layerFilter : (l) => l === self.layerPanoramax,
                 hitTolerance : 0
             };
-            var feature = e.map.forEachFeatureAtPixel(e.pixel, (feature) => feature, options);
+
+            const features = [];
+            e.map.forEachFeatureAtPixel(e.pixel, (feature) => {
+                features.push(feature);
+            }, options);
+
             var mapTarget = e.map.getTargetElement();
             if (mapTarget) {
-                mapTarget.style.cursor = feature ? "pointer" : "";
+                mapTarget.style.cursor = features.length > 0 ? "pointer" : "";
             }
-            if (!feature) {
+            if (features.length === 0) {
                 self.resetPreview();
                 return;
+            }
+            // Selon le zoom defini (17 ou 18 pour un picture), 
+            // on recherche un feature de type picture pour l'affichage de l'aperçu, 
+            // sinon on prend le premier feature (ex. grid ou sequence)
+            let feature = features[0];
+            if (e.map.getView().getZoom() >= 17) {
+                const pictureFeature = features.find(f => f.get("mvt:layer") === "pictures");
+                if (pictureFeature) {
+                    feature = pictureFeature;
+                }
             }
             feature.pointerCoordinate = e.coordinate;
             self.displayPreview(feature);
@@ -2551,7 +2566,6 @@ class Panoramax extends Control {
         // stocke la feature survolée
         this.selectedFeature = feature;
         var pfeature = this._transformToPanoramaxFeature(feature);
-        console.warn(type);
         switch (type) {
             case "grid":
                 // preview des statistiques panoramax

--- a/src/packages/Controls/Panoramax/Panoramax.js
+++ b/src/packages/Controls/Panoramax/Panoramax.js
@@ -946,14 +946,37 @@ class Panoramax extends Control {
 
     onPointerMoveDebounced (handler) {
         const debounce = (func, delay) => {
-            let timerId;
+            let timerId = null;
+            let isDestroyed = false;
     
-            return function (...args) {
+            const debounced = function (...args) {
+                if (isDestroyed) {
+                    return;
+                }
                 clearTimeout(timerId);
                 timerId = setTimeout(() => {
-                    func.apply(this, args);
+                    if (!isDestroyed) {
+                        func.apply(this, args);
+                        timerId = null;
+                    }
                 }, delay);
             };
+
+            // Permet d'annuler les timeouts en attente
+            debounced.cancel = () => {
+                if (timerId !== null) {
+                    clearTimeout(timerId);
+                    timerId = null;
+                }
+            };
+
+            // Marquer comme détruit pour éviter les appels après suppression
+            debounced.destroy = () => {
+                debounced.cancel();
+                isDestroyed = true;
+            };
+
+            return debounced;
         };
 
         return debounce(handler, 10);
@@ -1072,6 +1095,10 @@ class Panoramax extends Control {
             delete this.eventsListeners[this.CLICKED_DATA_PANORAMAX_CB];
         }
         if (this.eventsListeners[this.HOVERED_DATA_PANORAMAX_CB]) {
+            // Annuler les timeouts en attente du debounce
+            if (this.eventsListeners[this.HOVERED_DATA_PANORAMAX_CB].destroy) {
+                this.eventsListeners[this.HOVERED_DATA_PANORAMAX_CB].destroy();
+            }
             map.un("pointermove", this.eventsListeners[this.HOVERED_DATA_PANORAMAX_CB]);
             delete this.eventsListeners[this.HOVERED_DATA_PANORAMAX_CB];
         }

--- a/src/packages/Controls/Panoramax/Panoramax.js
+++ b/src/packages/Controls/Panoramax/Panoramax.js
@@ -1002,11 +1002,17 @@ class Panoramax extends Control {
                     // depending on the density of images in the sequence
                     if (self.options.interactions.sequences.active && 
                         self.options.interactions.sequences.actions.includes("zoom")) {
-                        e.map.getView().animate({
-                            center : feature.pointerCoordinate || feature.coordinates,
-                            zoom : 18, // FIXME zoom niveau fixe !?
-                            duration : 500
-                        });
+                        var zoom = e.map.getView().getZoom();
+                        var newZoom = 17; // FIXME zoom niveau fixe !?
+                        // si le zoom actuel est inférieur au zoom cible, on zoome, 
+                        // sinon on ne fait rien pour éviter les animations de zoom intempestives
+                        if (zoom < newZoom) {
+                            e.map.getView().animate({
+                                center : feature.pointerCoordinate || feature.coordinates,
+                                zoom : newZoom, 
+                                duration : 500
+                            });
+                        }
                     }
                 }
                 return;
@@ -1029,6 +1035,7 @@ class Panoramax extends Control {
             if (!self.eventActived || e.dragging) {
                 return;
             }
+            console.warn(e.map.getView().getZoom());
             var options = {
                 layerFilter : (l) => l === self.layerPanoramax,
                 hitTolerance : 0
@@ -2517,7 +2524,7 @@ class Panoramax extends Control {
         // stocke la feature survolée
         this.selectedFeature = feature;
         var pfeature = this._transformToPanoramaxFeature(feature);
-
+        console.warn(type);
         switch (type) {
             case "grid":
                 // preview des statistiques panoramax

--- a/src/packages/Controls/Panoramax/Panoramax.js
+++ b/src/packages/Controls/Panoramax/Panoramax.js
@@ -1027,12 +1027,17 @@ class Panoramax extends Control {
                         self.options.interactions.sequences.actions.includes("zoom")) {
                         var zoom = e.map.getView().getZoom();
                         var newZoom = 17; // FIXME zoom niveau fixe !?
-                        // si le zoom actuel est inférieur au zoom cible, on zoome, 
-                        // sinon on ne fait rien pour éviter les animations de zoom intempestives
+                        // si le zoom actuel est inférieur au zoom cible, on zoome,
+                        // sinon on recentre uniquement pour éviter les animations de zoom intempestives
                         if (zoom < newZoom) {
                             e.map.getView().animate({
                                 center : feature.pointerCoordinate || feature.coordinates,
-                                zoom : newZoom, 
+                                zoom : newZoom,
+                                duration : 500
+                            });
+                        } else {
+                            e.map.getView().animate({
+                                center : feature.pointerCoordinate || feature.coordinates,
                                 duration : 500
                             });
                         }

--- a/src/packages/Controls/Panoramax/Panoramax.js
+++ b/src/packages/Controls/Panoramax/Panoramax.js
@@ -1082,10 +1082,11 @@ class Panoramax extends Control {
             // sinon on prend le premier feature (ex. grid ou sequence)
             let feature = features[0];
             if (e.map.getView().getZoom() >= 17) {
-                const pictureFeature = features.find(f => f.get("mvt:layer") === "pictures");
+                const pictureFeature = features.find(f => (f.get("mvt:layer") || f.get("layer")) === "pictures");
                 if (pictureFeature) {
                     feature = pictureFeature;
                 }
+            }
             }
             feature.pointerCoordinate = e.coordinate;
             self.displayPreview(feature);


### PR DESCRIPTION
cf. issue #522 


La transition du zoom lors d'un clic sur la sequence vers les pictures est de 17.
Les previews sont affichable uniquement pour les pictures (pas pour les sequences), et à partir du zoom 17.
Car, c'est à partir du zoom 17 que les informations (feature) sont disponibles pour les pictures.

---

Analyse erronée :exclamation: 

> Hors, le zoom n'était pas toujours sur une valeur absolue, ex. 17.122458
> Ce qui ne permettait pas d'afficher une preview pour les pictures.
~~Solution simple : on augment le zoom à 18 lors d'un clic sur une sequence.~~

---

Sur le zoom 17, la feature renvoyée par le hover devrait renvoyée une feature de type picture.
Hors, elle renvoie une feature de type sequence !?
Du coup, pas d'affichage de la preview.
Mais, pourquoi la feature n'est elle pas de type picture à ce niveau de zoom !?

À partir du zoom 15, les tuiles de données renvoient des features de sequences et de pictures.
Normalement, les sequences, puis les pictures qui viennent se superposer aux sequences.
Mais, ce n'est pas toujours le cas !?

Solution possible : 
ne pas se contenter de prendre le 1er feature rencontré, prendre une liste de features, et selon le zoom defini (17 ou 18), on recherche un feature de type picture !
