### PR TITLE
feat(ControlList): Catalogue d'outil réorganisable + adaptations dsfr

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -26,6 +26,7 @@ __DATE__
   - Panoramax : la couche Panoramax n'est pas affiché par défaut dans le gestionnaire de couches (#533)
   - Panoramax : modification de l'icone orientation dans la minimap (#538)
   - ContextMenu : ajout d’une méthode publique pour mettre à jour/ajouter des entrées personnalisées (#517)
+  - ControlList: Catalogue d'outils devient réorganisable + adaptation dsfr
 
 * 🔥 [Deprecated]
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.12-539",
-  "date": "09/06/2026",
+  "version": "1.0.0-beta.12-535",
+  "date": "10/06/2026",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/samples-src/pages/tests/ControlList/pages-ol-modules-dsfr-sortable.html
+++ b/samples-src/pages/tests/ControlList/pages-ol-modules-dsfr-sortable.html
@@ -1,0 +1,138 @@
+{{#extend "ol-sample-modules-dsfr-layout"}}
+
+{{#content "vendor"}}
+
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlCRS.js"></script>
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlLayers.js"></script>
+        <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlLayerSwitcher.css" />
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlLayerSwitcher.js"></script>
+        <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlDrawing.css" />
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlDrawing.js"></script>
+        <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlIsocurve.css" />
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlIsocurve.js"></script>
+        <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlRoute.css" />
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlRoute.js"></script>
+        <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlReverseGeocode.css" />
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlReverseGeocode.js"></script>
+        <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlMeasureLength.css" />
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlMeasureLength.js"></script>
+        <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlMeasureArea.css" />
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlMeasureArea.js"></script>
+        <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlMeasureAzimuth.css" />
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlMeasureAzimuth.js"></script>
+        <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlElevationPath.css" />
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlElevationPath.js"></script>
+        <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlControlList.css" />
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlControlList.js"></script>
+{{/content}}
+
+{{#content "head"}}
+        <title>ControlList - Sortable</title>
+{{/content}}
+
+{{#content "style"}}
+        <style>
+            div#map {
+                width: 100%;
+                height: 700px;
+            }
+            .ol-scale-line {
+                left: 60px;
+            }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+            <h2>ControlList - Sortable</h2>
+            <!-- map -->
+            <div id="map">
+            </div>
+            <div id="zoomer"></div>
+{{/content}}
+
+{{#content "js"}}
+            <script type="text/javascript">
+
+              let controlSelectors = {
+                'MeasureLength':  'div[id^="GPmeasureLength-"]',
+                'MeasureArea':    'div[id^="GPmeasureArea-"]',
+                'Drawing':        'div[id^="GPdrawing-"]',
+                'Route':          'div[id^="GProute-"]',
+                'Isocurve':       'div[id^="GPisochron-"]',
+                'ReverseGeocode': 'div[id^="GPreverseGeocoding-"]',
+                'ElevationPath':  'div[id^="GPelevationPath-"]',
+                'MeasureAzimuth': 'div[id^="GPmeasureAzimuth-"]',
+              };
+              let controls = Object.keys(controlSelectors);
+
+              // Reordonne physiquement les éléments dans le DOM
+              function applyControlsOrder(controls) {
+                const container = document.getElementById('position-container-top-right');
+
+                // Reordonne les contrôles
+                controls.forEach((control) => {
+                  const selector = controlSelectors[control];
+                  const widget = document.querySelector(selector);
+                  container.appendChild(widget);
+                });
+
+                // S'assure que ControlList reste à la fin
+                const controlListWidget = container.querySelector('div[id^="GPcontrolList-"]');
+                container.appendChild(controlListWidget);
+              }
+
+
+              var createMap = function () {
+                // on cache l'image de chargement du Géoportail.
+                document.getElementById("map").style.backgroundImage = "none";
+
+                // Création de la map
+                var map = new ol.Map({
+                  target : "map",
+                  layers : [
+                    new ol.layer.GeoportalWMTS({
+                      layer : "GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2"
+                    })
+                  ],
+                  view : new ol.View({
+                    center : [288074.8449901076, 6247982.515792289],
+                    zoom : 8
+                  })
+                });
+
+                controls.forEach((control) => {
+                  let olControl = new ol.control[control]({
+                    position: 'top-right',
+                    gutter: false,
+                    listable: true,
+                  });
+                  map.addControl(olControl);
+                })
+
+                var controlList = new ol.control.ControlList({
+                    position: "top-right",
+                    gutter: false,
+                    header: false,
+                    sortable: true,
+                });
+                map.addControl(controlList);
+
+                controlList.on('controllist:sorted', (e) => {
+                  applyControlsOrder(e.list);
+                });
+              };
+
+              Gp.Services.getConfig({
+                  customConfigFile : "{{ configurl }}",
+                  callbackSuffix : "",
+                  // apiKey: "{{ apikey }}",
+                  timeOut : 20000,
+                  onSuccess : createMap,
+                  onFailure : (e) => {
+                    console.error(e);
+                  }
+              });
+
+            </script>
+{{/content}}
+{{/extend}}

--- a/src/packages/CSS/Controls/ControlList/DSFRcontrolListStyle.css
+++ b/src/packages/CSS/Controls/ControlList/DSFRcontrolListStyle.css
@@ -20,50 +20,80 @@ div[id^="GPcontrolList-"] .GPshowOpen > span {
   /* transform: translate(-5px, -2px); */
 }
 
+dialog[id^="GPcontrolListPanel-"] .gpf-panel__body {
+  border-radius: 4px;
+  overflow-x: hidden;
+}
+
 dialog[id^="GPcontrolListPanel-"] .gpf-panel__content {
   display: flex;
   flex-direction: column;
-  padding: 0 1.5rem;
-  overflow: auto;
+  padding: 1.5rem;
+  transform: rotate(0); /* utile pour que sortable détecte le bon containing block O_o */
 }
 
 dialog[id^="GPcontrolListPanel-"] .gpf-panel__content:not(:has(~ .gpf-panel__footer)) {
   padding-bottom: 2rem;
 }
 
-dialog[id^="GPcontrolListPanel-"] .gpf-panel__content > div {
+dialog[id^="GPcontrolListPanel-"] .gpf-list-element {
   display: flex;
-  flex-direction: row;
-  column-gap: 1rem;
   align-items: center;
-  padding: 0.5rem 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
 }
 
-dialog[id^="GPcontrolListPanel-"] .gpf-panel__content > div:hover {
+dialog[id^="GPcontrolListPanel-"] .gpf-list-element:hover {
   background-color: var(--hover);
 }
 
-dialog[id^="GPcontrolListPanel-"] .gpf-panel__content > div:hover > button {
-  background-color: var(--hover);
+dialog[id^="GPcontrolListPanel-"] .gpf-list-element:active {
+  background-color: var(--active);
 }
 
-dialog[id^="GPcontrolListPanel-"] .gpf-panel__content > div > button {
-  height: 40px;
-  width: 40px;
+dialog[id^="GPcontrolListPanel-"] .gpf-list-element--active {
+  background-color: var(--background-open-blue-france);
 }
 
-dialog[id^="GPcontrolListPanel-"] .gpf-panel__content > div > button::after {
-  background-color: var(--text-default-grey);
+dialog[id^="GPcontrolListPanel-"] .gpf-list-element--active:hover {
+  color: var(--text-title-blue-france);
+  background-color: var(--background-open-blue-france-hover);
+/*  box-shadow: inset 0 0 0 1px var(--background-action-high-blue-france);*/
 }
 
-dialog[id^="GPcontrolListPanel-"] .gpf-panel__content > div > div {
-  display: flex;
-  flex-direction: column;
+dialog[id^="GPcontrolListPanel-"] .gpf-list-element--active:active {
+  color: var(--text-title-blue-france);
+  background-color: var(--background-open-blue-france-active);
+/*  box-shadow: inset 0 0 0 1px var(--background-action-high-blue-france);*/
 }
 
-dialog[id^="GPcontrolListPanel-"] .gpf-panel__content > div > div > span:nth-child(2) {
-  color: var(--text-mention-grey);
-  font-size: 0.75rem;
+dialog[id^="GPcontrolListPanel-"] .gpf-list-element--ghost {
+  color: var(--text-title-blue-france);
+  background-color: var(--background-open-blue-france);
+  box-shadow: inset 0 0 0 1px var(--background-action-high-blue-france);
+  opacity: 0;
+}
+
+dialog[id^="GPcontrolListPanel-"] .gpf-list-element--drag {
+  color: var(--text-title-blue-france);
+  box-shadow: inset 0 0 0 1px var(--background-action-high-blue-france);
+  background-color: var(--background-open-blue-france) !important;
+}
+
+dialog[id^="GPcontrolListPanel-"] .gpf-list-element-icon {
+  box-shadow: none;
+  background: none;
+  width: auto;
+}
+
+dialog[id^="GPcontrolListPanel-"] .gpf-list-element-icon::after {
+  background: var(--text-default-grey);
+}
+
+dialog[id^="GPcontrolListPanel-"]
+:is(.gpf-list-element--active:hover,.gpf-list-element--active:active,.gpf-list-element--ghost,.gpf-list-element--drag)
+.gpf-list-element-icon::after {
+  background-color: var(--background-action-high-blue-france) !important;
 }
 
 dialog[id^="GPcontrolListPanel-"] .gpf-panel__footer {
@@ -75,6 +105,20 @@ dialog[id^="GPcontrolListPanel-"] .gpf-panel__footer > button {
   width: 100%;
   justify-content: center;
 }
+
+dialog[id^="GPcontrolListPanel-"] .gpf-btn-icon-ls-draggable {
+  margin-left: auto;
+}
+
+dialog[id^="GPcontrolListPanel-"] div.keyboard-navigation:focus-within {
+  margin-left: -0.25em;
+}
+
+/* Cache les options de drag and drop */
+/*dialog[id^="GPcontrolListPanel-"] .gpf-list-element:first-child [data-direction="up"],
+dialog[id^="GPcontrolListPanel-"] .gpf-list-element:last-child [data-direction="down"] {
+    display: none;
+}*/
 
 .gpf-button-no-gutter + [id^="GPcontrolList-"] > .gpf-btn-icon-controllist > span::before {
     display: block;

--- a/src/packages/CSS/Controls/ControlList/GPFcontrolList.css
+++ b/src/packages/CSS/Controls/ControlList/GPFcontrolList.css
@@ -11,6 +11,7 @@ button[id^="GPshowControlListPicto-"][aria-pressed="true"] + dialog {
   flex-direction: column;
   visibility: visible;
   opacity: 100%;
+  z-index: 1800; /* au-dessus de .fr-modal à 1750 */
 }
 
 dialog[id^="GPcontrolListPanel-"] {

--- a/src/packages/Controls/ControlList/ControlList.js
+++ b/src/packages/Controls/ControlList/ControlList.js
@@ -21,6 +21,8 @@ var logger = Logger.getLogger("controlList");
  * @typedef {Object} ControlListOptions
  * @property {boolean} [collapsed=true] - Définit si le widget est replié au chargement.
  * @property {boolean} [draggable=false] - Permet de déplacer le panneau du widget.
+ * @property {boolean} [sortable=false] - Ajoute une interaction pour modifier l'ordre des contrôles
+ * @property {boolean} [header=true] - Ajoute ou non un header (titre + bouton fermer)
  * @property {string} [position] - Position CSS du widget sur la carte.
  * @property {string|number} [id] - Identifiant unique du widget.
  * @property {HTMLElement} [controlCatalogElement] - Élément DOM à afficher en pied de panneau (ex : bouton catalogue).
@@ -192,6 +194,8 @@ class ControlList extends Control {
         this.options = {
             collapsed : true,
             draggable : false,
+            sortable : false,
+            header : true,
         };
 
         // merge with user options
@@ -206,6 +210,17 @@ class ControlList extends Control {
          * @type {Boolean} 
          * specify if control is draggable (true) or not (false) */
         this.draggable = this.options.draggable;
+
+        /** 
+         * @type {Boolean} 
+         * specify if list is sortable (true) or not (false) */
+        this.sortable = this.options.sortable;
+
+        if (this.sortable) {
+            this._controlsListSorted = null;
+            this._controlsListStateSync = new globalThis.Map();
+            this._controlsListStateObserver = null;
+        }
 
         /**
          * @private
@@ -238,12 +253,16 @@ class ControlList extends Control {
         panel.appendChild(panelDiv);
 
         // header
-        var header = this._ControlListPanelHeaderContainer = this._createControlListPanelHeaderElement();
-        panelDiv.appendChild(header);
+        if (this.options.header) {
+            var header = this._ControlListPanelHeaderContainer = this._createControlListPanelHeaderElement();
+            panelDiv.appendChild(header);
+        }
 
         // content
-        var content = this._ControlListPanelContentContainer = this._createControlListPanelContentElement();
+        var content = this._createControlListPanelContentElement();
         panelDiv.appendChild(content);
+        // list element
+        this._ControlListPanelContentContainer = content.children[0];
 
         if (this.controlCatalogElement) {
             // footer
@@ -266,13 +285,8 @@ class ControlList extends Control {
      * @param { Event } e évènement associé au clic
      * @private
      */
-    onShowControlListPanelClick (e) {
-        if (e.target.ariaPressed === "true") {
-            this.onPanelOpen();
-        }
+    onShowControlListPanelClick () {
         var map = this.getMap();
-        // on supprime toutes les interactions
-        Interactions.unset(map);
         var opened = this._pictoControlListButton.ariaPressed;
         this.collapsed = !(opened === "true");
         // on génère nous même l'evenement OpenLayers de changement de propriété
@@ -283,16 +297,79 @@ class ControlList extends Control {
             this.updatePosition(this.options.position);
         }
         if (!this.collapsed) {
-            const controls = this.getMap().getControls().getArray();
+            let controls = this.getMap().getControls().getArray().filter(control => control.listable);
+            if (this.sortable && this._controlsListSorted) {
+                // si on a déjà trié la liste, on trie les controles de la map
+                let positions = Object.fromEntries(
+                    this._controlsListSorted.map((name, index) => [name, index])
+                );
+                controls.sort((a, b) => positions[a.CLASSNAME] - positions[b.CLASSNAME]);
+            }
+
             controls.forEach(control => {
-                if (control.listable) {
-                    let element = this._createControlListPanelControl(control);
-                    this._ControlListPanelContentContainer.appendChild(element);
-                }
+                let element = this._createControlListPanelControl(control);
+                this._ControlListPanelContentContainer.appendChild(element);
             });
+
+            // mode "sortable"
+            if (this.sortable) {
+                this._createSortableElement(this._ControlListPanelContentContainer);
+            }
+
+            this._startControlListStateObserver();
         } else {
+            this._stopControlListStateObserver();
             this._ControlListPanelContentContainer.innerHTML = "";
         }
+    }
+
+    _registerControlListStateSync (button, listElement) {
+        this._controlsListStateSync.set(button, listElement);
+    }
+
+    _startControlListStateObserver () {
+        if (this._controlsListStateObserver) {
+            this._controlsListStateObserver.disconnect();
+        }
+
+        this._controlsListStateObserver = new MutationObserver((mutations) => {
+            mutations.forEach((mutation) => {
+                if (mutation.type !== "attributes" || mutation.attributeName !== "aria-pressed") {
+                    return;
+                }
+                const button = mutation.target;
+                const listElement = this._controlsListStateSync.get(button);
+                if (!listElement) {
+                    return;
+                }
+                const isActive = button.getAttribute("aria-pressed") === "true";
+                listElement.classList.toggle("gpf-list-element--active", isActive);
+            });
+        });
+
+        this._controlsListStateSync.forEach((_, button) => {
+            this._controlsListStateObserver.observe(button, {
+                attributes : true,
+                attributeFilter : ["aria-pressed"]
+            });
+        });
+    }
+
+    _stopControlListStateObserver () {
+        if (this._controlsListStateObserver) {
+            this._controlsListStateObserver.disconnect();
+            this._controlsListStateObserver = null;
+        }
+        this._controlsListStateSync.clear();
+    }
+
+    _onSortedEnd () {
+        let listControls = [...this._ControlListPanelContentContainer.children].map(element => element.dataset.name);
+        this._controlsListSorted = listControls;
+        this.dispatchEvent({
+            type : "controllist:sorted",
+            list : listControls,
+        });
     }
 
 };

--- a/src/packages/Controls/ControlList/ControlListDOM.js
+++ b/src/packages/Controls/ControlList/ControlListDOM.js
@@ -1,4 +1,5 @@
 import checkDsfr from "../Utils/CheckDsfr";
+import Sortable from "sortablejs";
 
 var ControlListDOM = {
 
@@ -54,19 +55,11 @@ var ControlListDOM = {
 
         // gestionnaire d'evenement :
         // on ouvre le menu
-        if (button.addEventListener) {
-            button.addEventListener("click", function (e) {
-                var status = (e.target.ariaPressed === "true");
-                e.target.setAttribute("aria-pressed", !status);
-                context.onShowControlListPanelClick(e);
-            });
-        } else if (button.attachEvent) {
-            button.attachEvent("onclick", function (e) {
-                var status = (e.target.ariaPressed === "true");
-                e.target.setAttribute("aria-pressed", !status);
-                context.onShowControlListPanelClick(e);
-            });
-        }
+        button.addEventListener("click", function (e) {
+            var status = (e.target.ariaPressed === "true");
+            e.target.setAttribute("aria-pressed", !status);
+            context.onShowControlListPanelClick(e);
+        });
 
         return button;
     },
@@ -103,7 +96,7 @@ var ControlListDOM = {
         var self = this;
 
         var container = document.createElement("div");
-        container.className = "GPpanelHeader gpf-panel__header fr-modal__header";
+        container.className = "GPpanelHeader gpf-panel__header fr-modal__header fr-pb-0";
 
         var div = document.createElement("div");
         div.className = "GPpanelTitle gpf-panel__title fr-modal__title fr-pt-4w";
@@ -144,7 +137,12 @@ var ControlListDOM = {
      */
     _createControlListPanelContentElement : function () {
         var container = document.createElement("div");
-        container.className = "gpf-panel__content fr-modal__content";
+        container.className = "gpf-panel__content fr-modal__content fr-p-2v";
+
+        let listContainer = document.createElement("ul");
+        listContainer.classList.add("fr-m-0", "fr-p-0");
+        container.appendChild(listContainer);
+
         return container;
     },
 
@@ -180,32 +178,204 @@ var ControlListDOM = {
         } catch (e) {
             controlContainer = control.container;
         }
-        var container = document.createElement("div");
-        var btn = controlContainer.querySelector(".GPshowOpen").cloneNode();
-        btn.id = btn.id + "-controllist";
-        btn.classList.add("inside-control-list");
-        container.appendChild(btn);
-        var divText = document.createElement("div");
-        var spanTitle = document.createElement("span");
-        divText.appendChild(spanTitle);
-        if (controlContainer.querySelector(".GPshowOpen").ariaLabel) {
-            spanTitle.innerText = controlContainer.querySelector(".GPshowOpen").ariaLabel;
-        } else if (controlContainer.querySelector(".GPpanelTitle")) {
-            spanTitle.innerText = controlContainer.querySelector(".GPpanelTitle").innerText;
-        } else if (controlContainer.querySelector("[class^='gpf-btn-header-']")) {
-            spanTitle.innerText = controlContainer.querySelector("[class^='gpf-btn-header-']").title;
-        }
-        if (control.description) {
-            var spanDescription = document.createElement("span");
-            spanDescription.innerText = control.description;
-            divText.appendChild(spanDescription);
-        }
-        container.appendChild(divText);
+        let listElement = document.createElement("li");
+        listElement.classList.add("gpf-list-element", "fr-py-0-5v");
+        listElement.dataset.name = control.CLASSNAME;
+        listElement.setAttribute("role", "button");
+        listElement.setAttribute("tabindex", 0);
 
-        container.addEventListener("click", function () {
-            controlContainer.querySelector(".GPshowOpen").click();
+        let showButton = controlContainer.querySelector(".GPshowOpen");
+        let btnWidget = showButton.cloneNode();
+        // is active ?
+        let isActive = btnWidget.getAttribute("aria-pressed") === "true";
+        if (isActive) {
+            listElement.classList.add("gpf-list-element--active");
+        }
+
+        this._registerControlListStateSync(showButton, listElement);
+
+        // icone (pas dsfr, donc copie depuis le bouton du widget)
+        let icon = document.createElement("span");
+        icon.className = btnWidget.className;
+        icon.classList.add("gpf-list-element-icon", "fr-mx-2v");
+        listElement.appendChild(icon);
+
+        // button text
+        let listText = document.createElement("span");
+        listText.classList.add("gpf-list-element-text");
+        if (showButton.ariaLabel) {
+            listText.innerText = showButton.ariaLabel;
+        } else if (controlContainer.querySelector(".GPpanelTitle")) {
+            listText.innerText = controlContainer.querySelector(".GPpanelTitle").innerText;
+        } else if (controlContainer.querySelector("[class^='gpf-btn-header-']")) {
+            listText.innerText = controlContainer.querySelector("[class^='gpf-btn-header-']").title;
+        }
+        listElement.appendChild(listText);
+
+        let handler = () => {
+            let isActive = listElement.classList.contains("gpf-list-element--active");
+            listElement.parentNode.querySelectorAll(".gpf-list-element").forEach((el) => {
+                el.classList.remove("gpf-list-element--active");
+            });
+            if (!isActive) {
+                listElement.classList.add("gpf-list-element--active");
+            }
+            // click sur le bouton du control correspondant
+            showButton.click();
+
+            // on force la fermeture de controlllist si encore ouvert
+            if (this._pictoControlListButton.getAttribute("aria-pressed") === "true") {
+                this._pictoControlListButton.click();
+            }
+        };
+
+        listElement.addEventListener("click", handler);
+        listElement.addEventListener("keydown", (e) => {
+            if (["Enter", "Space"].includes(e.code)) {
+                handler();
+            }
         });
-        return container;
+        return listElement;
+    },
+
+    _createAccessibleSortableElement : function () {
+        let handle = document.createElement("div");
+        handle.className = "GPelementHidden GPlayerDragNDrop gpf-btn gpf-btn-icon-ls-draggable gpf-btn--tertiary";
+        handle.title = "Deplacer l’outil";
+
+        // Boutons pour déplacer la couche au clavier
+        let divKeyboard = document.createElement("div");
+        divKeyboard.className = "keyboard-navigation";
+
+        let spanUp = document.createElement("span");
+        spanUp.tabIndex = 0;
+        spanUp.dataset.direction = "up";
+        spanUp.title = spanUp.ariaLabel = "Déplacer l’outil vers le haut";
+        spanUp.className = "fr-icon-arrow-up-line fr-icon--sm";
+        spanUp.onkeydown = (e) => this._onMoveElement(true, e);
+
+        let spanDown = document.createElement("span");
+        spanDown.tabIndex = 0;
+        spanDown.dataset.direction = "down";
+        spanDown.title = spanDown.ariaLabel = "Déplacer l’outil vers le bas";
+        spanDown.className = "fr-icon-arrow-down-line fr-icon--sm";
+        spanDown.onkeydown = (e) => this._onMoveElement(false, e);
+
+        divKeyboard.appendChild(spanDown);
+        divKeyboard.appendChild(spanUp);
+
+        handle.appendChild(divKeyboard);
+
+        // stop click events
+        handle.addEventListener("click", (e) => {
+            e.stopImmediatePropagation();
+        });
+
+        return handle;
+    },
+
+    /**
+     * Écouteur d'événement pour modifier la position
+     * @param {Boolean} up Vrai si c'est up. Faux si down.
+     * @param {KeyboardEvent} event Événement du clavier
+     */
+    _onMoveElement : function (up, event) {
+        if (["Enter", "Space"].includes(event.code)) {
+            // Choisit la bonne direction
+            const direction = up ? "up" : "down";
+            const oppositeDirection = up ? "down" : "up";
+
+            event.stopPropagation();
+            event.preventDefault();
+
+            // Déplace l'élément dans la bonne direction
+            this._moveElement(event.currentTarget.closest(".gpf-list-element--sortable"), direction);
+
+            // Change le focus dans le cas où c'est le premier / dernier élément
+            if (window.getComputedStyle(event.currentTarget).visibility == "hidden") {
+                event.currentTarget.parentNode.querySelector(`[data-direction=${oppositeDirection}]`).focus();
+            } else {
+                event.currentTarget.focus();
+            }
+        }
+    },
+
+    /**
+     * Fonction permettant de déplacer un outil au clavier
+     * @param {HTMLElement} element Élément à déplacer
+     * @param {up|down} direction Direction dans laquelle déplacer l'outil
+     * @returns {Boolean} Vrai si l'opération a fonctionnée.
+     */
+    _moveElement : function (element, direction) {
+        const sortable_list = this._sortables[0];
+        if (["up", "down"].includes(direction) == false) {
+            return false;
+        }
+        if (typeof element.dataset.name == "undefined") {
+            return false;
+        }
+
+        // Attribut pour réorganiser après
+        let sortableId = element.dataset.name;
+        let order = sortable_list.toArray();
+        let index = order.indexOf(sortableId);
+        const originalLength = order.length;
+
+        // Retrait de l'objet à déplacer
+        order.splice(index, 1);
+
+        // Déplace la couche à la bonne position
+        let newIndex;
+        if (direction == "down") {
+            newIndex = (index === originalLength - 1) ? 0 : index + 1;
+        } else if (direction == "up") {
+            newIndex = (index === 0) ? order.length : index - 1;
+        }
+        order.splice(newIndex, 0, sortableId);
+
+        // Applique l'opéaration de tri
+        sortable_list.sort(order, true);
+        // callback
+        this._onSortedEnd();
+
+        return true;
+    },
+
+    _sortables : [],
+
+    /**
+     * https://github.com/SortableJS/Sortable?tab=readme-ov-file#options
+     * @param {HTMLElement} element - element to make sortable
+     * @returns {Object} Sortable instance
+     * @type {function(HTMLElement): Object}
+     */
+    _createSortableElement : function (element) {
+        if (this._sortables.length) {
+            this._sortables[0].destroy();
+            this._sortables = [];
+        }
+        // create sortable
+        const sortable = Sortable.create(element, {
+            animation : 150,
+            handle : ".gpf-btn-icon-ls-draggable", // handle
+            draggable : ".gpf-list-element--sortable", // item
+            ghostClass : "gpf-list-element--ghost",
+            dragClass : "gpf-list-element--drag",
+            dataIdAttr : "data-name",
+            onEnd : () => {
+                this._onSortedEnd();
+            },
+        });
+        this._sortables = [sortable];
+
+        // create accessible handles
+        let listElements = [...element.children];
+        listElements.forEach((listElement) => {
+            listElement.classList.add("gpf-list-element--sortable");
+            listElement.appendChild(this._createAccessibleSortableElement());
+        });
+
+        return sortable;
     },
 
 };

--- a/src/packages/Utils/PanelManager.js
+++ b/src/packages/Utils/PanelManager.js
@@ -27,9 +27,10 @@ function getSameSideOpenedPanel (position, openedPanelID) {
 
 var PanelManager = function (position, openedPanelID) {
     var openedPanel = getSameSideOpenedPanel(position, openedPanelID);
-    if (openedPanel.length > 0) {
-        openedPanel[0].getElementsByTagName("button")[0].click();
-    }
+    // on ferme tous les panels ouverts
+    openedPanel.forEach((panel) => {
+        panel.getElementsByTagName("button")[0].click();
+    });
 };
 
 export default PanelManager;


### PR DESCRIPTION
- Widget controlList revu au dsfr
- Ajout d'une option pour réorganiser les outils (`sortable`)
- Ajout d'une option pour enlever le header (`header`)
- Le tri est possible à la souris ou au clavier
- **Modification sur la fermeture des panels**: l'ouverture du panel de controlList ne ferme pas les autres panels. Du coup, à l'ouverture d'un panel du même coté, on doit potentiellement fermer 2 panels (un outil + celui de controlist). A voir si ça pose soucis, ou si on ferme plutôt explicitement le premier panel + celui de controllist
- Page de démo spécifique (`ControlList/pages-ol-modules-dsfr-sortable.html`)


https://github.com/user-attachments/assets/f7e7b657-c27d-4ea6-ba57-7a6738f98466



