### PR TITLE
feat(Catalog): normaliser le texte de recherche (ex. non sensitive)

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -15,6 +15,8 @@ __DATE__
 
 * ✨ [Added]
 
+  - Catalog : recherche non sensible à la casse ou aux accents (#558)
+
 * 🔨 [Changed]
 
   - Panoramax : possibilité de déclencher l'ouverture du _PhotoViewer_ programmatiquement (#550)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.12-557",
+  "version": "1.0.0-beta.12-558",
   "date": "22/06/2026",
   "module": "src/index.js",
   "directories": {},

--- a/src/packages/Controls/Catalog/Catalog.js
+++ b/src/packages/Controls/Catalog/Catalog.js
@@ -1638,7 +1638,7 @@ class Catalog extends Control {
                                 .filter(item => item != null) // valeur null ou undefined
                                 .join(" "));
                         } else {
-                            words += normalizeSearchText(layer[c]);
+                            words += " " + normalizeSearchText(layer[c]);
                         }
                     }
                 }

--- a/src/packages/Controls/Catalog/Catalog.js
+++ b/src/packages/Controls/Catalog/Catalog.js
@@ -1612,6 +1612,18 @@ class Catalog extends Control {
     setFilteredLayersList (value) {
         // on rend invisible les couches qui ne respecte pas la valeur 
         // selon le critère de recherche
+        
+        const normalizeSearchText = (input) => {
+            return String(input || "")
+                .toLowerCase()
+                .normalize("NFD")
+                .replace(/[\u0300-\u036f]/g, "")
+                .replace(/[_-]+/g, " ")
+                .replace(/\s+/g, " ")
+                .trim();
+        };
+
+        var normalizedValue = normalizeSearchText(value);
         var criteria = this.options.search.criteria;
         for (const key in this.layersList) {
             if (Object.prototype.hasOwnProperty.call(this.layersList, key)) {
@@ -1621,17 +1633,16 @@ class Catalog extends Control {
                     const c = criteria[i];
                     if (layer[c]) {
                         if (Array.isArray(layer[c])) {
-                            words += layer[c]
+                            words += normalizeSearchText(layer[c]
                                 .flat(Infinity) // tableau imbriqué
                                 .filter(item => item != null) // valeur null ou undefined
-                                .join("")
-                                .toLowerCase();
+                                .join(" "));
                         } else {
-                            words += String(layer[c]).toLowerCase();
+                            words += normalizeSearchText(layer[c]);
                         }
                     }
                 }
-                layer.hidden = !words.includes(value.toLowerCase());
+                layer.hidden = !words.includes(normalizedValue);
                 if (!layer.hidden) {
                     logger.info(`Filtering layer ${layer.name} with words : ${words}`);
                 }


### PR DESCRIPTION
L'outil de recherche du widget __Catalog__ est : 
- non sensible à la casse
- non sensible aux accents
- non sensible aux espaces / tirets / underscore

Pour recetter : 
- faire une recherche : ex. `Réseaux` ou `etat major`

Cette implementation sera à reproduire sur la recherche des documents de l'espace personnel : cf. issue https://github.com/IGNF/cartes.gouv.fr-entree-carto/issues/1092