### PR TITLE
fix(Panoramax): orientation de la photo dans le mini-carte au chargement de la photo

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -22,6 +22,8 @@ __DATE__
 * 🔥 [Removed]
 
 * 🐛 [Fixed]
+
+  - Panoramax : correctif sur l'orientation dans la minimap au chargement de la photo (#551)
   
 * 🔒 [Security]
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.12",
-  "date": "15/06/2026",
+  "version": "1.0.0-beta.12-551",
+  "date": "16/06/2026",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/src/packages/Controls/Panoramax/Panoramax.js
+++ b/src/packages/Controls/Panoramax/Panoramax.js
@@ -1901,6 +1901,15 @@ class Panoramax extends Control {
                 } else {
                     this.photoViewerMiniMap.pictureCoordinates = gps;
                 }
+
+                let heading = currentPsv.getPosition().yaw * (180 / Math.PI);
+		        heading += currentPsv.getPictureOriginalHeading();
+                
+		        if (typeof this.photoViewerMiniMap.setPhotoHeading === "function") {
+                    this.photoViewerMiniMap.setPhotoHeading(heading);
+                } else {
+                    this.photoViewerMiniMap.pictureHeading = heading;
+                }
             };
         }
 


### PR DESCRIPTION
cf. issue #528 