### PR TITLE
evol(GFI) : gfi évolution de l'activation

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -19,6 +19,7 @@ __DATE__
 
   - Tooltips : les tooltips au survol des boutons ne peuvent pas être survolées (#571)
   - LayerImport : le bouton retour est inclut dans le panel header (#575)
+  - GFI : activation du GFI au clic gauche et selon panels incompatibles (#1167)
 
 * 🔥 [Deprecated]
 

--- a/samples-src/pages/tests/ContextMenu/pages-ol-modules-contextmenu-dsfr.html
+++ b/samples-src/pages/tests/ContextMenu/pages-ol-modules-contextmenu-dsfr.html
@@ -164,6 +164,8 @@
                 map.addControl(catalog);
                 var getFeatureInfo = new ol.control.GetFeatureInfo({
                   position : "bottom-left",
+                    button: true,
+                    active : true,
                 });
                 map.addControl(getFeatureInfo);
         };

--- a/samples-src/pages/tests/GetFeatureInfo/pages-ol-getfeatureinfo-modules-options-active-dsfr.html
+++ b/samples-src/pages/tests/GetFeatureInfo/pages-ol-getfeatureinfo-modules-options-active-dsfr.html
@@ -7,6 +7,18 @@
         <script src="{{ baseurl }}/dist/modules/GpfExtOlGetFeatureInfo.js"></script>
         <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlDrawing.css" />
         <script src="{{ baseurl }}/dist/modules/GpfExtOlDrawing.js"></script>
+        <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlIsocurve.css" />
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlIsocurve.js"></script>
+        <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlRoute.css" />
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlRoute.js"></script>
+        <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlElevationPath.css" />
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlElevationPath.js"></script>
+        <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlMeasureLength.css" />
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlMeasureLength.js"></script>
+        <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlMeasureArea.css" />
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlMeasureArea.js"></script>
+        <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlMeasureAzimuth.css" />
+        <script src="{{ baseurl }}/dist/modules/GpfExtOlMeasureAzimuth.js"></script>
         <script src="{{ baseurl }}/dist/modules/GpfExtOlLayers.js"></script>
 {{/content}}
 
@@ -96,6 +108,42 @@
                 position : "top-left"
             });
             map.addControl(drawing);
