### PR TITLE
LayerImport: fixe la hauteur et déplace le bouton retour

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -26,6 +26,8 @@ __DATE__
 
 * 🐛 [Fixed]
 
+  - LayerImport : fixe la hauteur du contenu dans certains cas (#575)
+
 * 🔒 [Security]
 
 ---

--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -18,6 +18,7 @@ __DATE__
 * 🔨 [Changed]
 
   - Tooltips : les tooltips au survol des boutons ne peuvent pas être survolées (#571)
+  - LayerImport : le bouton retour est inclut dans le panel header (#575)
 
 * 🔥 [Deprecated]
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.13-571",
-  "date": "17/07/2026",
+  "version": "1.0.0-beta.13-575",
+  "date": "26/08/2026",
   "module": "src/index.js",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/src/packages/Controls/LayerImport/LayerImport.js
+++ b/src/packages/Controls/LayerImport/LayerImport.js
@@ -742,19 +742,26 @@ class LayerImport extends Control {
             icon : "ign-layerimport",
             title : "Import de données",
             btnClassForClose : "GPshowImportPicto",
+            backBtn : true,
         });
 
         importPanel.appendChild(panelHeader);
         importPanel.appendChild(importPanelPanelDiv);
 
-        // return
-        var panelReturn = this._importPanelReturnPicto = this._createImportPanelReturnPictoElement();
-        importPanelPanelDiv.appendChild(panelReturn);
-
         // panel title
         this._importPanelTitle = panelHeader._title;
         // close picto
         this._panelCloseButton = panelHeader._closeBtn;
+        // return btn
+        this._importPanelReturnPicto = panelHeader._backBtn;
+        this._importPanelReturnPicto.addEventListener("click", (e) => {
+            // on ferme le panneau
+            document.getElementById(this._addUID("GPshowImportPicto")).click();
+            // on nettoie la fenêtre de résultats
+            this._onReturnPictoClick(e);
+            // on rouvre le panneau vierge
+            document.getElementById(this._addUID("GPshowImportPicto")).click();
+        });
 
         // form : initialisation du formulaire d'import des couches (types d'import et saisie de l'url / du fichier)
         var importForm = this._formContainer = this._initInputFormElement();
@@ -966,8 +973,7 @@ class LayerImport extends Control {
     _onMapBoxPanelClose () {
         this.cleanMapBoxResultsList();
         this._loadingContainer.className = "";
-        this._importPanelReturnPicto.classList.replace("GPelementVisible", "GPelementHidden");
-        this._importPanelReturnPicto.classList.replace("gpf-visible", "gpf-hidden");
+        this._importPanelReturnPicto.classList.add("GPelementHidden", "gpf-hidden");
         this._mapBoxPanel.classList.replace("GPelementVisible", "GPelementHidden");
         this._mapBoxPanel.classList.replace("gpf-visible", "gpf-hidden");
     }
@@ -1570,8 +1576,7 @@ class LayerImport extends Control {
                                                 self._importPanelHeader.classList.replace("gpf-hidden", "gpf-visible");
                                                 self._mapBoxPanel.classList.replace("GPelementHidden", "GPelementVisible");
                                                 self._mapBoxPanel.classList.replace("gpf-hidden", "gpf-visible");
-                                                self._importPanelReturnPicto.classList.replace("GPelementHidden", "GPelementVisible");
-                                                self._importPanelReturnPicto.classList.replace("gpf-hidden", "gpf-visible");
+                                                self._importPanelReturnPicto.classList.remove("GPelementHidden", "gpf-hidden");
                                             }
                                         })
                                         .then(function () {
@@ -2267,8 +2272,7 @@ class LayerImport extends Control {
         this._getCapPanel.classList.replace("GPelementHidden", "GPelementVisible");
         this._getCapPanel.classList.replace("gpf-hidden", "gpf-visible");
         this._importPanelTitle.innerHTML = "Couches accessibles";
-        this._importPanelReturnPicto.classList.replace("GPelementHidden", "GPelementVisible");
-        this._importPanelReturnPicto.classList.replace("gpf-hidden", "gpf-visible");
+        this._importPanelReturnPicto.classList.remove("GPelementHidden", "gpf-hidden");
         this._hasGetCapResults = true;
         // Parse GetCapabilities Response
         if (this._currentImportType === "WMS") {

--- a/src/packages/Controls/LayerImport/LayerImportDOM.js
+++ b/src/packages/Controls/LayerImport/LayerImportDOM.js
@@ -106,44 +106,6 @@ var LayerImportDOM = {
         return div;
     },
 
-    /**
-     * Create Return PIcto into Panel
-     *
-     * @returns {HTMLElement} DOM element
-     */
-    _createImportPanelReturnPictoElement : function () {
-        var self = this;
-        // return picto
-        var returnDiv = document.createElement("button");
-        returnDiv.id = this._addUID("GPimportPanelReturnPicto");
-        returnDiv.title = "Masquer le panneau";
-        returnDiv.className = "GPreturnPicto GPimportPanelReturnPicto GPelementHidden gpf-hidden gpf-btn gpf-btn-icon-return fr-btn fr-btn--close fr-btn--tertiary-no-outline";
-        
-        if (checkDsfr()) {
-            var returnSpan = document.createElement("span");
-            returnSpan.className = "GPelementHidden";
-            returnSpan.innerHTML = "Retour";
-            returnDiv.appendChild(returnSpan);
-        }
-        if (returnDiv.addEventListener) {
-            returnDiv.addEventListener("click", function (e) {
-                // on ferme le panneau
-                document.getElementById(self._addUID("GPshowImportPicto")).click();
-                // on nettoie la fenêtre de résultats
-                self._onReturnPictoClick(e);
-                // on rouvre le panneau vierge
-                document.getElementById(self._addUID("GPshowImportPicto")).click();
-            });
-        } else if (returnDiv.attachEvent) {
-            returnDiv.attachEvent("onclick", function (e) {
-                document.getElementById(self._addUID("GPshowImportPicto")).click();
-                self._onReturnPictoClick(e);
-                document.getElementById(self._addUID("GPshowImportPicto")).click();
-            });
-        }
-        return returnDiv;
-    },
-
     // ################################################################### //
     // ########################### Form panel ############################ //
     // ################################################################### //

--- a/src/packages/Controls/LayerImport/LayerImportDOM.js
+++ b/src/packages/Controls/LayerImport/LayerImportDOM.js
@@ -547,7 +547,7 @@ var LayerImportDOM = {
     _createImportGetCapPanelElement : function () {
         var div = document.createElement("div");
         div.id = this._addUID("GPimportGetCapPanel");
-        div.className = "GPpanel GPelementHidden gpf-panel fr-modal gpf-hidden";
+        div.className = "GPpanel GPelementHidden gpf-hidden";
         return div;
     },
 
@@ -609,7 +609,7 @@ var LayerImportDOM = {
      */
     _createImportGetCapResultsContainer : function () {
         var container = document.createElement("div");
-        container.className = "GPimportGetCapRoot gpf-panel__list";
+        container.className = "GPimportGetCapRoot";
         container.id = this._addUID("GPimportGetCapResults");
 
         return container;
@@ -689,7 +689,7 @@ var LayerImportDOM = {
     _createImportMapBoxPanelElement : function () {
         var div = document.createElement("div");
         div.id = this._addUID("GPimportMapBoxPanel");
-        div.className = "GPpanel GPelementHidden gpf-panel fr-modal gpf-hidden";
+        div.className = "GPpanel GPelementHidden gpf-hidden";
         return div;
     },
 


### PR DESCRIPTION
- déplacement du bouton retour dans le header du panel

<img width="352" height="194" alt="image" src="https://github.com/user-attachments/assets/f28e35bd-e8aa-4547-8bf0-0228f26d9f83" />

- empêche le body du panel d'avoir une hauteur nulle dans certains cas (lié à ignf/cartes.gouv.fr-entree-carto#1196)