### PR TITLE
fix(MousePosition): focus sur l'edition des coordonnées type DMS

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -35,6 +35,7 @@ __DATE__
 
   - LayerImport : fixe la hauteur du contenu dans certains cas (#575)
   - GFI : empêche que l’ouverture de l’accordéon déplace le site en entier (#580)
+  - MousePosition : fixe sur le focus pour l'edition des coordonnées type DMS (#583)
 
 * 🔒 [Security]
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.13-581",
-  "date": "03/09/2026",
+  "version": "1.0.0-beta.13-583",
+  "date": "07/09/2026",
   "module": "src/index.js",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/src/packages/Controls/MousePosition/MousePositionDOM.js
+++ b/src/packages/Controls/MousePosition/MousePositionDOM.js
@@ -698,7 +698,11 @@ var MousePositionDOM = {
         if (editing === true) {
             locateElt.classList.remove("gpf-btn-icon-mp-edit");
             locateElt.classList.add("gpf-btn-icon-mp-edit-center");
-            document.getElementById(this._addUID("GPmousePositionLat")).focus();
+            // focus on the latitude input field
+            // select the text inside the latitude input field
+            var latInput = document.getElementById(this._addUID("GPmousePositionLat")) || document.getElementById(this._addUID("GPmousePositionLatDegrees"));
+            latInput.select();
+            latInput.focus();
         } else {
             locateElt.classList.remove("gpf-btn-icon-mp-edit-center");
             locateElt.classList.add("gpf-btn-icon-mp-edit");


### PR DESCRIPTION
Fix pour éditer des coordonnées de type DMS

cf. issue https://github.com/IGNF/cartes.gouv.fr-entree-carto/issues/1219

## Pour recetter

- utiliser l'exemple : `samples-src/pages/tests/MousePosition/pages-ol-mouseposition-modules-dsfr-editcoordinates.html`
- changer de système de référence : Degrés Sexagésimaux
- puis, éditer en cliquant sur une coordonnées (la latitude prend le focus) 