### PR TITLE
fix(Panoramax): déclenchement des événements lors de la réinitialisation des filtres

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -27,6 +27,7 @@ __DATE__
 
   - Panoramax : correctif sur l'orientation dans la minimap au chargement de la photo (#551)
   - Panoramax : modification du z-index par défaut du photoviewer pour être au-dessus des modales DFSR (#552)
+  - Panoramax : reinitialisation des filtres (#556)
   
 * 🔒 [Security]
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.12-551",
-  "date": "16/06/2026",
+  "version": "1.0.0-beta.12-556",
+  "date": "19/06/2026",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/src/packages/Controls/Panoramax/Panoramax.js
+++ b/src/packages/Controls/Panoramax/Panoramax.js
@@ -3415,6 +3415,9 @@ class Panoramax extends Control {
                 el.setAttribute("aria-pressed", "false");
             } else if (el.type === "date") {
                 el.value = "";
+                if (!silent) {
+                    el.dispatchEvent(new Event("change", { "bubbles" : true }));
+                }
             }
         });
 


### PR DESCRIPTION

cf. issue https://github.com/IGNF/cartes.gouv.fr-entree-carto/issues/1115
