### PR TITLE
fix(GeoJSON): gérer l'écriture de 'big' geojson 

### DIFF
--- a/src/packages/Formats/GeoJSON.js
+++ b/src/packages/Formats/GeoJSON.js
@@ -122,7 +122,19 @@ class GeoJSON extends olGeoJSON {
             Object.assign(geoJSONObject, this.options.extensions);
         }
 
-        return JSON.stringify(geoJSONObject);
+        // FIXME
+        // cela ne contourne pas la limite native de V8 (le JSON final reste trop gros 
+        // pour être stocké en String), il n'existe pas de moyen de stringifier un objet 
+        // dont la sortie dépasse la taille max d'une chaîne JS. 
+        // Si ce cas se présente réellement en production, il faudrait plutôt écrire le 
+        // GeoJSON par flux (streaming) vers un fichier/Blob au lieu de retourner une 
+        // String, ou paginer/découper les features en plusieurs exports. 
+        try {
+            return JSON.stringify(geoJSONObject);
+        } catch (e) {
+            // ex. RangeError: Invalid string length (trop de features / résultat trop volumineux pour tenir dans une chaine de caracteres)
+            throw new Error("GeoJSON.writeFeatures() : impossible de generer le GeoJSON, le resultat est trop volumineux (" + features.length + " feature(s)). Reduisez le nombre de features ou exportez par lots. Erreur d'origine : " + e.message);
+        }
     }
 
     /**


### PR DESCRIPTION
# Comment gérer l'écriture de gros fichier GeoJSON ? 

## Mise en place d'un message plus explicite 

**JSON.stringify** dans un try/catch : 
en cas de dépassement de la limite de longueur de chaîne (`RangeError: Invalid string length`), une erreur explicite est levée indiquant le nombre de features et suggérant de réduire le volume.

Note : 
> cela ne contourne pas la limite native de V8 (le JSON final reste trop gros pour être stocké en String), il n'existe pas de moyen de stringifier un objet dont la sortie dépasse la taille max d'une chaîne JS. Si ce cas se présente réellement en production, il faudrait plutôt écrire le GeoJSON par flux (streaming) vers un fichier/Blob au lieu de retourner une String, ou paginer/découper les features en plusieurs exports.

## Propositions ?

- limitation sur l'écriture : 
> Github limite l'import des GeoJSON pour rendu à 10 Mo

- réduire la taille des styles avec mutualisation des styles communs (hors standard) : 
> les styles communs seront renseignés par un link (ex `style:#123`) vers un style à la racine de la collection de features 

- streamer la sortie : 
> ex. lib stream-json : solution valable pour l'export dans un fichier, mais réalisable pour l'API d'enregistrement d'un document dans l'espace personnel ?
> :warning: l'API ne semble pas accepter le stream via `Transfer-Encoding: chunked`