### PR TITLE
Panoramax : affichage de la couche à partir du niveau 9 par défaut

### DIFF
--- a/src/packages/Controls/Panoramax/Panoramax.js
+++ b/src/packages/Controls/Panoramax/Panoramax.js
@@ -1515,7 +1515,7 @@ class Panoramax extends Control {
         }
         // zoomIn si en dehors de la plage de définition de la couche
         if (map.getView().getZoom() < minZoom) {
-            map.getView().setZoom(minZoom + 0.5);
+            map.getView().animate({ zoom : minZoom + 0.5 });
         }
 
         try {

--- a/src/packages/Controls/Panoramax/Panoramax.js
+++ b/src/packages/Controls/Panoramax/Panoramax.js
@@ -425,16 +425,12 @@ class Panoramax extends Control {
             layer : {
                 url : "https://api.panoramax.xyz/api/map/style.json",
                 source : "geovisio",
-                name : "Panoramax",
-                minZoom : 6,
-                maxZoom : 21
+                name : "Panoramax"
             },
             background : {
                 active : false,
                 url : "https://data.geopf.fr/annexes/ressources/vectorTiles/styles/PLAN.IGN/gris.json",
-                name : "Background",
-                minZoom : 6,
-                maxZoom : 21
+                name : "Background"
             },
             buttonsWindow : {
                 display : true,
@@ -1493,13 +1489,17 @@ class Panoramax extends Control {
         if (!map) {
             return;
         }
+        var minZoom = opts.minZoom || 9;
+        var maxZoom = opts.maxZoom || 21;
+
         var layer = new MapboxVectorLayer({ 
             styleUrl : opts.url,
             source : opts.source,
             declutter : true,
-            minZoom : opts.minZoom || 6,
-            maxZoom : opts.maxZoom || 21
+            minZoom : minZoom,
+            maxZoom : maxZoom
         });
+
         // hack pour le gestionnaire de couche
         layer.styleUrl = opts.url;
         layer.gpResultLayerId = "panoramax:layer";
@@ -1512,6 +1512,10 @@ class Panoramax extends Control {
             this.groupPanoramax.getLayers().push(layer);
         } else {
             map.addLayer(layer);
+        }
+        // zoomIn si en dehors de la plage de définition de la couche
+        if (map.getView().getZoom() < minZoom) {
+            map.getView().setZoom(minZoom + 0.5);
         }
 
         try {
@@ -1547,12 +1551,16 @@ class Panoramax extends Control {
             return;
         }
 
+        var minZoom = opts.minZoom || 9;
+        var maxZoom = opts.maxZoom || 21;
+
         var layer = new MapboxVectorLayer({ 
             styleUrl : opts.url,
             declutter : true,
-            minZoom : opts.minZoom || 6,
-            maxZoom : opts.maxZoom || 21
+            minZoom : minZoom,
+            maxZoom : maxZoom
         });
+        
         layer.styleUrl = opts.url;
         layer.gpResultLayerId = "panoramax:background";
 


### PR DESCRIPTION

Fix #542 --> zoom 9 plus pertinent que 7

Retrait des paramètres minZoom et maxZoom par défaut qui n'étaient pas surchargeables.



Gestion de la plage de niveaux de zoom de définition de la couche au niveau des fonctions "setLayer" et "setBackground".





Si Trop dézoomé, on zoomIn au bon niveau pour voir la couche (est-ce fait au bon endroit ?)

[Capture vidéo du 12-06-2026 13:47:32.webm](https://github.com/user-attachments/assets/5c1e64da-ce64-4060-b127-63f0369b278c)





