### PR TITLE
feat(Interactions): désactiver les interactions de manière moins brutale

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -39,6 +39,7 @@ __DATE__
   - Catalog: correction du nom des icones (#519)
   - Panoramax : correction sur l'affichage de la previsualisation des images (#534)
   - Panoramax : fixe l’icone en mode sombre (#539)
+  - Interactions : fixe sur le nettoyage des interactions utilisateurs (#537)
   
 * 🔒 [Security]
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.12-535",
-  "date": "10/06/2026",
+  "version": "1.0.0-beta.12-537",
+  "date": "12/06/2026",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/samples-src/pages/tests/Utils/pages-ol-modules-dsfr-default.html
+++ b/samples-src/pages/tests/Utils/pages-ol-modules-dsfr-default.html
@@ -82,7 +82,7 @@
             <h2>Test d'une interaction</h2>
             <p>Cliquer sur l'icône pour activer l'interaction</p>
             <p>Cliquer sur les boutons de mesure pour activer les interactions de mesure</p>
-            <p>Et, verifier que l'interaction fonctionne correctement</p>
+            <p>Et vérifier que l'interaction fonctionne correctement</p>
             <!-- map -->
             <div id="map">
             </div>

--- a/samples-src/pages/tests/Utils/pages-ol-modules-dsfr-default.html
+++ b/samples-src/pages/tests/Utils/pages-ol-modules-dsfr-default.html
@@ -1,0 +1,197 @@
+{{#extend "ol-sample-modules-dsfr-layout"}}
+
+{{#content "vendor"}}
+
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlCRS.js"></script>
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlLayers.js"></script>
+        <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlLayerSwitcher.css" />
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlLayerSwitcher.js"></script>
+        <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlDrawing.css" />
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlDrawing.js"></script>
+        <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlMeasureLength.css" />
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlMeasureLength.js"></script>
+        <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlMeasureArea.css" />
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlMeasureArea.js"></script>
+        <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlMeasureAzimuth.css" />
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlMeasureAzimuth.js"></script>
+        <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlElevationPath.css" />
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlElevationPath.js"></script>
+{{/content}}
+
+{{#content "head"}}
+        <title>Test d'une interaction</title>
+{{/content}}
+
+{{#content "style"}}
+        <style>
+          div#map {
+            width: 100%;
+            height: 700px;
+          }
+          .ol-popup {
+            position: absolute;
+            background-color: #888888;
+            -webkit-filter: drop-shadow(0 1px 4px rgba(0, 0, 0, 0.2));
+            filter: drop-shadow(0 1px 4px rgba(0, 0, 0, 0.2));
+            padding: 15px;
+            border-radius: 10px;
+            border: 1px solid #cccccc;
+            bottom: 12px;
+            left: -50px;
+            min-width: 280px;
+          }
+
+          .ol-popup:after, .ol-popup:before {
+            top: 100%;
+            border: solid transparent;
+            content: " ";
+            height: 0;
+            width: 0;
+            position: absolute;
+            pointer-events: none;
+          }
+
+          .ol-popup:after {
+            border-top-color: white;
+            border-width: 10px;
+            left: 48px;
+            margin-left: -10px;
+          }
+
+          .ol-popup:before {
+            border-top-color: #cccccc;
+            border-width: 11px;
+            left: 48px;
+            margin-left: -11px;
+          }
+
+          .ol-popup-closer {
+            text-decoration: none;
+            position: absolute;
+            top: 2px;
+            right: 8px;
+          }
+
+          .ol-popup-closer:after {
+            content: "✖";
+          }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+            <h2>Test d'une interaction</h2>
+            <p>Cliquer sur l'icône pour activer l'interaction</p>
+            <p>Cliquer sur les boutons de mesure pour activer les interactions de mesure</p>
+            <p>Et, verifier que l'interaction fonctionne correctement</p>
+            <!-- map -->
+            <div id="map">
+            </div>
+{{/content}}
+
+{{#content "js"}}
+            <script type="text/javascript">
+
+              var createMap = function () {
+                // on cache l'image de chargement du Géoportail.
+                document.getElementById("map").style.backgroundImage = "none";
+
+                const centre = [288074.8449901076, 6247982.515792289];
+                
+                const icon = new ol.Feature({
+                  geometry: new ol.geom.Point(centre)
+                });
+                icon.setStyle(new ol.style.Style({
+                    image: new ol.style.Circle({
+                      radius: 8,
+                      fill: new ol.style.Fill({ color: '#FFFF00' })
+                    }),
+                    text: new ol.style.Text({
+                      text: "Hello world !",
+                      font: '14px sans-serif',
+                      offsetX: 10,
+                      offsetY: 4
+                    })
+                }));
+                var marker = new ol.layer.Vector({
+                  source: new ol.source.Vector({
+                    features: [icon]
+                  })
+                });
+
+                // Création de la map
+                var map = new ol.Map({
+                  target : "map",
+                  layers : [
+                    new ol.layer.GeoportalWMTS({
+                      layer : "GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2"
+                    }),
+                    marker
+                  ],
+                  view : new ol.View({
+                    center : centre,
+                    zoom : 8
+                  })
+                });
+
+                const select = new ol.interaction.Select({
+                    condition: ol.events.condition.click,
+                    layers: [marker]
+                });
+                map.addInteraction(select);
+                select.on('select', () => {
+                    console.log("Interaction select !");
+                });
+
+                var drawing = new ol.control.Drawing({
+                  draggable: true,
+                  position : "bottom-left"
+                });
+                map.addControl(drawing);
+
+                var layerSwitcher = new ol.control.LayerSwitcher({
+                  options : {
+                    panel: true,
+                    draggable: true,
+                    position : "top-left",
+                    counter : true,
+                  }
+                });
+                map.addControl(layerSwitcher);
+
+                var measureLength = new ol.control.MeasureLength({
+                  position : "top-left"
+                });
+                map.addControl(measureLength);
+
+                var measureArea = new ol.control.MeasureArea({
+                  position : "top-left",
+                  listable : true
+                });
+                map.addControl(measureArea);
+
+                var measureAzimuth = new ol.control.MeasureAzimuth({
+                  position : "top-left"
+                });
+                map.addControl(measureAzimuth);
+
+                var measureProfil = new ol.control.ElevationPath({
+                  position : "top-left"
+                });
+                map.addControl(measureProfil);
+
+              };
+
+              Gp.Services.getConfig({
+                  customConfigFile : "{{ configurl }}",
+                  callbackSuffix : "",
+                  // apiKey: "{{ apikey }}",
+                  timeOut : 20000,
+                  onSuccess : createMap,
+                  onFailure : (e) => {
+                    console.error(e);
+                  }
+              });
+
+            </script>
+{{/content}}
+{{/extend}}

--- a/src/packages/Controls/Utils/Interactions.js
+++ b/src/packages/Controls/Utils/Interactions.js
@@ -112,7 +112,8 @@ var Interactions = {
                         }
                     }
                 } else {
-                    interactions[i].setActive(false);
+                    // FIXME un peu trop violent !?
+                    // interactions[i].setActive(false);
                 }
             }
         }


### PR DESCRIPTION
Pour basculer d'un outil à un autres sur les outils de mesures et de dessins, on a besoin de réinitialiser les interactions.
Hors, le **reset** était un peu trop violant car il supprimait aussi les interactions utilisateurs !

Pour recetter : 

- `npm run sample:modules`
- ouvrir le navigateur (automatique) : `https://localhost:8080/samples/index-modules.html`
- utiliser l'exemple `samples-src/pages/tests/Utils/pages-ol-modules-dsfr-default.html`

L'exemple permet de vérifier que l'interaction utilisateur (icone google avec 'Hello world!') est toujours active malgré les manipulations des outils.