### PR TITLE
fix(SearchEngineAdvanced) : ajout d'événements homogènes

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -22,6 +22,7 @@ Résolution d'alertes de sécurité remontées par codeQL.
 * 🔨 [Changed]
 
   - Panoramax : possibilité de déclencher l'ouverture du _PhotoViewer_ programmatiquement (#550)
+  - SearchEngineAdvanced : ajout d'events sur l'ajout et la suppression de pop-up et de features et refacto de la geolocalisation (#565) 
 
 * 🔥 [Deprecated]
 
@@ -38,6 +39,7 @@ Résolution d'alertes de sécurité remontées par codeQL.
   - MousePosition : conservation de l'ordre lat/lon y/x pour l'affichage des coordonnées (#560)
   - LayerSwitcher : correctif sur le drag n' drop en conflit avec le slider d'opacité (#562)
   - ControlList : fixe l’événement change:collapsed (#561)
+  - SearchEngineAdvanced : refactorisation et amélioration de la géolocalisation et des mécanismes qui y sont liés (#565)
   
 * 🔒 [Security]
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.12-560",
-  "date": "24/06/2026",
+  "version": "1.0.0-beta.12-565",
+  "date": "03/07/2026",
   "module": "src/index.js",
   "directories": {},
   "engines": {

--- a/src/packages/Controls/SearchEngine/SearchEngineAdvanced.js
+++ b/src/packages/Controls/SearchEngine/SearchEngineAdvanced.js
@@ -172,11 +172,9 @@ class SearchEngineAdvanced extends Control {
      */
     _initEvents (options) {
         this.geolocation.on("change:position", () => {
-            const pt = new Point(this.geolocation.getPosition());
-            pt.transform("EPSG:4326", this.getMap().getView().getProjection());
-            const evt = this.createEvent(pt, "Ma localisation");
-            this.addResultToMap(evt);
-            this.dispatchEvent(evt);
+            const coords = this.geolocation.getPosition();
+            const content = "Ma localisation"
+            this._createMarker (coords, content);
             this.geolocation.setTracking(false);
         });
 
@@ -626,6 +624,20 @@ class SearchEngineAdvanced extends Control {
             }
         };
         return btn;
+    }
+
+    /**
+     * Positionne un marker sur la carte.
+     * @param {coords} coords - Coordonnées où positionner le marker
+     * @param {String} content - Contenu à afficher dans la popup
+     * @private
+     */
+    _createMarker (coords, content) {
+        const pt = new Point(coords);
+        pt.transform("EPSG:4326", this.getMap().getView().getProjection());
+        const evt = this.createEvent(pt, content);
+        this.addResultToMap(evt);
+        this.dispatchEvent(evt);
     }
 
     /**

--- a/src/packages/Controls/SearchEngine/SearchEngineAdvanced.js
+++ b/src/packages/Controls/SearchEngine/SearchEngineAdvanced.js
@@ -670,6 +670,7 @@ class SearchEngineAdvanced extends Control {
         locationBtn.addEventListener("click", () => {
             this.geolocation.setTracking(true);
             const onPosition = () => {
+                const position = this.geolocation.getPosition();
                 /**
                  * @event searchengineadvanced:geolocation:click
                  * @property {Object} type - event
@@ -680,16 +681,14 @@ class SearchEngineAdvanced extends Control {
                  *   console.log(e.coordinates);
                  * })
                 */
-                const position = this.geolocation.getPosition();
                 this.dispatchEvent({
                     type : "searchengineadvanced:geolocation:click",
                     coordinates : position
                 });
-                // On ne veut être notifié qu'une seule fois
-                this.geolocation.un("change:position", onPosition);
             };
-            this.geolocation.on("change:position", onPosition);
+            this.geolocation.once("change:position", onPosition);
         });
+
         return locationBtn;
     }
 

--- a/src/packages/Controls/SearchEngine/SearchEngineAdvanced.js
+++ b/src/packages/Controls/SearchEngine/SearchEngineAdvanced.js
@@ -174,7 +174,7 @@ class SearchEngineAdvanced extends Control {
         this.geolocation.on("change:position", () => {
             const coords = this.geolocation.getPosition();
             const content = "Ma localisation";
-            this._createMarker (coords, content, "geolocate");
+            this.createMarker (coords, content, "geolocate", true);
             this.geolocation.setTracking(false);
         });
 
@@ -223,9 +223,10 @@ class SearchEngineAdvanced extends Control {
      * Crée un événement de recherche à partir d'un objet (Feature ou Point).
      * @param {Object|Point|OlFeature} obj Objet à afficher (Feature ou Point)
      * @param {String} [info] Texte affiché dans la popup
+     * @param {Boolean} [center=true] Indique si le résultat doit être centré
      * @returns {Object} Événement normalisé de type "search"
      */
-    createEvent (obj, info) {
+    createEvent (obj, info, center) {
         let evt = obj;
         if (obj instanceof OlFeature) {
             evt = {
@@ -242,6 +243,7 @@ class SearchEngineAdvanced extends Control {
             evt.result.set("infoPopup", info);
         }
         evt.type = "search";
+        evt.center = center !== false; // center = true par défaut
         return evt;
     }
 
@@ -407,10 +409,10 @@ class SearchEngineAdvanced extends Control {
 
     /**
      * Ajoute les résultats (features) sur la carte et ajuste la vue.
-     * @param {Object} e Événement de recherche contenant result/extent
+     * @param {Object} e Événement de recherche contenant result/extent/center
      */
     addResultToMap (e) {
-        this._closePopup();
+        this._closePopup(e);
         this.layer.getSource().clear();
         let extent;
         if (!!e.result) {
@@ -423,7 +425,7 @@ class SearchEngineAdvanced extends Control {
             this.layer.getSource().addFeature(e.extent);
             extent = e.extent.getGeometry().getExtent();
         }
-        if (this.getMap()) {
+        if (this.getMap() && e.center !== false) {
             let view = this.getMap().getView();
             if (extent) {
                 view.fit(extent);
@@ -456,6 +458,7 @@ class SearchEngineAdvanced extends Control {
             this.setPopupContent(feature.get("infoPopup") || "");
             this.popup.set("feature", feature);
             this.popup.set("layer", this.layer);
+            this.popup.set("origin", feature.get("origin"));
         } else {
             this.popup.setPosition(undefined);
             this.setPopupContent("");
@@ -538,13 +541,18 @@ class SearchEngineAdvanced extends Control {
 
     /**
      * Ferme le popup et désélectionne la feature.
+     * @param {Object} evt - event ayant déclenché la fermeture de la popup
      * @returns {Boolean} false
      * @private
      */
-    _closePopup () {
+    _closePopup (evt) {
         this.selectInteraction.getFeatures().clear();
         if (this.popup !== null) {
             this.popup.setPosition(undefined);
+            this.dispatchEvent({
+                type : "searchengineadvanced:popup:close",
+                evt : evt
+            });
         }
         return false;
     }
@@ -631,9 +639,9 @@ class SearchEngineAdvanced extends Control {
      * @param {coords} coords - Coordonnées où positionner le marker
      * @param {String} content - Contenu à afficher dans la popup
      * @param {String} origin - Origine de la feature
-     * @private
+     * @param {Boolean} center - La vue se centre sur la feature ajoutée
      */
-    _createMarker (coords, content, origin) {
+    createMarker (coords, content, origin, center) {
         const pt = new Point(coords);
         pt.transform("EPSG:4326", this.getMap().getView().getProjection());
 
@@ -642,8 +650,8 @@ class SearchEngineAdvanced extends Control {
             f.set("origin", origin);
         }
 
-        const evt = this.createEvent(f, content);
-
+        const evt = this.createEvent(f, content, center);
+        
         this.addResultToMap(evt);
         this.dispatchEvent(evt);
     }
@@ -660,21 +668,26 @@ class SearchEngineAdvanced extends Control {
         locationBtn.addEventListener("click", () => {
             this.geolocation.setTracking(true);
             console.log("tracking", this.geolocation);
-            /**
-             * @event searchengineadvanced:geolocation:click
-             * @property {Object} type - event
-             * @property {Object} coordinates - coordinates
-             * @property {Object} target - instance SearchEngineAdvanced
-             * @example
-             * SearchEngineAdvanced.on("searchengineadvanced:geolocation:click", function (e) {
-             *   console.log(e.coordinates);
-             * })
-            */
-            const position = this.geolocation.getPosition();
-            this.dispatchEvent({
-                type : "searchengineadvanced:geolocation:click",
-                coordinates : position
-            });
+            const onPosition = () => {
+                /**
+                 * @event searchengineadvanced:geolocation:click
+                 * @property {Object} type - event
+                 * @property {Object} coordinates - coordinates
+                 * @property {Object} target - instance SearchEngineAdvanced
+                 * @example
+                 * SearchEngineAdvanced.on("searchengineadvanced:geolocation:click", function (e) {
+                 *   console.log(e.coordinates);
+                 * })
+                */
+                const position = this.geolocation.getPosition();
+                this.dispatchEvent({
+                    type : "searchengineadvanced:geolocation:click",
+                    coordinates : position
+                });
+                // On ne veut être notifié qu'une seule fois
+                this.geolocation.un("change:position", onPosition);
+            };
+            this.geolocation.on("change:position", onPosition);
         });
         return locationBtn;
     }

--- a/src/packages/Controls/SearchEngine/SearchEngineAdvanced.js
+++ b/src/packages/Controls/SearchEngine/SearchEngineAdvanced.js
@@ -173,7 +173,7 @@ class SearchEngineAdvanced extends Control {
     _initEvents (options) {
         this.geolocation.on("change:position", () => {
             const coords = this.geolocation.getPosition();
-            const content = "Ma localisation"
+            const content = "Ma localisation";
             this._createMarker (coords, content);
             this.geolocation.setTracking(false);
         });
@@ -578,9 +578,9 @@ class SearchEngineAdvanced extends Control {
             layer.getSource().removeFeature(f);
 
             this.dispatchEvent({
-                type : this.REMOVE_FEATURE_EVENT,
+                type : "searchengineadvanced:feature:remove",
                 feature : f,
-                layer : layer,
+                layer : layer
             });
 
             // Ferme le popup

--- a/src/packages/Controls/SearchEngine/SearchEngineAdvanced.js
+++ b/src/packages/Controls/SearchEngine/SearchEngineAdvanced.js
@@ -640,6 +640,21 @@ class SearchEngineAdvanced extends Control {
         locationBtn.addEventListener("click", () => {
             this.geolocation.setTracking(true);
             console.log("tracking", this.geolocation);
+            /**
+             * @event searchengineadvanced:geolocation:click
+             * @property {Object} type - event
+             * @property {Object} coordinates - coordinates
+             * @property {Object} target - instance SearchEngineAdvanced
+             * @example
+             * SearchEngineAdvanced.on("searchengineadvanced:geolocation:click", function (e) {
+             *   console.log(e.coordinates);
+             * })
+            */
+            const position = this.geolocation.getPosition();
+            this.dispatchEvent({
+                type : "searchengineadvanced:geolocation:click",
+                coordinates : position
+            });
         });
         return locationBtn;
     }

--- a/src/packages/Controls/SearchEngine/SearchEngineAdvanced.js
+++ b/src/packages/Controls/SearchEngine/SearchEngineAdvanced.js
@@ -4,6 +4,7 @@ import OlFeature from "ol/Feature";
 import Point from "ol/geom/Point";
 import SearchEngineGeocodeIGN from "./SearchEngineGeocodeIGN";
 import Helper from "../../Utils/Helper";
+import { sanitizeHtml } from "../../Utils/Sanitize";
 import Select, { SelectEvent } from "ol/interaction/Select";
 import Map from "ol/Map";
 
@@ -381,7 +382,6 @@ class SearchEngineAdvanced extends Control {
             // Notifie l'input du changement
             this.baseSearchEngine.input.dispatchEvent(new Event("input"));
             // Met le focus sur l'input
-            console.log("click");
             setTimeout(() => {
                 this.baseSearchEngine.input.focus();
             }, 50);
@@ -600,6 +600,7 @@ class SearchEngineAdvanced extends Control {
      * Crée un bouton personnalisé pour le popup.
      * @param {PopupButton} popupButton - Configuration du bouton.
      * @returns {HTMLButtonElement} Bouton HTML
+     * @private
      */
     _createCustomPopupButton (popupButton) {
         const btn = document.createElement("button");
@@ -640,6 +641,7 @@ class SearchEngineAdvanced extends Control {
      * @param {String} content - Contenu à afficher dans la popup
      * @param {String} origin - Origine de la feature
      * @param {Boolean} center - La vue se centre sur la feature ajoutée
+     * @public
      */
     createMarker (coords, content, origin, center) {
         const pt = new Point(coords);
@@ -649,8 +651,8 @@ class SearchEngineAdvanced extends Control {
         if (origin) {
             f.set("origin", origin);
         }
-
-        const evt = this.createEvent(f, content, center);
+        const cleanContent = sanitizeHtml(content);
+        const evt = this.createEvent(f, cleanContent, center);
         
         this.addResultToMap(evt);
         this.dispatchEvent(evt);
@@ -667,7 +669,6 @@ class SearchEngineAdvanced extends Control {
         locationBtn.className = "GPSearchEngine-locate fr-btn fr-btn--sm fr-icon-crosshair-2-line fr-btn--icon-left fr-btn--tertiary-no-outline";
         locationBtn.addEventListener("click", () => {
             this.geolocation.setTracking(true);
-            console.log("tracking", this.geolocation);
             const onPosition = () => {
                 /**
                  * @event searchengineadvanced:geolocation:click

--- a/src/packages/Controls/SearchEngine/SearchEngineAdvanced.js
+++ b/src/packages/Controls/SearchEngine/SearchEngineAdvanced.js
@@ -174,7 +174,7 @@ class SearchEngineAdvanced extends Control {
         this.geolocation.on("change:position", () => {
             const coords = this.geolocation.getPosition();
             const content = "Ma localisation";
-            this._createMarker (coords, content);
+            this._createMarker (coords, content, "geolocate");
             this.geolocation.setTracking(false);
         });
 
@@ -630,12 +630,20 @@ class SearchEngineAdvanced extends Control {
      * Positionne un marker sur la carte.
      * @param {coords} coords - Coordonnées où positionner le marker
      * @param {String} content - Contenu à afficher dans la popup
+     * @param {String} origin - Origine de la feature
      * @private
      */
-    _createMarker (coords, content) {
+    _createMarker (coords, content, origin) {
         const pt = new Point(coords);
         pt.transform("EPSG:4326", this.getMap().getView().getProjection());
-        const evt = this.createEvent(pt, content);
+
+        const f = new OlFeature(pt);
+        if (origin) {
+            f.set("origin", origin);
+        }
+
+        const evt = this.createEvent(f, content);
+
         this.addResultToMap(evt);
         this.dispatchEvent(evt);
     }


### PR DESCRIPTION
fix #564 


## Résumé de la PR

Cette PR corrige l'implémentation des événements du composant `SearchEngineAdvanced` pour les rendre homogènes et compatibles avec le widget `SearchEngine` existant (#564).

### Problème
Le composant `SearchEngineAdvanced` n'implémentait pas les événements utilisés par l'entité carto, notamment :
- `searchengineadvanced:search:click`
- `searchengineadvanced:autocomplete:click`
- `searchengineadvanced:geocode:click`
- `searchengineadvanced:coordinates:click`
- `searchengineadvanced:geolocation:click`
- `searchengineadvanced:geolocation:remove`

### Solution
La PR introduit :

1. **Événement de géolocalisation** : Ajout de l'événement `searchengineadvanced:geolocation:click` lors de l'obtention de la position GPS
2. **Événement de fermeture de popup** : Ajout de `searchengineadvanced:popup:close` quand le popup est fermé
3. **Événement de suppression de feature** : Normalisation en `searchengineadvanced:feature:remove`
4. **Nouvelle méthode `createMarker()`** : Factorisation du code pour une meilleure maintenabilité
5. **Paramètre `center` optionnel** : Permet de contrôler si la vue doit se centrer sur le résultat
6. **Meilleure gestion de l'origine** : Les features gardent trace de leur origine (géolocalisation, recherche, etc.)



PR liée côté entree carto : https://github.com/IGNF/cartes.gouv.fr-entree-carto/pull/1155
