### PR TITLE
feat(SearchEngineAdvanced): advanced search select extent

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -20,6 +20,7 @@ __DATE__
   - Tooltips : les tooltips au survol des boutons ne peuvent pas être survolées (#571)
   - LayerImport : le bouton retour est inclut dans le panel header (#575)
   - GFI : activation du GFI au clic gauche et selon panels incompatibles (#1167)
+  - SearchBar : option selectGeometry : permet de sélectionner uniquement l'extent plutot que le point si existant (besoin extraction)
 
 * 🔥 [Deprecated]
 

--- a/samples-src/pages/tests/SearchEngine/pages-ol-searchenginebase-modules-dsfr-geocodeAdvanced.html
+++ b/samples-src/pages/tests/SearchEngine/pages-ol-searchenginebase-modules-dsfr-geocodeAdvanced.html
@@ -90,6 +90,7 @@
                     var search = new ol.control.SearchEngineAdvanced({
                         advancedSearch : [insee, location, coordinates, parcel],
                         returnTrueGeometry : true,
+                        selectGeometry : 'extent',
                         autocompleteOptions : {
                             serviceOptions : {
                                 maximumResponses : 10

--- a/src/packages/Controls/SearchEngine/SearchEngineAdvanced.js
+++ b/src/packages/Controls/SearchEngine/SearchEngineAdvanced.js
@@ -2,6 +2,7 @@ import Control from "../Control";
 import Geolocation from "ol/Geolocation";
 import OlFeature from "ol/Feature";
 import Point from "ol/geom/Point";
+import { getCenter } from "ol/extent";
 import SearchEngineGeocodeIGN from "./SearchEngineGeocodeIGN";
 import Helper from "../../Utils/Helper";
 import { sanitizeHtml } from "../../Utils/Sanitize";
@@ -119,6 +120,12 @@ class SearchEngineAdvanced extends Control {
          * @type {Boolean}
          */
         this.listenToClick = false;
+
+        /**
+         * Géométrie sélectionnée après une recherche.
+         * @type {String}
+         */
+        this.selectGeometry = options.selectGeometry === "extent" ? "extent" : "point";
 
         if (options.advancedSearch && options.advancedSearch instanceof Array) {
             this._searchForms = options.advancedSearch;
@@ -415,15 +422,22 @@ class SearchEngineAdvanced extends Control {
         this._closePopup(e);
         this.layer.getSource().clear();
         let extent;
+        let selectedFeature;
         if (!!e.result) {
             this.layer.getSource().addFeature(e.result);
             extent = e.result.getGeometry().getExtent();
-            this.selectInteraction.getFeatures().push(e.result);
-            this._setPopupInfo(e.result);
-        }
+            selectedFeature = e.result;
+        }SearchEngineAdvanced
         if (!!e.extent) {
             this.layer.getSource().addFeature(e.extent);
             extent = e.extent.getGeometry().getExtent();
+            if (this.selectGeometry === "extent") {
+                selectedFeature = e.extent;
+            }
+        }
+        if (selectedFeature) {
+            this.selectInteraction.getFeatures().push(selectedFeature);
+            this._setPopupInfo(selectedFeature);
         }
         if (this.getMap() && e.center !== false) {
             let view = this.getMap().getView();
@@ -447,11 +461,14 @@ class SearchEngineAdvanced extends Control {
             this.popup.setPosition(undefined);
             let offset = null;
             // Ajoute le popup
-            if (feature.getGeometry()?.getType() === "Point") {
+            const geometry = feature.getGeometry();
+            if (geometry?.getType() === "Point") {
                 // Place le popup sur le point
-                position = feature.getGeometry()?.getCoordinates();
+                position = geometry.getCoordinates();
                 // TODO : AMÉLIORER L'OFFSET
                 offset = [0, -20];
+            } else if (!position && geometry) {
+                position = geometry.getInteriorPoint?.()?.getCoordinates() || getCenter(geometry.getExtent());
             }
             this.popup.setPosition(position);
             offset && this.popup.setOffset(offset);
@@ -659,7 +676,7 @@ class SearchEngineAdvanced extends Control {
     }
 
     /**
-     * Crée le bouton de géolocalisation.
+            if (!!e.result && (this.selectGeometry !== "extent" || !e.extent)) {
      * @returns {HTMLButtonElement} Bouton de géolocalisation
      * @private
      */

--- a/src/packages/Controls/SearchEngine/SearchEngineAdvanced.js
+++ b/src/packages/Controls/SearchEngine/SearchEngineAdvanced.js
@@ -423,11 +423,13 @@ class SearchEngineAdvanced extends Control {
         this.layer.getSource().clear();
         let extent;
         let selectedFeature;
-        if (!!e.result) {
+
+        // Ajoute le résultat principal sauf si seule l'emprise doit être affichée.
+        if (!!e.result && (this.selectGeometry !== "extent" || !e.extent)) {
             this.layer.getSource().addFeature(e.result);
             extent = e.result.getGeometry().getExtent();
             selectedFeature = e.result;
-        }SearchEngineAdvanced
+        }
         if (!!e.extent) {
             this.layer.getSource().addFeature(e.extent);
             extent = e.extent.getGeometry().getExtent();

--- a/src/packages/Controls/SearchEngine/SearchEngineAdvanced.js
+++ b/src/packages/Controls/SearchEngine/SearchEngineAdvanced.js
@@ -678,7 +678,7 @@ class SearchEngineAdvanced extends Control {
     }
 
     /**
-            if (!!e.result && (this.selectGeometry !== "extent" || !e.extent)) {
+     * Crée le bouton de géolocalisation.
      * @returns {HTMLButtonElement} Bouton de géolocalisation
      * @private
      */

--- a/src/packages/Controls/SearchEngine/typedefs.js
+++ b/src/packages/Controls/SearchEngine/typedefs.js
@@ -157,6 +157,7 @@
  * @property {String} [label] - Label affiché.
  * @property {String} [hint] - Texte d'aide.
  * @property {Boolean} [search] - Comportement en tant que barre de recherche.
+ * @property {String} [selectGeometry="point"] - Géométrie sélectionnée après une recherche ("point" ou "extent").
  * @property {String} [ariaLabel] - Libellé ARIA.
  * @property {String} [placeholder] - Placeholder de l'input.
  * @property {Number} [minChars] - Nombre minimal de caractères pour autocomplétion.


### PR DESCRIPTION
Ajout d'une option selectGeometry 

On peut choisir 'extent' ou 'point'

Si extent est choisie, alors l'outil sélectionne plutot l'emprise du résultat, si elle existe, et n'affiche que celle-ci
