### PR TITLE
Tooltips: amélioration usage et accessibilité

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -28,6 +28,7 @@ __DATE__
   - Panoramax : modification de l'icone orientation dans la minimap (#538)
   - ContextMenu : ajout d’une méthode publique pour mettre à jour/ajouter des entrées personnalisées (#517)
   - ControlList: Catalogue d'outils devient réorganisable + adaptation dsfr
+  - Tooltip: ajoute un délai avant affichage
 
 * 🔥 [Deprecated]
 

--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -15,7 +15,7 @@ __DATE__
 
 * ✨ [Added]
 
-  - Panoramax : 🎉 nouveau widget !
+  - Panoramax : 🎉 nouveau widget ! (#492)
   - Panoramax : Ajout de l'orientation du déplacement dans la minimap du PhotoViewer (#532)
   - LayerSwitcher : Possibilité de rendre une couche affichable ou non dans le gestionnaire (#533)
 
@@ -23,13 +23,14 @@ __DATE__
 
   - AdvancedSearch : conversion des coordonnées renseignés dans les inputs en changeant de système ou d'unité via les dropdowns (#518) 
   - LayerSwitcher : le tooltip au survol de l'entrée de la couche affiche son titre (#505)
-  - LayerSwitcher : pas de title si on affiche une tooltip
+  - LayerSwitcher : pas de title si on affiche une tooltip (#546)
   - Panoramax : la couche Panoramax n'est pas affiché par défaut dans le gestionnaire de couches (#533)
   - Panoramax : modification de l'icone orientation dans la minimap (#538)
+  - Panoramax : affichage de la couche Panoramax qu'à partir du niveau 9 par défaut (#543)
   - ContextMenu : ajout d’une méthode publique pour mettre à jour/ajouter des entrées personnalisées (#517)
   - ControlList: Catalogue d'outils devient réorganisable + adaptation dsfr
-  - Tooltip: ajoute un délai avant affichage
-  - Tooltip: affichage des tooltips en-dessous de l’élément survolé
+  - Tooltip: ajoute un délai avant affichage (#546)
+  - Tooltip: affichage des tooltips en-dessous de l’élément survolé (#546)
 
 * 🔥 [Deprecated]
 

--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -29,6 +29,7 @@ __DATE__
   - ContextMenu : ajout d’une méthode publique pour mettre à jour/ajouter des entrées personnalisées (#517)
   - ControlList: Catalogue d'outils devient réorganisable + adaptation dsfr
   - Tooltip: ajoute un délai avant affichage
+  - Tooltip: affichage des tooltips en-dessous de l’élément survolé
 
 * 🔥 [Deprecated]
 

--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -23,6 +23,7 @@ __DATE__
 
   - AdvancedSearch : conversion des coordonnées renseignés dans les inputs en changeant de système ou d'unité via les dropdowns (#518) 
   - LayerSwitcher : le tooltip au survol de l'entrée de la couche affiche son titre (#505)
+  - LayerSwitcher : pas de title si on affiche une tooltip
   - Panoramax : la couche Panoramax n'est pas affiché par défaut dans le gestionnaire de couches (#533)
   - Panoramax : modification de l'icone orientation dans la minimap (#538)
   - ContextMenu : ajout d’une méthode publique pour mettre à jour/ajouter des entrées personnalisées (#517)

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.12-535",
-  "date": "10/06/2026",
+  "version": "1.0.0-beta.12-546",
+  "date": "12/06/2026",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/src/packages/Controls/LayerSwitcher/LayerSwitcherDOM.js
+++ b/src/packages/Controls/LayerSwitcher/LayerSwitcherDOM.js
@@ -614,7 +614,8 @@ var LayerSwitcherDOM = {
         if (tooltips) {
             label.dataset.tooltip = obj.title || obj.description;
             ToolTips.active(label);
-            label.title = obj.name;
+            // pas de title si tooltip
+            label.removeAttribute("title");
         }
         label.innerHTML = obj.title;
         // FIXME Hack temporaire pour TMS
@@ -640,7 +641,7 @@ var LayerSwitcherDOM = {
         div.innerHTML = obj.producer;
         if (tooltips) {
             div.dataset.tooltip = obj.producer;
-            ToolTips.active(div);
+            //ToolTips.active(div);
         }
 
         return div;

--- a/src/packages/Utils/ToolTips.js
+++ b/src/packages/Utils/ToolTips.js
@@ -40,6 +40,8 @@ var ToolTips = {
             tooltip.style.top = `${rect.top - tooltip.offsetHeight - 10}px`;
             tooltip.style.left = `${rect.left + rect.width / 2}px`;
             tooltip.style.transform = "translateX(-50%)";
+            tooltip.style.transitionDelay = "500ms";
+            tooltip.style.transitionDuration = "250ms";
             tooltip.style.opacity = "1";
         });
 
@@ -48,6 +50,8 @@ var ToolTips = {
             if (!tooltip) {
                 return;
             }
+            tooltip.style.transitionDelay = "0ms";
+            tooltip.style.transitionDuration = "0ms";
             tooltip.style.opacity = "0";
         });
     }

--- a/src/packages/Utils/ToolTips.js
+++ b/src/packages/Utils/ToolTips.js
@@ -37,7 +37,7 @@ var ToolTips = {
             }
             tooltip.innerHTML = content;
             const rect = element.getBoundingClientRect();
-            tooltip.style.top = `${rect.top - tooltip.offsetHeight - 10}px`;
+            tooltip.style.top = `${rect.bottom + 10}px`;
             tooltip.style.left = `${rect.left + rect.width / 2}px`;
             tooltip.style.transform = "translateX(-50%)";
             tooltip.style.transitionDelay = "500ms";


### PR DESCRIPTION
- suppression de l’attribut `title` si on crée nous-même une tooltip (accessibilité + double bulle)
- suppression de la tooltip du producteur (trop de tooltip)
- ajoute un délai avant affichage de la tooltip (plus pratique à l'usage)
- affiche la tooltip en dessous, plutôt qu'au dessus (comportement plus classique)