+
+            var iso = new ol.control.Isocurve({
+                collapsed : true,
+                position : "top-left"
+            });
+            map.addControl(iso);
+
+            var route = new ol.control.Route({
+                collapsed : true,
+                position : "top-left"
+            });
+            map.addControl(route);
+
+            var elevationPath = new ol.control.ElevationPath({
+                collapsed : true,
+                position : "top-left"
+            });
+            map.addControl(elevationPath);
+
+            var measureLength = new ol.control.MeasureLength({
+                collapsed : true,
+                position : "top-left"
+            });
+            map.addControl(measureLength);
+
+            var measureArea = new ol.control.MeasureArea({
+                collapsed : true,
+                position : "top-left"
+            });
+            map.addControl(measureArea);
+
+            var measureAzimuth = new ol.control.MeasureAzimuth({
+                collapsed : true,
+                position : "top-left"
+            });
+            map.addControl(measureAzimuth);
 
             var getFeatureInfo = new ol.control.GetFeatureInfo({
                 position : "bottom-left",

--- a/samples-src/pages/tests/GetFeatureInfo/pages-ol-getfeatureinfo-modules-options-active-dsfr.html
+++ b/samples-src/pages/tests/GetFeatureInfo/pages-ol-getfeatureinfo-modules-options-active-dsfr.html
@@ -1,7 +1,6 @@
 {{#extend "ol-sample-modules-dsfr-layout"}}
 
 {{#content "vendor"}}
-                 
         <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlLayerSwitcher.css" />
         <script src="{{ baseurl }}/dist/modules/GpfExtOlLayerSwitcher.js"></script>
         <link rel="stylesheet" href="{{ baseurl }}/dist/modules/GpfExtOlGetFeatureInfo.css" />
@@ -12,7 +11,7 @@
 {{/content}}
 
 {{#content "head"}}
-        <title>Sample openlayers GetFeatureInfo</title>
+        <title>Sample OpenLayers GetFeatureInfo actif sans bouton</title>
 {{/content}}
 
 {{#content "style"}}
@@ -28,10 +27,8 @@
 {{/content}}
 
 {{#content "body"}}
-            <h2>Ajout des widgets GetFeatureInfo et Drawing avec DSFR</h2>
-            <!-- map -->
-            <div id="map">
-            </div>
+            <h2>GetFeatureInfo actif sans bouton et outils Drawing avec DSFR</h2>
+            <div id="map"></div>
             <button type="button" id="addVectorKml">Ajouter une couche vecteur kml</button>
             <button type="button" id="addVectorGpx">Ajouter une couche vecteur gpx</button>
             <button type="button" id="addWms">Ajouter une couche WMS</button>
@@ -44,7 +41,6 @@
         var createMap = function () {
             document.getElementById('map').style.backgroundImage = 'none';
 
-            // 1. Création de la map
             map = new ol.Map({
                 target : "map",
                 view : new ol.View({
@@ -53,7 +49,6 @@
                 })
             });
 
-            // 2. Ajout de plusieurs couches différentes.
             var gpMaps = new ol.layer.Tile({
                 source : new ol.source.GeoportalWMTS({
                     layer: "GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2"
@@ -96,122 +91,77 @@
             });
             map.addLayer(mapbox);
 
-            // 3. Ajout des outils de dessin
             var drawing = new ol.control.Drawing({
                 collapsed : false,
-                position : "bottom-right"
+                position : "top-left"
             });
             map.addControl(drawing);
-            
-            // 4. Ajout du GetFeatureInfo
+
             var getFeatureInfo = new ol.control.GetFeatureInfo({
-                position: "bottom-left",
-                button: true,
+                position : "bottom-left",
+                button : false,
                 active : true,
                 noDataMessage : "<h6 style='text-align: center;'> Pas d'infos disponibles </h6> <p style='text-align: center;'> Il n'y a pas de données interrogeables ici </p>"
             });
             map.addControl(getFeatureInfo);
 
-            // 4. Quelques évènements pour tester...
-            document.getElementById("addVectorKml").onclick = function(e) {
-                if ( !this.kmlUrls )
-                {
-                  this.kmlUrls = [
+            document.getElementById("addVectorKml").onclick = function() {
+                var kmlUrls = [
                     '{{ resources }}/data/kml/bassin_bleu.kml',
                     '{{ resources }}/data/kml/croquis-simple.kml'
-                  ];
-                }
-                if ( !this.index )
-                {
+                ];
+                this.index = (this.index || 0) + 1;
+                if (this.index === kmlUrls.length) {
                     this.index = 0;
                 }
-                ++this.index;
-                if ( this.index ==  this.kmlUrls.length ) {
-                    this.index = 0;
-                }
-                map.addLayer(
-                    new ol.layer.Vector({
-                        source: new ol.source.Vector({
-                            url: this.kmlUrls[this.index],
-                            format: new ol.format.KML()
-                        })
+                map.addLayer(new ol.layer.Vector({
+                    source: new ol.source.Vector({
+                        url: kmlUrls[this.index],
+                        format: new ol.format.KML()
                     })
-                );
-            }
+                }));
+            };
 
-            document.getElementById("addVectorGpx").onclick = function(e) {
-                if ( !this.gpxUrls )
-                {
-                  this.gpxUrls = [
-                    '{{ resources }}/data/gpx/Campomoro-Tizzano-Sartene_3029.gpx',
-                  ];
-                }
-                if ( !this.index )
-                {
+            document.getElementById("addVectorGpx").onclick = function() {
+                var gpxUrls = ['{{ resources }}/data/gpx/Campomoro-Tizzano-Sartene_3029.gpx'];
+                this.index = (this.index || 0) + 1;
+                if (this.index === gpxUrls.length) {
                     this.index = 0;
                 }
-                ++this.index;
-                if ( this.index ==  this.gpxUrls.length ) {
-                    this.index = 0;
-                }
-                map.addLayer(
-                    new ol.layer.Vector({
-                        source: new ol.source.Vector({
-                            url: this.gpxUrls[this.index],
-                            format: new ol.format.GPX()
-                        })
+                map.addLayer(new ol.layer.Vector({
+                    source: new ol.source.Vector({
+                        url: gpxUrls[this.index],
+                        format: new ol.format.GPX()
                     })
-                );
-            }
-            document.getElementById("addWms").onclick = function(e) {
-                if ( !this.wmsLayers )
-                {
-                  this.wmsLayers = [
-                    "TN.RoadTransportNetwork",
-                    "HY.PhysicalWaters"
-                  ];
-                }
-                if ( !this.index )
-                {
-                    this.index = 0;
-                }
-                ++this.index;
-                if ( this.index ==  this.wmsLayers.length ) {
-                    this.index = 0;
-                }
-                map.addLayer(
-                    new ol.layer.Tile({
-                        source : new ol.source.GeoportalWMS({
-                            layer: this.wmsLayers[this.index]
-                        })
-                    })
-                );
-            }
-            document.getElementById("addWtms").onclick = function(e) {
-                if ( !this.wtmsLayers )
-                {
-                  this.wtmsLayers = [
-                    "GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2"
-                  ];
-                }
-                if ( !this.index )
-                {
-                    this.index = 0;
-                }
-                ++this.index;
-                if ( this.index ==  this.wtmsLayers.length ) {
-                    this.index = 0;
-                }
-                map.addLayer(
-                    new ol.layer.Tile({
-                        source : new ol.source.GeoportalWMTS({
-                            layer: this.wtmsLayers[this.index]
-                        })
-                    })
-                );
-            }
+                }));
+            };
 
-            // 5. Ajout du contrôle de gestion de l'empilement des couches (layerSwitcher)
+            document.getElementById("addWms").onclick = function() {
+                var wmsLayers = ["TN.RoadTransportNetwork", "HY.PhysicalWaters"];
+                this.index = (this.index || 0) + 1;
+                if (this.index === wmsLayers.length) {
+                    this.index = 0;
+                }
+                map.addLayer(new ol.layer.Tile({
+                    source : new ol.source.GeoportalWMS({
+                        layer: wmsLayers[this.index]
+                    })
+                }));
+            };
+
+            document.getElementById("addWtms").onclick = function() {
+                var wtmsLayers = ["GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2"];
+                this.index = (this.index || 0) + 1;
+                if (this.index === wtmsLayers.length) {
+                    this.index = 0;
+                }
+                map.addLayer(new ol.layer.Tile({
+                    source : new ol.source.GeoportalWMTS({
+                        layer: wtmsLayers[this.index]
+                    })
+                }));
+            };
+
             var layerSwitcher = new ol.control.LayerSwitcher({
                 options : {
                     collapsed: false,
@@ -223,7 +173,6 @@
         Gp.Services.getConfig({
             customConfigFile : "{{ configurl }}",
             callbackSuffix : "",
-            // apiKey: "{{ apikey }}",
             timeOut : 20000,
             onSuccess : createMap,
             onFailure : (e) => {

--- a/src/packages/Controls/ContextMenu/ContextMenu.js
+++ b/src/packages/Controls/ContextMenu/ContextMenu.js
@@ -496,12 +496,8 @@ class ContextMenu extends Control {
     getFeatureInfo (evt) {
         var gfi = this.getMap().getControls().getArray().filter(control => control.CLASSNAME == "GetFeatureInfo")[0];
         // Enregistrement de l'état actif ou non du GFI
-        var activatedGFI;
-        if (gfi.buttonGetFeatureInfoShow.getAttribute("aria-pressed") === "false") {
-            activatedGFI = false;
-        }
-        gfi.buttonGetFeatureInfoShow.click();
-        gfi.buttonGetFeatureInfoShow.setAttribute("aria-pressed", true);
+        var activatedGFI = gfi.getActive();
+        gfi.setActive(true);
         let pixel = this.getMap().getPixelFromCoordinate(evt.coordinate);
         let fakeEvent = {
             pixel : pixel,
@@ -510,8 +506,8 @@ class ContextMenu extends Control {
         };
         this.getMap().dispatchEvent({ type : "singleclick", ...fakeEvent });
         // on re-désactive le bouton GFI s'il était désactivé
-        if (activatedGFI === false) {
-            gfi.buttonGetFeatureInfoShow.setAttribute("aria-pressed", false);
+        if (!activatedGFI) {
+            gfi.setActive(false);
         }
     }
 

--- a/src/packages/Controls/Drawing/Drawing.js
+++ b/src/packages/Controls/Drawing/Drawing.js
@@ -2140,6 +2140,7 @@ class Drawing extends Control {
             if (this.popupOvl) {
                 this.getMap().removeOverlay(this.popupOvl);
             }
+            this.onPanelClose();
         }
         
         this.disable();

--- a/src/packages/Controls/ElevationPath/ElevationPath.js
+++ b/src/packages/Controls/ElevationPath/ElevationPath.js
@@ -1668,6 +1668,8 @@ class ElevationPath extends Control {
         var opened = this._pictoButton.ariaPressed;
         if (opened === "true") {
             this.onPanelOpen();
+        } else {
+            this.onPanelClose();
         }
 
         var map = this.getMap();

--- a/src/packages/Controls/GetFeatureInfo/GetFeatureInfo.js
+++ b/src/packages/Controls/GetFeatureInfo/GetFeatureInfo.js
@@ -38,6 +38,8 @@ class GetFeatureInfo extends Control {
     /**
      * @constructor
     * @param {Object} options - options for function call.
+    * @param {Boolean} [options.button = true] - display the activation button. If false, the control is active by default.
+    * @param {Boolean} [options.active] - set the initial active state. This value takes precedence over the button default.
     * @example
     * var getFeatureInfo = new ol.control.GetFeatureInfo();
     * map.addControl(getFeatureInfo);
@@ -87,8 +89,8 @@ class GetFeatureInfo extends Control {
                 );
             }
             // mode "collapsed"
-            if (!this.collapsed) {
-                this.buttonGetFeatureInfoShow.setAttribute("aria-pressed", true);
+            if (!this.collapsed && !this.activeExplicit && this.buttonGetFeatureInfoShow) {
+                this.setActive(true);
             }
 
             // some stuff
@@ -123,6 +125,28 @@ class GetFeatureInfo extends Control {
     // ################### getters / setters ############################# //
     // ################################################################### //
 
+    /**
+     * Returns whether the control is active.
+     *
+     * @returns {Boolean} true if active, false otherwise
+     */
+    getActive () {
+        return this.active;
+    }
+
+    /**
+     * Sets whether the control is active.
+     *
+     * @param {Boolean} active - true to activate the control
+     */
+    setActive (active) {
+        this.active = active === true;
+        this.activeExplicit = true;
+        if (this.buttonGetFeatureInfoShow) {
+            this.buttonGetFeatureInfoShow.setAttribute("aria-pressed", this.active);
+        }
+    }
+
 
     // ################################################################### //
     // #################### privates methods ############################# //
@@ -141,11 +165,17 @@ class GetFeatureInfo extends Control {
         this.options = {
             collapsed : true,
             draggable : false,
-            auto : true
+            auto : true,
+            button : true,
+            active : false
         };
 
         // merge with user options
         Utils.assign(this.options, options);
+
+        this.button = this.options.button;
+        this.activeExplicit = options.active !== undefined;
+        this.active = options.active === undefined ? !this.button : options.active === true;
 
         /** 
          * @type {Boolean} 
@@ -207,8 +237,11 @@ class GetFeatureInfo extends Control {
         // create main container
         var container = this._createMainContainerElement();
 
-        var picto = this.buttonGetFeatureInfoShow = this._createShowGetFeatureInfoPictoElement();
-        container.appendChild(picto);
+        if (this.button) {
+            var picto = this.buttonGetFeatureInfoShow = this._createShowGetFeatureInfoPictoElement();
+            picto.setAttribute("aria-pressed", this.active);
+            container.appendChild(picto);
+        }
 
         // panel
         var getFeatureInfoPanel = this.panelGetFeatureInfoContainer = this._createGetFeatureInfoPanelElement();
@@ -217,12 +250,16 @@ class GetFeatureInfo extends Control {
         // header
         var getFeatureInfoPanelHeader = this.panelGetFeatureInfoHeaderContainer = this._createPanelHeaderElement({
             icon : "ign-getfeatureinfo",
-            title : "Infos sur les couches",
-            btnClassForClose : "GPgetFeatureInfoPicto",
+            title : "Infos sur les couches"
         });
         // close picto
         this.buttonGetFeatureInfoClose = getFeatureInfoPanelHeader._closeBtn;
         this.buttonGetFeatureInfoClose.classList.add("GPcloseGetFeatureInfo");
+        // la fermeture du panneau ne doit pas désactiver le GFI (le singleclick doit rester actif)
+        this.buttonGetFeatureInfoClose.addEventListener("click", (e) => {
+            this.buttonGetFeatureInfoClose.setAttribute("aria-pressed", false);
+            this.onCloseGetFeatureInfoClick(e);
+        });
 
         getFeatureInfoPanel.appendChild(getFeatureInfoPanelHeader);
         getFeatureInfoPanel.appendChild(getFeatureInfoPanelDiv);
@@ -272,7 +309,7 @@ class GetFeatureInfo extends Control {
      * @returns { Boolean } true if active false if not
      */
     getFeatureInfoIsActive () {
-        return this.buttonGetFeatureInfoShow.getAttribute("aria-pressed");
+        return this.getActive();
     }
 
 
@@ -282,12 +319,14 @@ class GetFeatureInfo extends Control {
      * @private
      */
     onMapClick (e) {
-        if (this.getFeatureInfoIsActive() === "true") {
+        if (this.getFeatureInfoIsActive()) {
             this.getFeatureInfoAccordionGroup.remove();
             if (this.noDataMessage) {
                 this.noDataMessageDiv.remove();
             }
             this.buttonGetFeatureInfoClose.setAttribute("aria-pressed", true);
+            // le panel est réellement ouvert ici (suite au clic sur la carte) donc on prévient les autres panels
+            this.onPanelOpen();
             this.layers = e.map.getLayers().getArray().filter((l) => {
                 // On ne passe au GFI que les layers visibles
                 if (l.isVisible(e.map.getView()) && l.getOpacity() > 0){
@@ -498,6 +537,7 @@ class GetFeatureInfo extends Control {
                         data.get("contentDiv").querySelector("div.fr-collapse").innerHTML = data.get("content");
                         // on affiche la pop-up car il y a au moins une entrée à afficher
                         this.buttonGetFeatureInfoClose.setAttribute("aria-pressed", true);
+                        this.onPanelOpen();
                         // du contenu est renvoyé : on affiche l'entrée
                         data.get("contentDiv").style.display = "block";
                     }

--- a/src/packages/Controls/GetFeatureInfo/GetFeatureInfoDOM.js
+++ b/src/packages/Controls/GetFeatureInfo/GetFeatureInfoDOM.js
@@ -82,14 +82,14 @@ var GetFeatureInfoDOM = {
         // Close all results and panels when minimizing the getFeatureInfo
         if (button.addEventListener) {
             button.addEventListener("click", function (e) {
-                var status = (e.target.ariaPressed === "true");
-                e.target.setAttribute("aria-pressed", !status);
+                var status = self.getActive();
+                self.setActive(!status);
                 self.onShowGetFeatureInfoClick(e);
             });
         } else if (button.attachEvent) {
             button.attachEvent("onclick", function (e) {
-                var status = (e.target.ariaPressed === "true");
-                e.target.setAttribute("aria-pressed", !status);
+                var status = self.getActive();
+                self.setActive(!status);
                 self.onShowGetFeatureInfoClick(e);
             });
         }

--- a/src/packages/Controls/Isocurve/Isocurve.js
+++ b/src/packages/Controls/Isocurve/Isocurve.js
@@ -1218,6 +1218,8 @@ class Isocurve extends Control {
         var opened = this._pictoIsoButton.ariaPressed;
         if (opened === "true") {
             this.onPanelOpen();
+        } else {
+            this.onPanelClose();
         }
 
         var map = this.getMap();

--- a/src/packages/Controls/Measures/MeasureArea.js
+++ b/src/packages/Controls/Measures/MeasureArea.js
@@ -306,9 +306,6 @@ class MeasureArea extends Control {
      * @private
      */
     onShowMeasureAreaClick (e) {
-        if (e.target.ariaPressed === "true") {
-            this.onPanelOpen();
-        }
         logger.trace("call MeasureArea::onShowMeasureAreaClick()", e);
 
         // appel de la methode commune

--- a/src/packages/Controls/Measures/MeasureAzimuth.js
+++ b/src/packages/Controls/Measures/MeasureAzimuth.js
@@ -345,9 +345,6 @@ class MeasureAzimuth extends Control {
      * @private
      */
     onShowMeasureAzimuthClick (e) {
-        if (e.target.ariaPressed === "true") {
-            this.onPanelOpen();
-        }
         logger.trace("call MeasureAzimuth::onShowMeasureAzimuthClick()", e);
 
         // appel de la methode commune

--- a/src/packages/Controls/Measures/MeasureLength.js
+++ b/src/packages/Controls/Measures/MeasureLength.js
@@ -312,9 +312,6 @@ class MeasureLength extends Control {
      * @private
      */
     onShowMeasureLengthClick (e) {
-        if (e.target.ariaPressed === "true") {
-            this.onPanelOpen();
-        }
         logger.trace("call MeasureLength::onShowMeasureLengthClick()", e);
 
         // appel de la methode commune

--- a/src/packages/Controls/Measures/Measures.js
+++ b/src/packages/Controls/Measures/Measures.js
@@ -212,8 +212,10 @@ var Measures = {
      * @private
      */
     onShowMeasureClick : function (e, type) {
-        if (e.target.ariaPressed === "true") {
+        if (this._pictoContainer.ariaPressed === "true") {
             this.onPanelOpen();
+        } else {
+            this.onPanelClose();
         }
         var map = this.getMap();
         var currentMapId = map.getTargetElement().id;

--- a/src/packages/Controls/Route/Route.js
+++ b/src/packages/Controls/Route/Route.js
@@ -1287,6 +1287,8 @@ class Route extends Control {
         var opened = this._showRouteButton.ariaPressed;
         if (opened === "true") {
             this.onPanelOpen();
+        } else {
+            this.onPanelClose();
         }
         var map = this.getMap();
         // on supprime toutes les interactions

--- a/src/packages/Controls/Widget.js
+++ b/src/packages/Controls/Widget.js
@@ -1,4 +1,4 @@
-import PanelManager from "../Utils/PanelManager";
+import PanelManager, { PanelManagerClose } from "../Utils/PanelManager";
 // Mixin pour ajouter des méthodes communes à tous les widgets.
 
 // voir fichiers DOM  et assign
@@ -10,7 +10,15 @@ var Widget = {
      */
     onPanelOpen : function () {
         // On récupère l'id du widget à partir de l'id du DOM de la forme GPwidgetName-1876465465
-        PanelManager(this.options.position, this.element.id.match(/(\w+)-[0-9]+/)[1]);
+        PanelManager(this.options.position, this.element.id.match(/(\w+)-[0-9]+/)[1], this);
+    },
+
+    /**
+     * This method is called when a widget closes its panel
+     * It lets the panelManager restore the state of the other widgets
+     */
+    onPanelClose : function () {
+        PanelManagerClose(this.element.id.match(/(\w+)-[0-9]+/)[1], this);
     }
 };
 

--- a/src/packages/Utils/PanelManager.js
+++ b/src/packages/Utils/PanelManager.js
@@ -1,5 +1,19 @@
 const exceptions = ["GPoverviewMap", "GPfullScreen"];
 
+// widgets dont l'ouverture doit désactiver le GetFeatureInfo
+const gfiIncompatiblePanels = ["GPdrawing"];
+
+// état du GetFeatureInfo avant sa désactivation par un widget incompatible
+var gfiActiveBeforePanel = false;
+
+function getGetFeatureInfoControl (widget) {
+    var map = (widget && typeof widget.getMap === "function") ? widget.getMap() : null;
+    if (!map) {
+        return null;
+    }
+    return map.getControls().getArray().filter(control => control.CLASSNAME === "GetFeatureInfo")[0] || null;
+}
+
 function getSameSideOpenedPanel (position, openedPanelID) {
     // on ajoute aux exceptions le panel qui vient d'être ouvert
     var exceptionPanel = [...exceptions, openedPanelID];
@@ -25,12 +39,41 @@ function getSameSideOpenedPanel (position, openedPanelID) {
     });
 }
 
-var PanelManager = function (position, openedPanelID) {
+var PanelManager = function (position, openedPanelID, widget) {
     var openedPanel = getSameSideOpenedPanel(position, openedPanelID);
     // on ferme tous les panels ouverts
     openedPanel.forEach((panel) => {
-        panel.getElementsByTagName("button")[0].click();
+        console.log("Fermeture du panel : ", panel);
+        // Si panel du GFI, on ferme le panel en cliquant sur le bouton de fermeture du panel
+        var closeButton = panel.querySelector(".GPcloseGetFeatureInfo") || panel.getElementsByTagName("button")[0];
+        closeButton.click();
     });
+
+    if (gfiIncompatiblePanels.includes(openedPanelID)) {
+        var gfi = getGetFeatureInfoControl(widget);
+        if (gfi) {
+            gfiActiveBeforePanel = gfi.getActive();
+            gfi.setActive(false);
+        }
+    }
+};
+
+/**
+ * Réactive le GetFeatureInfo à la fermeture d'un widget incompatible.
+ *
+ * @param {String} closedPanelID - id du widget fermé
+ * @param {Object} widget - instance du widget fermé
+ */
+var PanelManagerClose = function (closedPanelID, widget) {
+    if (!gfiIncompatiblePanels.includes(closedPanelID)) {
+        return;
+    }
+    var gfi = getGetFeatureInfoControl(widget);
+    if (gfi && gfiActiveBeforePanel) {
+        gfi.setActive(true);
+    }
+    gfiActiveBeforePanel = false;
 };
 
 export default PanelManager;
+export { PanelManagerClose };

--- a/src/packages/Utils/PanelManager.js
+++ b/src/packages/Utils/PanelManager.js
@@ -43,7 +43,6 @@ var PanelManager = function (position, openedPanelID, widget) {
     var openedPanel = getSameSideOpenedPanel(position, openedPanelID);
     // on ferme tous les panels ouverts
     openedPanel.forEach((panel) => {
-        console.log("Fermeture du panel : ", panel);
         // Si panel du GFI, on ferme le panel en cliquant sur le bouton de fermeture du panel
         var closeButton = panel.querySelector(".GPcloseGetFeatureInfo") || panel.getElementsByTagName("button")[0];
         closeButton.click();

--- a/src/packages/Utils/PanelManager.js
+++ b/src/packages/Utils/PanelManager.js
@@ -1,7 +1,7 @@
 const exceptions = ["GPoverviewMap", "GPfullScreen"];
 
 // widgets dont l'ouverture doit désactiver le GetFeatureInfo
-const gfiIncompatiblePanels = ["GPdrawing"];
+const gfiIncompatiblePanels = ["GPdrawing", "GPisochron", "GPmeasureArea", "GPmeasureAzimuth", "GPmeasureLength", "GProute", "GPelevationPath"];
 
 // état du GetFeatureInfo avant sa désactivation par un widget incompatible
 var gfiActiveBeforePanel = false;


### PR DESCRIPTION
réaction au ticket https://github.com/IGNF/cartes.gouv.fr-entree-carto/issues/1167

- Le panneau GetFeatureInfo est désormais géré par PanelManager comme les autres widgets.
  - L’ouverture du panneau GFI ferme les autres panneaux ouverts du même côté, hors exceptions prévues.
  - L’ouverture du Drawing désactive temporairement le GetFeatureInfo et restaure son état initial à la fermeture.

- La fermeture du panneau de résultats GFI ne désactive plus l’interrogation sur la carte : le contrôle reste disponible pour les clics suivants.

- ajout d'options :
  - button: 
  true : affiche le bouton d’activation ; le GFI est désactivé par défaut.
  false : masque le bouton ; le GFI est activé par défaut.
  
  - active : force l’état initial du contrôle, qu’un bouton soit affiché ou non.