### PR TITLE
fix(layerswitcher): Bug sous chrome pour le drag des couches

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -36,6 +36,7 @@ Résolution d'alertes de sécurité remontées par codeQL.
   - Isocurve : correctif sur l'évenement de fin de traitement (#557)
   - Drawing : correctif sur l'ouverture du panneau de dessin (#557)
   - MousePosition : conservation de l'ordre lat/lon y/x pour l'affichage des coordonnées (#560)
+  - LayerSwitcher : correctif sur le drag n' drop en conflit avec le slider d'opacité (#562)
   
 * 🔒 [Security]
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.12-563",
+  "version": "1.0.0-beta.12-562",
   "date": "03/07/2026",
   "module": "src/index.js",
   "directories": {},

--- a/src/packages/Controls/LayerSwitcher/LayerSwitcherDOM.js
+++ b/src/packages/Controls/LayerSwitcher/LayerSwitcherDOM.js
@@ -18,7 +18,7 @@ var LayerSwitcherDOM = {
         if (checkDsfr()) {
             handleClass.push(".GPlayerDragNDrop");
         }
-        const forceFallback = !!navigator.userAgent.match(/chrome|chromium|crios/i);
+        // const forceFallback = !!navigator.userAgent.match(/chrome|chromium|crios/i);
 
         // Voir lien suivant pour dragndrop avec tab
         // https://robbymacdonell.medium.com/refactoring-a-sortable-list-for-keyboard-accessibility-2176b34a07f4
@@ -455,6 +455,15 @@ var LayerSwitcherDOM = {
         var container = document.createElement("div");
         container.id = this._addUID("GPlayerSwitcher_ID_" + obj.id);
         container.className = "GPlayerSwitcher_layer gpf-panel__content fr-modal__content draggable-layer";
+        container.ondragstart = (e) => {
+            // Empêche les problèmes sur Chrome
+            if (e.target.draggable === false) {
+                e.preventDefault();
+                e.stopImmediatePropagation();
+                e.stopPropagation();
+                return false;
+            }
+        };
 
         // ajout des outils basiques (visibility / layer name)
         container.appendChild(this._createBasicToolElement(obj, tooltips));


### PR DESCRIPTION
Probablement à cause de la librairie Sortablejs, sous Chrome et d'autres navigateurs, le comportement de drag (pour modifier la position des couches) s'effectuait aussi lors du déplacement du slider de l'opacité, au lieu de n'être effectif que lorsque l'on déplace la couche avec le bouton dragndrop ou via le titre. Pourtant, l'attribut `draggable="false"` était bien présent sur la div. Voir IGNF/cartes.gouv.fr-editeur-carto#145 pour avoir le contexte entier du problème.

La PR ajoute donc une vérification sur le conteneur (via l'écouteur `container.ondragstart`) et si l'élément a draggable="false", cela empêche la propagation de l'événement.

:warning: Avant de merge sur main, il serait intéressant de tester sur l'ensemble des navigateurs, à minima sous Windows. Les tests n'ont été effectué que sur Linux (Mozilla et Google Chrome).

Close IGNF/cartes.gouv.fr-editeur-carto#145