### PR TITLE
fix: Initialisation des composants dans le constructeur (fix #568)

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -52,6 +52,7 @@ __DATE__
   - ControlList : fixe l’événement change:collapsed (#561)
   - SearchEngineAdvanced : refactorisation et amélioration de la géolocalisation et des mécanismes qui y sont liés (#565)
   - Tooltip : affichage des tooltip DSFR au survol ainsi qu'au focus (#515)
+  - Zoom/OverviewMap/Fullscreen : initialisation du composant dans le constructeur (fix #568) (#570)
   
 * 🔒 [Security]
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.12-567",
+  "version": "1.0.0-beta.12-570",
   "date": "16/07/2026",
   "module": "src/index.js",
   "main": "src/index.js",

--- a/src/packages/Controls/FullScreen/GeoportalFullScreen.js
+++ b/src/packages/Controls/FullScreen/GeoportalFullScreen.js
@@ -46,6 +46,7 @@ class GeoportalFullScreen extends FullScreen {
         this.CLASSNAME = "FullScreen";
         this.container = null;
         this.options = options;
+        this._initContainer();
     }
 
     /**
@@ -129,7 +130,6 @@ class GeoportalFullScreen extends FullScreen {
     setMap (map) {
         if (map) {
             this._createContainerPosition(map);
-            this._initContainer();
             // INFO
             // on ne supprime pas le zoom par defaut,
             // on le desactive simplement pour éviter des effets de bords

--- a/src/packages/Controls/OverviewMap/GeoportalOverviewMap.js
+++ b/src/packages/Controls/OverviewMap/GeoportalOverviewMap.js
@@ -286,6 +286,7 @@ class GeoportalOverviewMap extends OverviewMap {
         this.CLASSNAME = "OverviewMap";
         this.container = null;
         this.options = options;
+        this._initContainer();
     }
 
     /**
@@ -383,7 +384,6 @@ class GeoportalOverviewMap extends OverviewMap {
     setMap (map) {
         if (map) {
             this._createContainerPosition(map);
-            this._initContainer();
             if (this.options.disableOverviewDragging) {
                 const ovDiv = this.ovmapDiv_;
                 if (ovDiv) {

--- a/src/packages/Controls/Zoom/GeoportalZoom.js
+++ b/src/packages/Controls/Zoom/GeoportalZoom.js
@@ -44,6 +44,7 @@ class GeoportalZoom extends Zoom {
 
         this.container = null;
         this.options = options;
+        this._initContainer();
     }
 
     /**
@@ -154,7 +155,6 @@ class GeoportalZoom extends Zoom {
     setMap (map) {
         if (map) {
             this._createContainerPosition(map);
-            this._initContainer();
             // INFO
             // on ne supprime pas le zoom par defaut,
             // on le desactive simplement pour éviter des effets de bords


### PR DESCRIPTION
Fixe l'issue #568
Le soucis se pose quand on ajoute/enlève le contrôle plusieurs fois

- déplacement de la fonction `initContainer` de `setMap` vers le constructeur.