### PR TITLE
fix(Isocurve/Drawing): corriger l'événement de calcul d'isocurve / ouverture de l'outil de dessin

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -30,6 +30,7 @@ __DATE__
   - Panoramax : reinitialisation des filtres (#556)
   - Catalog : améliorer la gestion des critères de recherche pour inclure des valeurs issues de tableaux (#555)
   - Isocurve : correctif sur l'évenement de fin de traitement (#557)
+  - Drawing : correctif sur l'ouverture du panneau de dessin (#557)
   
 * 🔒 [Security]
 

--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -29,6 +29,7 @@ __DATE__
   - Panoramax : modification du z-index par défaut du photoviewer pour être au-dessus des modales DFSR (#552)
   - Panoramax : reinitialisation des filtres (#556)
   - Catalog : améliorer la gestion des critères de recherche pour inclure des valeurs issues de tableaux (#555)
+  - Isocurve : correctif sur l'évenement de fin de traitement (#557)
   
 * 🔒 [Security]
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.12-556",
-  "date": "19/06/2026",
+  "version": "1.0.0-beta.12-557",
+  "date": "22/06/2026",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/src/packages/Controls/Drawing/Drawing.js
+++ b/src/packages/Controls/Drawing/Drawing.js
@@ -461,9 +461,13 @@ class Drawing extends Control {
         if ((collapsed && this.collapsed) || (!collapsed && !this.collapsed)) {
             return;
         }
-        // on simule l'ouverture du panneau après un click
-        this.onShowDrawingClick();
-        this._showDrawingButton.click();
+
+        if (collapsed) {
+            document.getElementById("GPdrawingPanelClose-" + this._uid).click();
+        } else {
+            this._showDrawingButton.click();
+        }
+        this.collapsed = collapsed;
     }
 
     /**

--- a/src/packages/Controls/Isocurve/Isocurve.js
+++ b/src/packages/Controls/Isocurve/Isocurve.js
@@ -636,7 +636,7 @@ class Isocurve extends Control {
          *   console.log(e.target.getData());
          * })
          */
-        this.COMPUTE_ISOCURVE_EVENT = "isocurve:comput";
+        this.COMPUTE_ISOCURVE_EVENT = "isocurve:compute";
         /**
          * event triggered when user clear points to compute isochrone
          *
@@ -1413,13 +1413,6 @@ class Isocurve extends Control {
          * @private
          * sauvegarde de l'etat des resultats */
         this._currentIsoInformations = results;
-
-        /**
-         * event triggered when the compute is finished
-         */
-        this.dispatchEvent({
-            type : this.COMPUTE_ISOCURVE_EVENT
-        });
 
         // mise à jour du controle !
         this._formContainer.className = "GPelementHidden gpf-hidden gpf-panel__content fr-modal__content";

--- a/src/packages/Controls/Route/Route.js
+++ b/src/packages/Controls/Route/Route.js
@@ -72,7 +72,6 @@ class Route extends Control {
      * @fires route:drawstart
      * @fires route:drawend
      * @fires route:compute
-     * @fires route:compute
      * @fires route:newresults
      * @example
      *  var route = ol.control.Route({


### PR DESCRIPTION
cf. issue https://github.com/IGNF/cartes.gouv.fr-entree-carto/issues/1117

Fix : 

* Erreur de frappe sur le nom de l’événement de fin de traitement !
* Appel multiple de l’événement de fin de traitement !
* Correctif de l'ouverture de l'outil de dessin

Correctif qui corrige l'édition du calcul sur l'entrée carto