### PR TITLE
fix(Panoramax): z-index par défaut au-dessus des modales DSFR (#552)

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -26,6 +26,7 @@ __DATE__
 * 🐛 [Fixed]
 
   - Panoramax : correctif sur l'orientation dans la minimap au chargement de la photo (#551)
+  - Panoramax : modification du z-index par défaut du photoviewer pour être au-dessus des modales DFSR (#552)
   
 * 🔒 [Security]
 

--- a/src/packages/CSS/Controls/Panoramax/DSFRpanoramaxStyle.css
+++ b/src/packages/CSS/Controls/Panoramax/DSFRpanoramaxStyle.css
@@ -215,7 +215,7 @@
     padding: 0;
     border: 0;
     border-radius: 0;
-    z-index: 1000;
+    z-index: 2000;
 }
 .pnx-visualization-window-size-fullscreen-map {
     position: fixed;


### PR DESCRIPTION
Fixe l’issue #552

- Modification du `z-index: 1000` par défaut par `2000`, pour être au-dessus des modales DSFR (qui sont à 1950)