### PR TITLE
feat(Panoramax): Création icone d'orientation dans la minimap

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -24,6 +24,7 @@ __DATE__
   - AdvancedSearch : conversion des coordonnées renseignés dans les inputs en changeant de système ou d'unité via les dropdowns (#518) 
   - LayerSwitcher : le tooltip au survol de l'entrée de la couche affiche son titre (#505)
   - Panoramax : la couche Panoramax n'est pas affiché par défaut dans le gestionnaire de couches (#533)
+  - Panoramax : modification de l'icone orientation dans la minimap (#536)
   - ContextMenu : ajout d’une méthode publique pour mettre à jour/ajouter des entrées personnalisées (#517)
 
 * 🔥 [Deprecated]

--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -24,7 +24,7 @@ __DATE__
   - AdvancedSearch : conversion des coordonnées renseignés dans les inputs en changeant de système ou d'unité via les dropdowns (#518) 
   - LayerSwitcher : le tooltip au survol de l'entrée de la couche affiche son titre (#505)
   - Panoramax : la couche Panoramax n'est pas affiché par défaut dans le gestionnaire de couches (#533)
-  - Panoramax : modification de l'icone orientation dans la minimap (#536)
+  - Panoramax : modification de l'icone orientation dans la minimap (#538)
   - ContextMenu : ajout d’une méthode publique pour mettre à jour/ajouter des entrées personnalisées (#517)
 
 * 🔥 [Deprecated]

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.12-517",
-  "date": "08/06/2026",
+  "version": "1.0.0-beta.12-538",
+  "date": "09/06/2026",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/src/packages/Controls/Panoramax/PnxMiniMapWidget.js
+++ b/src/packages/Controls/Panoramax/PnxMiniMapWidget.js
@@ -191,6 +191,10 @@ class MiniMap extends LitElement {
         markerElement.className = "pnx-mini-map__center-marker";
         markerElement.setAttribute("aria-hidden", "true");
 
+        let markerDirection = document.createElement("div");
+        markerDirection.classList.add("pnx-mini-map__center-marker-direction");
+        markerElement.appendChild(markerDirection);
+
         // TODO heading par defaut
         this._centerMarkerOverlay = new Overlay({
             element : markerElement,
@@ -462,13 +466,19 @@ class MiniMap extends LitElement {
                     transition: opacity .15s .3s; /* à l'ouverture, attendre 0.3s et animer en 0.15s */
                 }
                 .pnx-mini-map__center-marker {
-                    width: 14px;
-                    height: 14px;
+                    width: 20px;
+                    height: 20px;
+                    border-radius: 50%;
                     background-color: var(--background-action-high-blue-france);
-                    clip-path: polygon(50% 0%, 5% 100%, 95% 100%);
-                    filter: drop-shadow(0 0 0 2px #fff) drop-shadow(0 0 1px rgba(0,0,0,0.2));
+                    box-shadow: 0 0 0 2px #fff, 0 0 0 3px rgba(0, 0, 0, 0.2);
                     pointer-events: none;
                     z-index: 2;
+                }
+                .pnx-mini-map__center-marker-direction {
+                    width: 20px;
+                    height: 20px;
+                    background-color: white;
+                    clip-path: polygon(50% 18%, 25% 75%, 50% 66%, 75% 75%);
                 }
                 .pnx-mini-map__container .ol-viewport canvas,
                 .pnx-mini-map__container .ol-overlaycontainer {


### PR DESCRIPTION
Fixe l'issue #536.
Pas identique à la maquette (mais je pense que c'est directement le rendu Panoramax sur la maquette)

<img width="300" height="181" alt="image" src="https://github.com/user-attachments/assets/0fdedb35-ce96-40dc-a529-fba3e5a249b2" />
