### PR TITLE
fix(layerSwitcher): Modifie _addLayerMap pour corriger problème de div

### DIFF
--- a/samples-src/pages/tests/LayerSwitcher/pages-ol-layerswitcher-modules-dsfr-default.html
+++ b/samples-src/pages/tests/LayerSwitcher/pages-ol-layerswitcher-modules-dsfr-default.html
@@ -37,9 +37,18 @@
                 var map;
                 var layerSwitcher;
                 var plan, bdtopo;
+                var OSM, WMTS;
                 var createMap = function () {
                     // on cache l'image de chargement du Géoportail.
                     document.getElementById('map').style.backgroundImage = 'none';
+
+                    OSM = new ol.layer.Tile({
+                        source: new ol.source.OSM(),
+                        opacity: 0.5
+                    });
+                    WMTS = new ol.layer.GeoportalWMTS({
+                        layer : "ORTHOIMAGERY.ORTHOPHOTOS"
+                    });
                     
                     map = new ol.Map({
                         target : "map",
@@ -48,13 +57,8 @@
                             zoom : 16
                         }),
                         layers : [
-                            new ol.layer.Tile({
-                                source: new ol.source.OSM(),
-                                opacity: 0.5
-                            }),
-                            new ol.layer.GeoportalWMTS({
-                                layer : "ORTHOIMAGERY.ORTHOPHOTOS"
-                            })
+                            OSM,
+                            WMTS,
                         ]
                     });
 
@@ -81,19 +85,31 @@
                     plan.on("mapbox:style:loaded", (e) => {
                         console.log(e);
                     });
-                    map.addLayer(plan);
                     bdtopo = new ol.layer.GeoportalMapBox({
                         layer : "BDTOPO"
                     });
                     bdtopo.on("mapbox:style:loaded", (e) => {
                         console.log(e);
                     });
