### PR TITLE
fix(Panoramax): Fix l’icone Panoramax en mode sombre

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -37,7 +37,7 @@ __DATE__
   - LayerSwitcher : le label "éditer" s'affiche au lieu de "style" pour les couches non TMS (#516)
   - Catalog: correction du nom des icones (#519)
   - Panoramax : correction sur l'affichage de la previsualisation des images (#534)
-  - Panoramax : fixe l’icone en mode sombre (#527)
+  - Panoramax : fixe l’icone en mode sombre (#539)
   
 * 🔒 [Security]
 

--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -37,6 +37,7 @@ __DATE__
   - LayerSwitcher : le label "éditer" s'affiche au lieu de "style" pour les couches non TMS (#516)
   - Catalog: correction du nom des icones (#519)
   - Panoramax : correction sur l'affichage de la previsualisation des images (#534)
+  - Panoramax : fixe l’icone en mode sombre (#527)
   
 * 🔒 [Security]
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.12-538",
+  "version": "1.0.0-beta.12-539",
   "date": "09/06/2026",
   "module": "src/index.js",
   "directories": {},

--- a/src/packages/CSS/Controls/Panoramax/DSFRpanoramaxStyle.css
+++ b/src/packages/CSS/Controls/Panoramax/DSFRpanoramaxStyle.css
@@ -2,16 +2,8 @@
 .gpf-btn-icon-panoramax::after {
     -webkit-mask: url("img/dsfr/panoramax.svg") center no-repeat;
     mask: url("img/dsfr/panoramax.svg") center no-repeat;
-    background-color: var(--gpf-color-text);  /* hack to apply color to the icon */
 }
 
-.gpf-btn-icon-header-panoramax,
-.gpf-btn-icon-panoramax {
-    background-image: url("img/dsfr/panoramax.svg");
-    background-repeat: no-repeat;
-    background-size: auto auto;
-    background-position: center center;
-}
 .gpf-btn-header-panoramax {
     z-index: 2;
     position: absolute;

--- a/src/packages/Controls/Panoramax/PanoramaxDOM.js
+++ b/src/packages/Controls/Panoramax/PanoramaxDOM.js
@@ -100,7 +100,7 @@ var PanoramaxDOM = {
     },
     _createWidgetPanelButtonsIconElement : function () {
         var label = document.createElement("label");
-        label.className = "gpf-btn-header-panoramax gpf-icon-color"; // gpf-btn-icon-header-panoramax
+        label.className = "gpf-btn-header-panoramax gpf-icon-color";
         label.classList.add("fr-icon", "fr-icon-equalizer-line");
         label.title = `${title}`;
         label.setAttribute("aria-label", `Afficher ${title}`);


### PR DESCRIPTION
Fixe l'issue #527.

Mode clair
<img width="300" height="181" alt="image" src="https://github.com/user-attachments/assets/65ec0e82-9ab1-483d-bb05-c130d48ae219" />

Mode sombre
<img width="300" height="181" alt="image" src="https://github.com/user-attachments/assets/998e9803-d651-4307-aab7-3db663eea948" />
