### PR TITLE
feat(ContextMenu): autoriser le menu contextuel système sur les widgets

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -16,6 +16,7 @@ __DATE__
 * ✨ [Added]
 
   - Panoramax : Ajout de la fonctionnalité de partage d'URL pour le visualiseur d'images (#581)
+  - ContextMenu : Autoriser le menu contextuel système sur les widgets (#584)
 
 * 🔨 [Changed]
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geopf-extensions-openlayers",
   "description": "French Geoportal Extensions for OpenLayers libraries",
-  "version": "1.0.0-beta.13-581",
-  "date": "03/09/2026",
+  "version": "1.0.0-beta.13-584",
+  "date": "07/09/2026",
   "module": "src/index.js",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/src/packages/Controls/ContextMenu/ContextMenu.js
+++ b/src/packages/Controls/ContextMenu/ContextMenu.js
@@ -211,6 +211,8 @@ class ContextMenu extends Control {
         /** @private */
         this._listenersAdded = false;
         /** @private */
+        this._onContextBeforeOpen = null;
+        /** @private */
         this._onContextOpen = null;
         /** @private */
         this._onContextClose = null;
@@ -301,6 +303,10 @@ class ContextMenu extends Control {
             return;
         }
 
+        this._onContextBeforeOpen = (evt) => {
+            evt.this = this;
+            this.onBeforeOpenContextMenu(evt);
+        };
         this._onContextOpen = (evt) => {
             evt.this = this;
             this.onOpenContextMenu(evt);
@@ -315,6 +321,7 @@ class ContextMenu extends Control {
             }
         };
 
+        this.contextmenu.on("beforeopen", this._onContextBeforeOpen);
         this.contextmenu.on("open", this._onContextOpen);
         this.contextmenu.on("close", this._onContextClose);
         document.addEventListener("click", this._onDocumentClick);
@@ -330,6 +337,9 @@ class ContextMenu extends Control {
             return;
         }
 
+        if (this._onContextBeforeOpen) {
+            this.contextmenu.un("beforeopen", this._onContextBeforeOpen);
+        }
         if (this._onContextOpen) {
             this.contextmenu.un("open", this._onContextOpen);
         }
@@ -340,6 +350,7 @@ class ContextMenu extends Control {
             document.removeEventListener("click", this._onDocumentClick);
         }
 
+        this._onContextBeforeOpen = null;
         this._onContextOpen = null;
         this._onContextClose = null;
         this._onDocumentClick = null;
@@ -658,6 +669,35 @@ class ContextMenu extends Control {
      */
     onCloseContextMenu (e) {
         e.target.clear();
+    }
+
+    /**
+     * Déclenché avant l'ouverture du menu contextuel (avant l'appel à preventDefault()
+     * par la librairie ol-contextmenu) : active ou désactive le menu personnalisé
+     * selon la cible du clic droit, afin de laisser le menu contextuel système
+     * s'afficher sur les éléments des widgets (boutons, panneaux, ...)
+     * @param {Event} e - ...
+     * @private
+     */
+    onBeforeOpenContextMenu (e) {
+        const mapInstance = this.getMap();
+        if (!mapInstance) {
+            return;
+        }
+
+        const mapViewport = mapInstance.getViewport();
+        const target = e?.originalEvent?.target;
+
+        var isOutsideViewport = !mapViewport || (target && !mapViewport.contains(target));
+        var isOnWidgetOrControl = target && target.closest(".GPwidget, .gpf-widget, .ol-control");
+
+        if (isOutsideViewport || isOnWidgetOrControl) {
+            // désactive le menu contextuel personnalisé pour laisser
+            // le navigateur afficher son propre menu contextuel
+            this.contextmenu.disable();
+        } else {
+            this.contextmenu.enable();
+        }
     }
 
     /**


### PR DESCRIPTION
Autoriser le menu contextuel du système sur les widgets de la carte lors d'un clic droit.
Sur la carte (viewport), on affiche le le menu customisé.

cf. issue https://github.com/IGNF/cartes.gouv.fr-entree-carto/issues/1208

## Pour recetter

- ouvrir l'exemple : `samples-src/pages/tests/ContextMenu/pages-ol-modules-contextmenu-dsfr.html`
- effectuer des clics droits sur : 
  - un bouton de widget-> menu system
  - un panneau de widget-> menu system
  - en dehors de la carte -> menu system
  - sur la carte -> menu custom