+                    
+                    // Ajoute les couches
+                    map.addLayer(plan);
                     map.addLayer(bdtopo);
                 };
                 document.getElementById("btn-close-ls").addEventListener("click", function () {
+                    // Enlève couches et contrôles
+                    map.removeLayer(OSM);
+                    map.removeLayer(WMTS);
+                    map.removeLayer(plan);
+                    map.removeLayer(bdtopo);
                     map.removeControl(layerSwitcher);
                 });
                 document.getElementById("btn-open-ls").addEventListener("click", function () {
+                    // Ajoute couches et contrôles
+                    map.addLayer(OSM);
+                    map.addLayer(WMTS);
+                    map.addLayer(plan);
+                    map.addLayer(bdtopo);
                     map.addControl(layerSwitcher);
                 });
                 document.getElementById("btn-remove-layers").addEventListener("click", function () {

--- a/samples-src/pages/tests/LayerSwitcher/pages-ol-layerswitcher-modules-dsfr-default.html
+++ b/samples-src/pages/tests/LayerSwitcher/pages-ol-layerswitcher-modules-dsfr-default.html
@@ -69,6 +69,10 @@
                     layerSwitcher.on("layerswitcher:change:style", (e) => {
                         console.log(e);
                     });
+
+                    layerSwitcher.on(layerSwitcher.CHANGE_LAYER_SELECTED_EVENT, (e) => {
+                        console.log(e)
+                    })
                     // Couches TMS
                     plan = new ol.layer.GeoportalMapBox({
                         layer : "PLAN.IGN"
@@ -92,6 +96,8 @@
                     map.addControl(layerSwitcher);
                 });
                 document.getElementById("btn-reload-layers").addEventListener("click", function () {
+                    map.removeLayer(plan);
+                    map.removeLayer(bdtopo);
                     map.addLayer(plan);
                     map.addLayer(bdtopo);
                 });

--- a/src/packages/Controls/LayerSwitcher/LayerSwitcher.js
+++ b/src/packages/Controls/LayerSwitcher/LayerSwitcher.js
@@ -316,10 +316,16 @@ class LayerSwitcher extends Control {
             // on ajoute les couches
             this._addMapLayers(map);
 
+            
             // mode "collapsed"
             if (!this.collapsed) {
                 this._showLayerSwitcherButton.setAttribute("aria-pressed", true);
             }
+            
+            // Forget listeners (prevent adding them twice)
+            olObservableUnByKey(this._listeners.onMoveListener);
+            olObservableUnByKey(this._listeners.onAddListener);
+            olObservableUnByKey(this._listeners.onRemoveListener);
 
             // At every map movement, layer switcher may be updated,
             // according to layers on map, and their range.

--- a/src/packages/Controls/LayerSwitcher/LayerSwitcher.js
+++ b/src/packages/Controls/LayerSwitcher/LayerSwitcher.js
@@ -309,7 +309,8 @@ class LayerSwitcher extends Control {
         // cette méthode est appelée
         // après un map.addControl() ou map.removeControl()
 
-        this.selectedLayer = null;
+        // Déselectionne la couche sélectionnée
+        this.getSelectedLayer() && this.setSelectedLayer(this.getSelectedLayer(), false);
 
         if (map) { // dans le cas de l'ajout du contrôle à la map
             // on ajoute les couches
@@ -1438,9 +1439,9 @@ class LayerSwitcher extends Control {
             this._layers[layerOptions.id].div = layerDiv;
         }
 
-        // Sélectionne la première couche
+        // Sélectionne la première couche (si aucune couche sélectionnée)
         const layerValues = Object.values(this._layers);
-        if (layerValues.length > 0) {
+        if (!this.getSelectedLayer() && layerValues.length > 0) {
             this.setSelectedLayer(layerValues[layerValues.length - 1].layer, true);
         }
     }

--- a/src/packages/Controls/LayerSwitcher/LayerSwitcher.js
+++ b/src/packages/Controls/LayerSwitcher/LayerSwitcher.js
@@ -309,6 +309,8 @@ class LayerSwitcher extends Control {
         // cette méthode est appelée
         // après un map.addControl() ou map.removeControl()
 
+        this.selectedLayer = null;
+
         if (map) { // dans le cas de l'ajout du contrôle à la map
             // on ajoute les couches
             this._addMapLayers(map);
@@ -1424,12 +1426,22 @@ class LayerSwitcher extends Control {
             var layerOptions = this._layersOrder[j];
             var layerDiv = this._createLayerDiv(layerOptions);
             layerDiv.dataset.sortableId = layerOptions.id;
+            const layerDivId = "#" + layerDiv.id;
             // on ajoute la div seulement si elle n'existe pas
-            if (!this._layerListContainer.querySelector("#" + layerDiv.id)) {
+            if (!this._layerListContainer.querySelector(layerDivId)) {
                 this._layerListContainer.appendChild(layerDiv);
+            } else {
+                // La div est déjà ajoutée, on la garde en mémoire
+                layerDiv = this._layerListContainer.querySelector(layerDivId);
             }
             // on stocke la div dans les options de la couche, pour une éventuelle réorganisation (setZIndex par ex)
             this._layers[layerOptions.id].div = layerDiv;
+        }
+
+        // Sélectionne la première couche
+        const layerValues = Object.values(this._layers);
+        if (layerValues.length > 0) {
+            this.setSelectedLayer(layerValues[layerValues.length - 1].layer, true);
         }
     }
 
@@ -2529,7 +2541,8 @@ class LayerSwitcher extends Control {
             if (options) {
                 const layer = this._layers[layerID].layer;
 
-                if (layer !== this.getSelectedLayer()) {
+                // Compare les gpLayerId au lieu de comparer les objets
+                if (layer.gpLayerId !== this.getSelectedLayer()?.gpLayerId) {
                     this.setSelectedLayer(layer, true);
                 }
             }

--- a/src/packages/Controls/SearchEngine/ParcelAdvancedSearch.js
+++ b/src/packages/Controls/SearchEngine/ParcelAdvancedSearch.js
@@ -1,4 +1,3 @@
-import def from "ajv/dist/vocabularies/discriminator";
 import InseeSearchService from "../../Services/InseeSearchService";
 import Helper from "../../Utils/Helper";
 import AbstractAdvancedSearch from "./AbstractAdvancedSearch";


### PR DESCRIPTION
Dans le fichier LayerSwitcher.js, les divs des couches sont créées à deux endroits :
- [`_addMapLayers(map)`](../blob/fix/selected-layer-layer-switcher/src/packages/Controls/LayerSwitcher/LayerSwitcher.js#L1310]), méthode privée appelée uniquement lors d'un [`setMap(map)`](../blob/fix/selected-layer-layer-switcher/src/packages/Controls/LayerSwitcher/LayerSwitcher.js#L316) (via `switcher.setMap(map)` ou `map.addControl(switcher)`) avec une carte existante
- `addLayer(layer, config)`, méthode publique permettant d'ajouter des couches au gestionnaire de couche. Cette méthode est notamment appelée directement via `map.addLayer(layer)` via un [écouteur d'événement générique](../blob/fix/selected-layer-layer-switcher/src/packages/Controls/LayerSwitcher/LayerSwitcher.js#L347)

Le problème rencontré est que si on retire toutes les couches de la carte et qu'on les ajoute avec un `map.addControl(switcher)`, il y'a un problème car dans `_addMapLayers`, si la div existe déjà, elle n'est pas ajoutée au DOM, mais **la div non ajoutée au DOM est enregistrée dans les options** (voir [L1431](../blob/fix/selected-layer-layer-switcher/src/packages/Controls/LayerSwitcher/LayerSwitcher.js#L1431)). Cela empêche notamment la visibilité des couches sélectionnées.

Par ailleurs, j'ai rajouté quelques lignes [à la fin de `_addMapLayers`](../blob/fix/selected-layer-layer-switcher/src/packages/Controls/LayerSwitcher/LayerSwitcher.js#1441) afin de sélectionner la première couche lorsqu'on les ajoute toutes au début.


Un import non utilisé dans [ParcelAdvancedSearch.js](../blob/fix/selected-layer-layer-switcher/src/packages/Controls/SearchEngine/ParcelAdvancedSearch.js) posait problème pour le npm run publish, je l'ai donc enlevé.