### PR TITLE
fix(Catalog): améliorer la gestion des critères de recherche pour inclure des valeurs de tableaux

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -27,6 +27,7 @@ __DATE__
 
   - Panoramax : correctif sur l'orientation dans la minimap au chargement de la photo (#551)
   - Panoramax : modification du z-index par défaut du photoviewer pour être au-dessus des modales DFSR (#552)
+  - Catalog : améliorer la gestion des critères de recherche pour inclure des valeurs issues de tableaux (#555)
   
 * 🔒 [Security]
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.12-551",
-  "date": "16/06/2026",
+  "version": "1.0.0-beta.12-555",
+  "date": "19/06/2026",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/samples-src/pages/tests/Catalog/pages-ol-catalog-modules-dsfr-categories-1-icons.html
+++ b/samples-src/pages/tests/Catalog/pages-ol-catalog-modules-dsfr-categories-1-icons.html
@@ -67,7 +67,7 @@
                         size : "lg",
                         search : {
                             display : false,
-                            // criteria : ["name","title","description"]
+                            criteria : ["name","title","description", "thematic", "producer", "service"],
                         },
                         categories : [
                             {

--- a/src/packages/Controls/Catalog/Catalog.js
+++ b/src/packages/Controls/Catalog/Catalog.js
@@ -1620,7 +1620,15 @@ class Catalog extends Control {
                 for (let i = 0; i < criteria.length; i++) {
                     const c = criteria[i];
                     if (layer[c]) {
-                        words += layer[c].toLowerCase();
+                        if (Array.isArray(layer[c])) {
+                            words += layer[c]
+                                .flat(Infinity) // tableau imbriqué
+                                .filter(item => item != null) // valeur null ou undefined
+                                .join("")
+                                .toLowerCase();
+                        } else {
+                            words += String(layer[c]).toLowerCase();
+                        }
                     }
                 }
                 layer.hidden = !words.includes(value.toLowerCase());


### PR DESCRIPTION

cf. issue https://github.com/IGNF/cartes.gouv.fr-entree-carto/issues/1119

Les champs `producer` ou `thematic` sont des tableaux.
Dorénavant, on peut réaliser une recherche sur ce type de champ.

## Avant 

<img width="524" height="403" alt="image" src="https://github.com/user-attachments/assets/3dccd3e9-5e24-4002-97d0-870a1c81dfd4" />

## Après

<img width="505" height="525" alt="image" src="https://github.com/user-attachments/assets/3325be51-0c7a-4849-b80e-ca1b3854c8e6" />

## Recette

modifier les valeurs de recherche : 
```json
criteria : ["name","title","description", "thematic", "producer", "service"],
```

utiliser l'exemple : `samples-src/pages/tests/Catalog/pages-ol-catalog-modules-dsfr-categories-1-icons.html`